### PR TITLE
Customize linters and add black

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
+*,cover
 
 # Translations
 *.mo

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6
-      env: TOXENV=py36
+      env: TOXENV=qa
     - python: 3.7
       sudo: required
       dist: xenial

--- a/setup.py
+++ b/setup.py
@@ -13,27 +13,24 @@ from setuptools import find_packages, setup
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the README file
-with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+with open(path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
-    name='gbasis',
-    version='0.0.0',
-    description='A module for evaluating, differentiating, and integrating Gaussian functions.',
+    name="gbasis",
+    version="0.0.0",
+    description="A module for evaluating, differentiating, and integrating Gaussian functions.",
     long_description=long_description,
     # Denotes that our long_description is in Markdown; valid values are
     # text/plain, text/x-rst, and text/markdown
-    long_description_content_type='text/markdown',
-    url='https://github.com/pypa/sampleproject',
-
+    long_description_content_type="text/markdown",
+    url="https://github.com/pypa/sampleproject",
     # This should be your name or the name of the organization which owns the
     # project.
     # author='',
-
     # This should be a valid email address corresponding to the author listed
     # above.
     # author_email='',
-
     # Classifiers help users find your project by categorizing it.
     #
     # For a list of valid classifiers, see https://pypi.org/classifiers/
@@ -43,37 +40,39 @@ setup(
         #   3 - Alpha
         #   4 - Beta
         #   5 - Production/Stable
-        'Development Status :: 1 - Planning',
-
+        "Development Status :: 1 - Planning",
         # Indicate who your project is intended for
-        'Intended Audience :: Quantum Chemists',
-        'Topic :: Gaussian :: Integral :: Differentiation :: Evaluation',
-
+        "Intended Audience :: Quantum Chemists",
+        "Topic :: Gaussian :: Integral :: Differentiation :: Evaluation",
         # Pick your license as you wish
-        'License :: OSI Approved :: GNU Version 3',
-
+        "License :: OSI Approved :: GNU Version 3",
         # Specify the Python versions you support here.
         # These classifiers are *not* checked by 'pip install'. See instead
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
-
-    keywords='gaussian integration differentiation evaluation density',
-    packages=find_packages(exclude=['docs', 'tests']),
-    python_requires='>=3.5',
-    install_requires=['numpy', 'scipy'],
-
+    keywords="gaussian integration differentiation evaluation density",
+    packages=find_packages(exclude=["docs", "tests"]),
+    python_requires=">=3.5",
+    install_requires=["numpy", "scipy"],
     extras_require={
-        'dev': ['tox', 'flake8', 'flake8-pydocstyle', 'flake8-import-order',
-                'pep8-naming', 'pylint', 'bandit', 'pytest', 'pytest-cov'],
-        'test': ['tox', 'pytest', 'pytest-cov'],
+        "dev": [
+            "tox",
+            "flake8",
+            "flake8-pydocstyle",
+            "flake8-import-order",
+            "pep8-naming",
+            "pylint",
+            "bandit",
+            "pytest",
+            "pytest-cov",
+        ],
+        "test": ["tox", "pytest", "pytest-cov"],
     },
-
     # If there are data files included in your packages that need to be
     # installed, specify them here.
     package_data={},
-
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow
     # `pip` to create the appropriate form of executable for the target
@@ -86,11 +85,10 @@ setup(
     #         'sample=sample:main',
     #     ],
     # },
-
     # List additional URLs that are relevant to your project as a dict.
     project_urls={
-        'Bug Reports': 'https://github.com/theochem/gbasis/issues',
-        'Organization': 'https://github.com/quantumelephant/',
-        'Source': 'https://github.com/theochem/gbasis/',
+        "Bug Reports": "https://github.com/theochem/gbasis/issues",
+        "Organization": "https://github.com/quantumelephant/",
+        "Source": "https://github.com/theochem/gbasis/",
     },
 )

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py35,py36,py37
 
 [flake8]
 max-line-length = 100
+import-order-style = google
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,20 @@
 [tox]
-envlist = py35,py36,py37
+envlist = py35,py36,py37,qa
 
 [flake8]
 max-line-length = 100
 import-order-style = google
 
 [testenv]
+deps =
+    pytest
+    pytest-cov
+commands =
+    pytest --cov={envsitepackagesdir}/gbasis --cov-branch tests
+# prevent exit when error is encountered
+ignore_errors = true
+
+[testenv:qa]
 deps =
     flake8
     flake8-docstrings

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
     pytest-cov
 commands =
     flake8 gbasis/ tests/ setup.py
-    pylint gbasis
+    pylint gbasis --rcfile=tox.ini
     bandit gbasis
     pytest --cov={envsitepackagesdir}/gbasis --cov-branch tests
 # prevent exit when error is encountered
@@ -28,3 +28,19 @@ ignore_errors = true
 [FORMAT]
 # Maximum number of characters on a single line.
 max-line-length=100
+
+[MESSAGES CONTROL]
+disable=
+    # attribute-defined-outside-init (W0201):
+    # Attribute %r defined outside __init__ Used when an instance attribute is
+    # defined outside the __init__ method.
+    W0201
+    # too-many-instance-attributes (R0902):
+ 	# Too many instance attributes (%s/%s) Used when class has too many instance
+    # attributes, try to reduce this to get a simpler (and so easier to use)
+    # class.
+    R0902
+    # too-many-arguments (R0913):
+ 	# Too many arguments (%s/%s) Used when a function or method takes too many
+    # arguments.
+    R0913

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ commands =
     pylint gbasis --rcfile=tox.ini
     black -l 100 --check ./
     black -l 100 --diff ./
-    bandit gbasis
+    bandit -r gbasis
     pytest --cov={envsitepackagesdir}/gbasis --cov-branch tests
 # prevent exit when error is encountered
 ignore_errors = true

--- a/tox.ini
+++ b/tox.ini
@@ -13,12 +13,15 @@ deps =
     flake8-colors
     pep8-naming
     pylint
+    black
     bandit
     pytest
     pytest-cov
 commands =
     flake8 gbasis/ tests/ setup.py
     pylint gbasis --rcfile=tox.ini
+    black -l 100 --check ./
+    black -l 100 --diff ./
     bandit gbasis
     pytest --cov={envsitepackagesdir}/gbasis --cov-branch tests
 # prevent exit when error is encountered


### PR DESCRIPTION
- customize flake8-import-order-style to use a different import order style (google)
- customize pylint to disable a message (`attribute-defined-outside-init`) and store rc file in tox.ini
- use black to enforce formatting