### PR TITLE
Add components of angular momentum

### DIFF
--- a/gbasis/contractions.py
+++ b/gbasis/contractions.py
@@ -26,7 +26,7 @@ class ContractedCartesianGaussians:
         Angular momentum of the set of contractions.
         .. math::
 
-            \sum_i \vec{a} = a_x + a_y + a_z
+            l = \sum_i \vec{a} = a_x + a_y + a_z
 
     coord : np.ndarray(3,)
         Coordinate of the center of the Gaussian primitives.
@@ -247,3 +247,20 @@ class ContractedCartesianGaussians:
             raise ValueError("Coefficients array must have the same size as exponents array.")
 
         self._coeffs = coeffs
+
+    @property
+    def angmom_components(self):
+        r"""Components of the angular momentum.
+
+        Returns
+        -------
+        angmom_components : list of int
+            The x, y, and z components of the angular momentum (:math:`\vec{a} = (a_x, a_y, a_z)`
+            where :math:`a_x + a_y + a_z = l`).
+
+        """
+        return [
+            (x, y, self.angmom - x - y)
+            for x in range(self.angmom + 1)
+            for y in range(self.angmom - x + 1)
+        ]

--- a/tests/test_contractions.py
+++ b/tests/test_contractions.py
@@ -168,3 +168,36 @@ def tests_init():
     assert test._charge == 0
     assert np.allclose(test._coeffs, np.array([1, 2, 3, 4]))
     assert np.allclose(test._exps, np.array([5, 6, 7, 8]))
+
+
+def test_angmom_components():
+    """Test ContractedCartesianGaussians.angmom_components."""
+    test = skip_init(ContractedCartesianGaussians)
+    test._angmom = 0
+    assert test.angmom_components == [(0, 0, 0)]
+    test._angmom = 1
+    assert test.angmom_components == [(0, 0, 1), (0, 1, 0), (1, 0, 0)]
+    test._angmom = 2
+    assert test.angmom_components == [
+        (0, 0, 2),
+        (0, 1, 1),
+        (0, 2, 0),
+        (1, 0, 1),
+        (1, 1, 0),
+        (2, 0, 0),
+    ]
+    test._angmom = 3
+    assert test.angmom_components == [
+        (0, 0, 3),
+        (0, 1, 2),
+        (0, 2, 1),
+        (0, 3, 0),
+        (1, 0, 2),
+        (1, 1, 1),
+        (1, 2, 0),
+        (2, 0, 1),
+        (2, 1, 0),
+        (3, 0, 0),
+    ]
+    test._angmom = 10
+    assert len(test.angmom_components) == 11 * 12 / 2


### PR DESCRIPTION
The code was extracted from PR #15 (https://github.com/theochem/gbasis/pull/15),
specifically, commit ed51b6e1d0237096b767a1cdbff085cc84d7fe51 by Xiamin Huang

"Components" of an angular momentum is a (a_x, a_y, a_z) where l = a_x + a_y + a_z.