### PR TITLE
Disable warnings on pylint

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -76,3 +76,9 @@ disable=
  	# Too many arguments (%s/%s) Used when a function or method takes too many
     # arguments.
     R0913,
+    # fixme (W0511):
+    # Used when a warning note as FIXME or XXX is detected.
+    W0511,
+    # bad-continuation (C0330):
+    # Wrong hanging indentation before block (add 4 spaces).
+    C0330,


### PR DESCRIPTION
What:
1. Disable W0511 (FIXME and other warning notes)
2. Disable C0330 (hanging indentation before block)

Why:
1. Seeing a this code is pre-alpha stage, FIXME's and other warning notes will
be critical for quickly keeping note of what needs to be done and fixed without
having to go through some sort of workflow. It is perfectly acceptable to write
down things to do/fix on the code to do in the future because we have higher
priority things to do. Not writing them to satisfy pylint seems unnecessary.
Nonetheless, the appropriate issue/card should be made in either github or
trello.
2. Hanging indentation is quite common using black. For easy standardization of
formatting, we keep black's format and ignore pylint's.