### PR TITLE
Change API for evaluating derivative

### DIFF
--- a/gbasis/deriv.py
+++ b/gbasis/deriv.py
@@ -146,3 +146,70 @@ def _eval_deriv_contractions(coords, orders, center, angmom_comps, alphas, prim_
 
     prim_coeffs = prim_coeffs[:, np.newaxis]
     return np.sum(prim_coeffs * zeroth_part * deriv_part, axis=0)
+
+
+def eval_deriv_shell(*, coords, orders, shell):
+    """Return the derivatives of a set of Cartesian contractions evaluated at the given coordinates.
+
+    Parameters
+    ----------
+    coords : np.ndarray(3, N)
+        Point in space where the derivative of the Gaussian primitive is evaluated.
+    orders : np.ndarray(3,)
+        Orders of the derivative.
+        Negative orders are treated as zero orders.
+    shell : ContractedCartesianGaussians
+        Set of contracted Cartesian Gaussians with the same angular momentum.
+
+    Returns
+    -------
+    derivative : np.ndarray(L, N)
+        Evaluation of the derivative.
+        :math:`L` is the number of contractions associated with the given `shell`.
+
+    Raises
+    ------
+    TypeError
+        If the arguments are given as positional arguments.
+
+    Notes
+    -----
+    When calling this function, the arguments must be given via keywords and not positional
+    arguments. This feature is used to catch problems that arise due to a change in API.
+
+    """
+    alphas = shell.exps
+    prim_coeffs = shell.coeffs
+    angmom_comps = shell.angmom_components
+    center = shell.coord
+    return _eval_deriv_contractions(coords, orders, center, angmom_comps, alphas, prim_coeffs)
+
+
+def eval_shell(*, coords, shell):
+    """Return the a set of Cartesian contractions evaluated at the given coordinates.
+
+    Parameters
+    ----------
+    coords : np.ndarray(3, N)
+        Point in space where the derivative of the Gaussian primitive is evaluated.
+    shell : ContractedCartesianGaussians
+        Set of contracted Cartesian Gaussians with the same angular momentum.
+
+    Returns
+    -------
+    derivative : np.ndarray(L, N)
+        Evaluation of the derivative.
+        :math:`L` is the number of contractions associated with the given `shell`.
+
+    Raises
+    ------
+    TypeError
+        If the arguments are given as positional arguments.
+
+    Notes
+    -----
+    When calling this function, the arguments must be given via keywords and not positional
+    arguments. This feature is used to catch problems that arise due to a change in API.
+
+    """
+    return eval_deriv_shell(coords=coords, orders=np.zeros(shell.coord.shape), shell=shell)  # nosec

--- a/gbasis/lincomb.py
+++ b/gbasis/lincomb.py
@@ -80,6 +80,8 @@ def lincomb_blocks_evals(contractions, eval_func, trans_blocks, **kwargs):
         # NOTE: this process is pretty similar to
         # np.einsum("ij,j...->i...", transform, matrix, optimize='optimal')
         # evaluate the function at the given points
+        # FIXME: eval_func is probably almost always going to be eval_shell or eval_deriv_shell,
+        # maybe these can be hardcoded?
         eval_cont = eval_func(contraction=contraction, **kwargs)
         # save original shape
         old_shape = eval_cont.shape[1:]

--- a/gbasis/lincomb.py
+++ b/gbasis/lincomb.py
@@ -80,7 +80,7 @@ def lincomb_blocks_evals(contractions, eval_func, trans_blocks, **kwargs):
         # NOTE: this process is pretty similar to
         # np.einsum("ij,j...->i...", transform, matrix, optimize='optimal')
         # evaluate the function at the given points
-        eval_cont = eval_func(contraction, **kwargs)
+        eval_cont = eval_func(contraction=contraction, **kwargs)
         # save original shape
         old_shape = eval_cont.shape[1:]
         # combine all indices except the first index

--- a/tests/test_deriv.py
+++ b/tests/test_deriv.py
@@ -1,7 +1,8 @@
 """Test gbasis.deriv."""
 import itertools as it
 
-from gbasis.deriv import _eval_deriv_contractions
+from gbasis.contractions import ContractedCartesianGaussians
+from gbasis.deriv import _eval_deriv_contractions, eval_deriv_shell, eval_shell
 import numpy as np
 from utils import partial_deriv_finite_diff
 
@@ -365,3 +366,80 @@ def test_eval_deriv_contractions():
                     ),
                 ],
             )
+
+
+def test_eval_deriv_shell():
+    """Test gbasis.deriv.eval_deriv_shell."""
+    # first order
+    for k in range(3):
+        orders = np.zeros(3, dtype=int)
+        orders[k] = 1
+        for i in range(6):
+            test = ContractedCartesianGaussians(
+                1, np.array([0.5, 1, 1.5]), 0, np.array([1.0, 2.0]), np.array([0.1, 0.01])
+            )
+            answer = np.array(
+                [
+                    _eval_deriv_contractions(
+                        np.array([2, 3, 4]),
+                        orders,
+                        np.array([0.5, 1, 1.5]),
+                        angmom_comp,
+                        np.array([0.1, 0.01]),
+                        np.array([1, 2]),
+                    )
+                    for angmom_comp in test.angmom_components
+                ]
+            )
+            assert np.allclose(
+                eval_deriv_shell(coords=np.array([2, 3, 4]), orders=orders, shell=test),
+                answer.ravel(),
+            )
+    # second order
+    for k, l in it.product(range(3), range(3)):
+        orders = np.zeros(3, dtype=int)
+        orders[k] += 1
+        orders[l] += 1
+        for i in range(6):
+            test = ContractedCartesianGaussians(
+                1, np.array([0.5, 1, 1.5]), 0, np.array([1.0, 2.0]), np.array([0.1, 0.01])
+            )
+            answer = np.array(
+                [
+                    _eval_deriv_contractions(
+                        np.array([2, 3, 4]),
+                        orders,
+                        np.array([0.5, 1, 1.5]),
+                        angmom_comp,
+                        np.array([0.1, 0.01]),
+                        np.array([1, 2]),
+                    )
+                    for angmom_comp in test.angmom_components
+                ]
+            )
+            assert np.allclose(
+                eval_deriv_shell(coords=np.array([2, 3, 4]), orders=orders, shell=test),
+                answer.ravel(),
+            )
+
+
+def test_eval_shell():
+    """Test gbasis.deriv.eval_shell."""
+    for i in range(6):
+        test = ContractedCartesianGaussians(
+            1, np.array([0.5, 1, 1.5]), 0, np.array([1.0, 2.0]), np.array([0.1, 0.01])
+        )
+        answer = np.array(
+            [
+                _eval_deriv_contractions(
+                    np.array([2, 3, 4]),
+                    np.array([0, 0, 0]),
+                    np.array([0.5, 1, 1.5]),
+                    angmom_comp,
+                    np.array([0.1, 0.01]),
+                    np.array([1, 2]),
+                )
+                for angmom_comp in test.angmom_components
+            ]
+        )
+        assert np.allclose(eval_shell(coords=np.array([2, 3, 4]), shell=test), answer.ravel())

--- a/tests/test_deriv.py
+++ b/tests/test_deriv.py
@@ -1,9 +1,68 @@
 """Test gbasis.deriv."""
 import itertools as it
 
-from gbasis.deriv import eval_contraction, eval_deriv_contraction, eval_deriv_prim, eval_prim
+from gbasis.deriv import _eval_deriv_contractions
 import numpy as np
 from utils import partial_deriv_finite_diff
+
+
+def eval_deriv_prim(coord, orders, center, angmom_comps, alpha):
+    """Return the evaluation of the derivative of a Gaussian primitive.
+
+    Parameters
+    ----------
+    coord : np.ndarray(3,)
+        Point in space where the derivative of the Gaussian primitive is evaluated.
+    orders : np.ndarray(3,)
+        Orders of the derivative.
+        Negative orders are treated as zero orders.
+    center : np.ndarray(3,)
+        Center of the Gaussian primitive.
+    angmom_comps : np.ndarray(3,)
+        Component of the angular momentum that corresponds to this dimension.
+    alpha : float
+        Value of the exponential in the Guassian primitive.
+
+    Returns
+    -------
+    derivative : float
+        Evaluation of the derivative.
+
+    Note
+    ----
+    If you want to evaluate the derivative of the contractions of the primitive, then use
+    `gbasis.deriv.eval_deriv_contraction` instead.
+
+    """
+    return _eval_deriv_contractions(coord, orders, center, angmom_comps, alpha, 1)[0]
+
+
+def eval_prim(coord, center, angmom_comps, alpha):
+    """Return the evaluation of a Gaussian primitive.
+
+    Parameters
+    ----------
+    coord : np.ndarray(3,)
+        Point in space where the derivative of the Gaussian primitive is evaluated.
+    center : np.ndarray(3,)
+        Center of the Gaussian primitive.
+    angmom_comps : np.ndarray(3,)
+        Component of the angular momentum that corresponds to this dimension.
+    alpha : float
+        Value of the exponential in the Guassian primitive.
+
+    Returns
+    -------
+    derivative : float
+        Evaluation of the derivative.
+
+    Note
+    ----
+    If you want to evaluate the contractions of the primitive, then use
+    `gbasis.deriv.eval_contraction` instead.
+
+    """
+    return eval_deriv_prim(coord, np.zeros(angmom_comps.shape), center, angmom_comps, alpha)
 
 
 def test_eval_prim():
@@ -75,41 +134,77 @@ def test_eval_deriv_prim():
             )
 
 
-def test_eval_contraction():
-    """Test gbasis.deriv.eval_contraction.
-
-    Note that this also tests the no derivative case of gbasis.deriv.eval_deriv_contraction.
-    """
+def test_eval_contractions():
+    """Test gbasis.deriv._eval_deriv_contraction without derivatization."""
     # angular momentum: 0
     assert np.allclose(
-        eval_contraction(np.array([0, 0, 0]), np.array([0, 0, 0]), np.array([0, 0, 0]), 1, 1), 1
+        _eval_deriv_contractions(
+            np.array([0, 0, 0]), np.array([0, 0, 0]), np.array([0, 0, 0]), np.array([0, 0, 0]), 1, 1
+        ),
+        1,
     )
     assert np.allclose(
-        eval_contraction(np.array([1.0, 0, 0]), np.array([0, 0, 0]), np.array([0, 0, 0]), 1, 1),
+        _eval_deriv_contractions(
+            np.array([1.0, 0, 0]),
+            np.array([0, 0, 0]),
+            np.array([0, 0, 0]),
+            np.array([0, 0, 0]),
+            1,
+            1,
+        ),
         np.exp(-1),
     )
     assert np.allclose(
-        eval_contraction(np.array([1.0, 2.0, 0]), np.array([0, 0, 0]), np.array([0, 0, 0]), 1, 1),
+        _eval_deriv_contractions(
+            np.array([1.0, 2.0, 0]),
+            np.array([0, 0, 0]),
+            np.array([0, 0, 0]),
+            np.array([0, 0, 0]),
+            1,
+            1,
+        ),
         np.exp(-1) * np.exp(-4),
     )
     assert np.allclose(
-        eval_contraction(np.array([1.0, 2.0, 3.0]), np.array([0, 0, 0]), np.array([0, 0, 0]), 1, 1),
+        _eval_deriv_contractions(
+            np.array([1.0, 2.0, 3.0]),
+            np.array([0, 0, 0]),
+            np.array([0, 0, 0]),
+            np.array([0, 0, 0]),
+            1,
+            1,
+        ),
         np.exp(-1) * np.exp(-4) * np.exp(-9),
     )
     # angular momentum 1
     assert np.allclose(
-        eval_contraction(np.array([2.0, 0, 0]), np.array([0, 0, 0]), np.array([1, 0, 0]), 1, 1),
+        _eval_deriv_contractions(
+            np.array([2.0, 0, 0]),
+            np.array([0, 0, 0]),
+            np.array([0, 0, 0]),
+            np.array([1, 0, 0]),
+            1,
+            1,
+        ),
         2 * np.exp(-2 ** 2),
     )
     # other angular momentum
     assert np.allclose(
-        eval_contraction(np.array([2.0, 0, 0]), np.array([0, 3, 4]), np.array([2, 1, 3]), 1, 1),
+        _eval_deriv_contractions(
+            np.array([2.0, 0, 0]),
+            np.array([0, 0, 0]),
+            np.array([0, 3, 4]),
+            np.array([2, 1, 3]),
+            1,
+            1,
+        ),
         4 * 3 * 4 ** 3 * np.exp(-(2 ** 2 + 3 ** 2 + 4 ** 2)),
     )
     # contraction
     assert np.allclose(
-        eval_contraction(
+        _eval_deriv_contractions(
             np.array([2, 0, 0]),
+            np.array([0, 0, 0]),
             np.array([0, 3, 4]),
             np.array([2, 1, 3]),
             np.array([0.1, 0.001]),
@@ -120,8 +215,9 @@ def test_eval_contraction():
     )
     # contraction + multiple angular momentums
     assert np.allclose(
-        eval_contraction(
+        _eval_deriv_contractions(
             np.array([2, 0, 0]),
+            np.array([0, 0, 0]),
             np.array([0, 3, 4]),
             np.array([[2, 1, 3], [1, 3, 4]]),
             np.array([0.1, 0.001]),
@@ -136,8 +232,8 @@ def test_eval_contraction():
     )
 
 
-def test_eval_deriv_contraction():
-    """Test gbasis.deriv.eval_deriv_contraction."""
+def test_eval_deriv_contractions():
+    """Test gbasis.deriv._eval_deriv_contractions."""
     # first order
     for k in range(3):
         orders = np.zeros(3, dtype=int)
@@ -145,7 +241,7 @@ def test_eval_deriv_contraction():
         for x, y, z in it.product(range(3), range(3), range(3)):
             # only contraction
             assert np.allclose(
-                eval_deriv_contraction(
+                _eval_deriv_contractions(
                     np.array([2, 3, 4]),
                     orders,
                     np.array([0.5, 1, 1.5]),
@@ -164,7 +260,7 @@ def test_eval_deriv_contraction():
             )
             # contraction + multiple angular momentums
             assert np.allclose(
-                eval_deriv_contraction(
+                _eval_deriv_contractions(
                     np.array([2, 3, 4]),
                     orders,
                     np.array([0.5, 1, 1.5]),
@@ -206,7 +302,7 @@ def test_eval_deriv_contraction():
         orders[l] += 1
         for x, y, z in it.product(range(4), range(4), range(4)):
             assert np.allclose(
-                eval_deriv_contraction(
+                _eval_deriv_contractions(
                     np.array([2, 3, 4]), orders, np.array([0.5, 1, 1.5]), np.array([x, y, z]), 1, 1
                 ),
                 eval_deriv_prim(
@@ -215,7 +311,7 @@ def test_eval_deriv_contraction():
             )
             # only contraction
             assert np.allclose(
-                eval_deriv_contraction(
+                _eval_deriv_contractions(
                     np.array([2, 3, 4]),
                     orders,
                     np.array([0.5, 1, 1.5]),
@@ -234,7 +330,7 @@ def test_eval_deriv_contraction():
             )
             # contraction + multiple angular momentums
             assert np.allclose(
-                eval_deriv_contraction(
+                _eval_deriv_contractions(
                     np.array([2, 3, 4]),
                     orders,
                     np.array([0.5, 1, 1.5]),


### PR DESCRIPTION
1. Change name of function `eval_deriv_contraction` to `_eval_deriv_contractions`
2. Change name of argument from `coord` to `coords`
3. Make functions that work with data class instances
4. Cosmetic changes
