### PR TITLE
Add low level function for computing the multipole moment integrals

### DIFF
--- a/gbasis/moment_int.py
+++ b/gbasis/moment_int.py
@@ -1,0 +1,183 @@
+"""Multipole moment integrals involving Contracted Cartesian Gaussians."""
+import numpy as np
+
+
+# TODO: in the case of generalized Cartesian contraction where multiple shells have the same sets of
+# exponents but different sets of primitive coefficients, it will be helpful to vectorize the
+# `prim_coeffs` also.
+def _compute_multipole_moment_integrals(
+    coord_moment,
+    orders_moment,
+    coord_a,
+    angmoms_a,
+    alphas_a,
+    coeffs_a,
+    coord_b,
+    angmoms_b,
+    alphas_b,
+    coeffs_b,
+):
+    """Return the multipole moment integrals of two contraction.
+
+    Parameters
+    ----------
+    coord_moment : np.ndarray(3,)
+        Center of the moment.
+    orders_moment : np.ndarray(M, 3)
+        Orders of the moment for each dimension (x, y, z).
+        Note that two dimensional array must be given, even if there is only one set of orders of
+        the moment.
+    coord_a : np.ndarray(3,)
+        Center of the contraction on the left side.
+    angmoms_a : np.ndarray(L_a, 3)
+        Angular momentum vectors (lx, ly, lz) for the contractions on the left side.
+        Note that two dimensional array must be given, even if there is only one angular momentum
+        vector.
+    alphas_a : np.ndarray(K_a,)
+        Values of the (square root of the) precisions of the primitives on the left side.
+    coeffs_a : np.ndarray(K_a,)
+        Contraction coefficients of the primitives on the left side.
+    coord_b : np.ndarray(3,)
+        Center of the contraction on the right side.
+    angmoms_b : np.ndarray(L_b, 3)
+        Angular momentum vectors (lx, ly, lz) for the contractions on the right side.
+        Note that two dimensional array must be given, even if there is only one angular momentum
+        vector.
+    alphas_b : np.ndarray(K_b,)
+        Values of the (square root of the) precisions of the primitives on the right side.
+    coeffs_b : np.ndarray(K_b,)
+        Contraction coefficients of the primitives on the right side.
+
+    Returns
+    -------
+    integrals : np.ndarray(M, L_a, L_b)
+        Multipole moment integrals associated with the given orders of moments and angular momentum
+        vectors (contractions).
+
+    """
+    # pylint: disable=R0914
+    # NOTE: following convention will be used to organize the axis of the multidimensional arrays
+    # axis 0 = index for order of moment in the corresponding dimension (size: L_c^{max})
+    # axis 1 = index for angular momentum component of contraction b in the corresponding dimension
+    # (size: L_b^{max})
+    # axis 2 = index for angular momentum component of contraction a in the corresponding dimension
+    # (size: L_a^{max})
+    # axis 3 = index for dimension (x, y, z) of coordinate (size: 3)
+    # axis 4 = index for primitive of contraction a (size: K_a)
+    # axis 5 = index for primitive of contraction b (size: K_b)
+
+    angmom_a_max = np.max(angmoms_a)
+    angmom_b_max = np.max(angmoms_b)
+    order_moment_max = np.max(orders_moment)
+    # swap a and b if l(a) > l_b
+    # NOTE: If the transient integrals are returned, then we need ot make sure to swap back the
+    # a and b should they be swapped
+    # FIXME: not sure if a < b or a > b
+    if angmom_a_max < angmom_b_max:
+        angmom_a_max, angmom_b_max = angmom_b_max, angmom_a_max
+        coord_a, coord_b = coord_b, coord_a
+        alphas_a, alphas_b = alphas_b, alphas_a
+        coeffs_a, coeffs_b = coeffs_b, coeffs_a
+        angmoms_a, angmoms_b = angmoms_b, angmoms_a
+
+    integrals = np.zeros(
+        (order_moment_max + 1, angmom_b_max + 1, angmom_a_max + 1, 3, alphas_a.size, alphas_b.size)
+    )
+
+    # adjust axis
+    coord_moment = coord_moment[np.newaxis, np.newaxis, np.newaxis, :, np.newaxis, np.newaxis]
+    coord_a = coord_a[np.newaxis, np.newaxis, np.newaxis, :, np.newaxis, np.newaxis]
+    coord_b = coord_b[np.newaxis, np.newaxis, np.newaxis, :, np.newaxis, np.newaxis]
+    alphas_a = alphas_a[np.newaxis, np.newaxis, np.newaxis, np.newaxis, :, np.newaxis]
+    alphas_b = alphas_b[np.newaxis, np.newaxis, np.newaxis, np.newaxis, np.newaxis, :]
+    # NOTE: coeffs_a and coeffs_b are not flattened because tensordot will be used at the end where
+    # the primitives are transformed to contractions
+
+    # sum of the exponents
+    alphas_sum = alphas_a + alphas_b
+    # coordinate of the weighted average center
+    coord_wac = (alphas_a * coord_a + alphas_b * coord_b) / alphas_sum
+    # relative distance from weighted average center
+    rel_coord_a = coord_wac - coord_a
+    rel_coord_b = coord_wac - coord_b
+    rel_coord_moment = coord_wac - coord_moment
+    # harmonic mean
+    harm_mean = alphas_a * alphas_b / alphas_sum
+
+    # start of recursion
+    integrals[0, 0, 0, :, :, :] = np.sqrt(np.pi / alphas_sum) * np.exp(
+        -harm_mean * (coord_a - coord_b) ** 2
+    )
+
+    # recurse over angular momentum for a
+    # NOTE: array is sliced to avoid an if statement for angmom_a_max > 0
+    integrals[0, 0, 1:2, :, :, :] = rel_coord_a * integrals[0, 0, 0:1, :, :, :]
+    for i in range(1, angmom_a_max):
+        integrals[0, 0, i + 1, :, :, :] = rel_coord_a * integrals[0, 0, i, :, :, :] + (
+            i * integrals[0, 0, i - 1, :, :, :] / (2 * alphas_sum)
+        )
+
+    # recurse over angular momentum for b
+    i_range = np.arange(angmom_a_max + 1)[None, None, :, None, None, None]
+    # NOTE: array is sliced to avoid an if statement for angmom_b_max > 0
+    integrals[0, 1:2, 0, :, :, :] = rel_coord_b * integrals[0, 0:1, 0, :, :, :]
+    integrals[0, 1:2, 1:, :, :, :] = rel_coord_b * integrals[0, 0:1, 1:, :, :, :] + (
+        i_range[0, 0:1, 1:, :, :, :] * integrals[0, 0:1, :-1, :, :, :] / (2 * alphas_sum)
+    )
+    for j in range(1, angmom_b_max):
+        integrals[0, j + 1, 0, :, :, :] = rel_coord_b * integrals[0, j, 0, :, :, :] + (
+            j * integrals[0, j - 1, 0, :, :, :] / (2 * alphas_sum)
+        )
+        integrals[0, j + 1, 1:, :, :, :] = rel_coord_b * integrals[0, j, 1:, :, :, :] + (
+            i_range[0, 0, 1:, :, :, :] * integrals[0, j, :-1, :, :, :]
+            + j * integrals[0, j - 1, 1:, :, :, :]
+        ) / (2 * alphas_sum)
+    # recurse over order of moment
+    j_range = np.arange(angmom_b_max + 1)[None, :, None, None, None, None]
+    # NOTE: array is sliced to avoid an if statement for angmom_b_max > 0
+    integrals[1:2, 0, 0, :, :, :] = rel_coord_moment * integrals[0:1, 0, 0, :, :, :]
+    integrals[1:2, 0, 1:, :, :, :] = rel_coord_moment * integrals[0:1, 0, 1:, :, :, :] + (
+        i_range[0:1, 0, 1:, :, :, :] * integrals[0:1, 0, :-1, :, :, :] / (2 * alphas_sum)
+    )
+    integrals[1:2, 1:, 0, :, :, :] = rel_coord_moment * integrals[0:1, 1:, 0, :, :, :] + (
+        j_range[0:1, 1:, 0, :, :, :] * integrals[0:1, :-1, 0, :, :, :] / (2 * alphas_sum)
+    )
+    integrals[1:2, 1:, 1:, :, :, :] = rel_coord_moment * integrals[0:1, 1:, 1:, :, :, :] + (
+        i_range[0:1, 0:1, 1:, :, :, :] * integrals[0:1, 1:, :-1, :, :, :]
+        + j_range[0:1, 1:, 0:1, :, :, :] * integrals[0:1, :-1, 1:, :, :, :]
+    ) / (2 * alphas_sum)
+    for k in range(1, order_moment_max):
+        integrals[k + 1, 0, 0, :, :, :] = rel_coord_moment * integrals[k, 0, 0, :, :, :] + (
+            k * integrals[k - 1, 0, 0, :, :, :] / (2 * alphas_sum)
+        )
+        integrals[k + 1, 0, 1:, :, :, :] = rel_coord_moment * integrals[k, 0, 1:, :, :, :] + (
+            i_range[0, 0, 1:, :, :, :] * integrals[k, 0, :-1, :, :, :]
+            + k * integrals[k - 1, 0, 1:, :, :, :]
+        ) / (2 * alphas_sum)
+        integrals[k + 1, 1:, 0, :, :, :] = rel_coord_moment * integrals[k, 1:, 0, :, :, :] + (
+            j_range[0, 1:, 0, :, :, :] * integrals[k, :-1, 0, :, :, :]
+            + k * integrals[k - 1, 1:, 0, :, :, :]
+        ) / (2 * alphas_sum)
+        integrals[k + 1, 1:, 1:, :, :, :] = rel_coord_moment * integrals[k, 1:, 1:, :, :, :] + (
+            i_range[0, 0:, 1:, :, :, :] * integrals[k, 1:, :-1, :, :, :]
+            + j_range[0, 1:, 0:, :, :, :] * integrals[k, :-1, 1:, :, :, :]
+            + k * integrals[k - 1, 1:, 1:, :, :, :]
+        ) / (2 * alphas_sum)
+
+    # select the appropriate moments and angular momentums
+    integrals = integrals[
+        orders_moment[:, np.newaxis, np.newaxis, :],
+        angmoms_b[np.newaxis, :, np.newaxis, :],
+        angmoms_a[np.newaxis, np.newaxis, :, :],
+        np.arange(3)[np.newaxis, np.newaxis, np.newaxis, :],
+    ]
+
+    # multiply the x, y, and z components together
+    integrals = np.prod(integrals, axis=3)
+
+    # transform the primitives
+    # NOTE: axis for dimension (x, y, z) of the coordinate has been removed
+    integrals = np.tensordot(integrals, coeffs_b, (4, 0))
+    integrals = np.tensordot(integrals, coeffs_a, (3, 0))
+
+    return integrals

--- a/gbasis/moment_int.py
+++ b/gbasis/moment_int.py
@@ -69,16 +69,6 @@ def _compute_multipole_moment_integrals(
     angmom_a_max = np.max(angmoms_a)
     angmom_b_max = np.max(angmoms_b)
     order_moment_max = np.max(orders_moment)
-    # swap a and b if l(a) > l_b
-    # NOTE: If the transient integrals are returned, then we need ot make sure to swap back the
-    # a and b should they be swapped
-    # FIXME: not sure if a < b or a > b
-    if angmom_a_max < angmom_b_max:
-        angmom_a_max, angmom_b_max = angmom_b_max, angmom_a_max
-        coord_a, coord_b = coord_b, coord_a
-        alphas_a, alphas_b = alphas_b, alphas_a
-        coeffs_a, coeffs_b = coeffs_b, coeffs_a
-        angmoms_a, angmoms_b = angmoms_b, angmoms_a
 
     integrals = np.zeros(
         (order_moment_max + 1, angmom_b_max + 1, angmom_a_max + 1, 3, alphas_a.size, alphas_b.size)

--- a/tests/test_moment_int.py
+++ b/tests/test_moment_int.py
@@ -1,0 +1,547 @@
+"""Test gbasis.moment_int."""
+import itertools as it
+
+from gbasis.moment_int import _compute_multipole_moment_integrals
+import numpy as np
+
+
+def answer_prim(coord_type, i, j, k):
+    """Return the answer to the multipole moment integral tests.
+
+    Data for primitive on the left:
+    - Coordinate: [0.2, 0.4, 0.6]
+    - Exponents: [0.1]
+    - Coefficients: [1.0]
+
+    Data for primitive on the right:
+    - Coordinate: [1.0, 1.5, 2.0]
+    - Exponents: [0.2]
+    - Coefficients: [1.0]
+
+    Parameters
+    ----------
+    coord_type : {'x', 'y', 'z'}
+        Coordinate along which the multipole moment is integrated.
+    i : int
+        Angular momentum component for the given coordinate of the primitive on the left.
+    j : int
+        Angular momentum component for the given coordinate of the primitive on the right.
+    k : int
+        Order of the multipole moment for the given coordinate.
+
+    Returns
+    -------
+    answer : float
+
+    """
+    x_pa = (0.1 * 0.2 + 0.2 * 1) / 0.3 - 0.2
+    y_pa = (0.1 * 0.4 + 0.2 * 1.5) / 0.3 - 0.4
+    z_pa = (0.1 * 0.6 + 0.2 * 2) / 0.3 - 0.6
+    x_pb = (0.1 * 0.2 + 0.2 * 1) / 0.3 - 1.0
+    y_pb = (0.1 * 0.4 + 0.2 * 1.5) / 0.3 - 1.5
+    z_pb = (0.1 * 0.6 + 0.2 * 2) / 0.3 - 2.0
+    x_pc = (0.1 * 0.2 + 0.2 * 1) / 0.3 - 0.0
+    y_pc = (0.1 * 0.4 + 0.2 * 1.5) / 0.3 - 1.0
+    z_pc = (0.1 * 0.6 + 0.2 * 2) / 0.3 - 2.0
+
+    output = {}
+    output[("x", 0, 0, 0)] = np.sqrt(np.pi / 0.3) * np.exp(-0.02 / 0.3 * 0.8 ** 2)
+    output[("y", 0, 0, 0)] = np.sqrt(np.pi / 0.3) * np.exp(-0.02 / 0.3 * 1.1 ** 2)
+    output[("z", 0, 0, 0)] = np.sqrt(np.pi / 0.3) * np.exp(-0.02 / 0.3 * 1.4 ** 2)
+    output[("x", 0, 1, 0)] = x_pb * output[("x", 0, 0, 0)]
+    output[("y", 0, 1, 0)] = y_pb * output[("y", 0, 0, 0)]
+    output[("z", 0, 1, 0)] = z_pb * output[("z", 0, 0, 0)]
+    output[("x", 0, 2, 0)] = x_pb * output[("x", 0, 1, 0)] + 1 * output["x", 0, 0, 0] / 2 / 0.3
+    output[("y", 0, 2, 0)] = y_pb * output[("y", 0, 1, 0)] + 1 * output["y", 0, 0, 0] / 2 / 0.3
+    output[("z", 0, 2, 0)] = z_pb * output[("z", 0, 1, 0)] + 1 * output["z", 0, 0, 0] / 2 / 0.3
+    output[("x", 0, 3, 0)] = x_pb * output[("x", 0, 2, 0)] + 2 * output["x", 0, 1, 0] / 2 / 0.3
+    output[("y", 0, 3, 0)] = y_pb * output[("y", 0, 2, 0)] + 2 * output["y", 0, 1, 0] / 2 / 0.3
+    output[("z", 0, 3, 0)] = z_pb * output[("z", 0, 2, 0)] + 2 * output["z", 0, 1, 0] / 2 / 0.3
+
+    output[("x", 1, 0, 0)] = x_pa * output[("x", 0, 0, 0)]
+    output[("y", 1, 0, 0)] = y_pa * output[("y", 0, 0, 0)]
+    output[("z", 1, 0, 0)] = z_pa * output[("z", 0, 0, 0)]
+    output[("x", 1, 1, 0)] = x_pb * output[("x", 1, 0, 0)] + 1 * output["x", 0, 0, 0] / 2 / 0.3
+    output[("y", 1, 1, 0)] = y_pb * output[("y", 1, 0, 0)] + 1 * output["y", 0, 0, 0] / 2 / 0.3
+    output[("z", 1, 1, 0)] = z_pb * output[("z", 1, 0, 0)] + 1 * output["z", 0, 0, 0] / 2 / 0.3
+    output[("x", 1, 2, 0)] = (
+        x_pb * output[("x", 1, 1, 0)]
+        + (1 * output["x", 0, 1, 0] + 1 * output["x", 1, 0, 0]) / 2 / 0.3
+    )
+    output[("y", 1, 2, 0)] = (
+        y_pb * output[("y", 1, 1, 0)]
+        + (1 * output["y", 0, 1, 0] + 1 * output["y", 1, 0, 0]) / 2 / 0.3
+    )
+    output[("z", 1, 2, 0)] = (
+        z_pb * output[("z", 1, 1, 0)]
+        + (1 * output["z", 0, 1, 0] + 1 * output["z", 1, 0, 0]) / 2 / 0.3
+    )
+    output[("x", 1, 3, 0)] = (
+        x_pb * output[("x", 1, 2, 0)]
+        + (1 * output["x", 0, 2, 0] + 2 * output["x", 1, 1, 0]) / 2 / 0.3
+    )
+    output[("y", 1, 3, 0)] = (
+        y_pb * output[("y", 1, 2, 0)]
+        + (1 * output["y", 0, 2, 0] + 2 * output["y", 1, 1, 0]) / 2 / 0.3
+    )
+    output[("z", 1, 3, 0)] = (
+        z_pb * output[("z", 1, 2, 0)]
+        + (1 * output["z", 0, 2, 0] + 2 * output["z", 1, 1, 0]) / 2 / 0.3
+    )
+
+    output[("x", 1, 3, 1)] = (
+        x_pc * output[("x", 1, 3, 0)]
+        + (1 * output["x", 0, 3, 0] + 3 * output["x", 1, 2, 0]) / 2 / 0.3
+    )
+    output[("y", 1, 3, 1)] = (
+        y_pc * output[("y", 1, 3, 0)]
+        + (1 * output["y", 0, 3, 0] + 3 * output["y", 1, 2, 0]) / 2 / 0.3
+    )
+    output[("z", 1, 3, 1)] = (
+        z_pc * output[("z", 1, 3, 0)]
+        + (1 * output["z", 0, 3, 0] + 3 * output["z", 1, 2, 0]) / 2 / 0.3
+    )
+
+    output[("x", 2, 0, 0)] = x_pa * output[("x", 1, 0, 0)] + 1 * output["x", 0, 0, 0] / 2 / 0.3
+    output[("y", 2, 0, 0)] = y_pa * output[("y", 1, 0, 0)] + 1 * output["y", 0, 0, 0] / 2 / 0.3
+    output[("z", 2, 0, 0)] = z_pa * output[("z", 1, 0, 0)] + 1 * output["z", 0, 0, 0] / 2 / 0.3
+    output[("x", 2, 1, 0)] = x_pb * output[("x", 2, 0, 0)] + 2 * output["x", 1, 0, 0] / 2 / 0.3
+    output[("y", 2, 1, 0)] = y_pb * output[("y", 2, 0, 0)] + 2 * output["y", 1, 0, 0] / 2 / 0.3
+    output[("z", 2, 1, 0)] = z_pb * output[("z", 2, 0, 0)] + 2 * output["z", 1, 0, 0] / 2 / 0.3
+    output[("x", 2, 2, 0)] = (
+        x_pb * output[("x", 2, 1, 0)]
+        + (2 * output["x", 1, 1, 0] + 1 * output["x", 2, 0, 0]) / 2 / 0.3
+    )
+    output[("y", 2, 2, 0)] = (
+        y_pb * output[("y", 2, 1, 0)]
+        + (2 * output["y", 1, 1, 0] + 1 * output["y", 2, 0, 0]) / 2 / 0.3
+    )
+    output[("z", 2, 2, 0)] = (
+        z_pb * output[("z", 2, 1, 0)]
+        + (2 * output["z", 1, 1, 0] + 1 * output["z", 2, 0, 0]) / 2 / 0.3
+    )
+    output[("x", 2, 3, 0)] = (
+        x_pb * output[("x", 2, 2, 0)]
+        + (2 * output["x", 1, 2, 0] + 2 * output["x", 2, 1, 0]) / 2 / 0.3
+    )
+    output[("y", 2, 3, 0)] = (
+        y_pb * output[("y", 2, 2, 0)]
+        + (2 * output["y", 1, 2, 0] + 2 * output["y", 2, 1, 0]) / 2 / 0.3
+    )
+    output[("z", 2, 3, 0)] = (
+        z_pb * output[("z", 2, 2, 0)]
+        + (2 * output["z", 1, 2, 0] + 2 * output["z", 2, 1, 0]) / 2 / 0.3
+    )
+
+    output[("x", 2, 2, 1)] = (
+        x_pc * output[("x", 2, 2, 0)]
+        + (2 * output["x", 1, 2, 0] + 2 * output["x", 2, 1, 0]) / 2 / 0.3
+    )
+    output[("y", 2, 2, 1)] = (
+        y_pc * output[("y", 2, 2, 0)]
+        + (2 * output["y", 1, 2, 0] + 2 * output["y", 2, 1, 0]) / 2 / 0.3
+    )
+    output[("z", 2, 2, 1)] = (
+        z_pc * output[("z", 2, 2, 0)]
+        + (2 * output["z", 1, 2, 0] + 2 * output["z", 2, 1, 0]) / 2 / 0.3
+    )
+    output[("x", 2, 3, 1)] = (
+        x_pc * output[("x", 2, 3, 0)]
+        + (2 * output["x", 1, 3, 0] + 3 * output["x", 2, 2, 0]) / 2 / 0.3
+    )
+    output[("y", 2, 3, 1)] = (
+        y_pc * output[("y", 2, 3, 0)]
+        + (2 * output["y", 1, 3, 0] + 3 * output["y", 2, 2, 0]) / 2 / 0.3
+    )
+    output[("z", 2, 3, 1)] = (
+        z_pc * output[("z", 2, 3, 0)]
+        + (2 * output["z", 1, 3, 0] + 3 * output["z", 2, 2, 0]) / 2 / 0.3
+    )
+    output[("x", 2, 3, 2)] = (
+        x_pc * output[("x", 2, 3, 1)]
+        + (2 * output["x", 1, 3, 1] + 3 * output["x", 2, 2, 1] + 1 * output["x", 2, 3, 0]) / 2 / 0.3
+    )
+    output[("y", 2, 3, 2)] = (
+        y_pc * output[("y", 2, 3, 1)]
+        + (2 * output["y", 1, 3, 1] + 3 * output["y", 2, 2, 1] + 1 * output["y", 2, 3, 0]) / 2 / 0.3
+    )
+    output[("z", 2, 3, 2)] = (
+        z_pc * output[("z", 2, 3, 1)]
+        + (2 * output["z", 1, 3, 1] + 3 * output["z", 2, 2, 1] + 1 * output["z", 2, 3, 0]) / 2 / 0.3
+    )
+
+    output[("x", 3, 0, 0)] = x_pa * output[("x", 2, 0, 0)] + 2 * output["x", 1, 0, 0] / 2 / 0.3
+    output[("y", 3, 0, 0)] = y_pa * output[("y", 2, 0, 0)] + 2 * output["y", 1, 0, 0] / 2 / 0.3
+    output[("z", 3, 0, 0)] = z_pa * output[("z", 2, 0, 0)] + 2 * output["z", 1, 0, 0] / 2 / 0.3
+    output[("x", 3, 1, 0)] = x_pb * output[("x", 3, 0, 0)] + 3 * output["x", 2, 0, 0] / 2 / 0.3
+    output[("y", 3, 1, 0)] = y_pb * output[("y", 3, 0, 0)] + 3 * output["y", 2, 0, 0] / 2 / 0.3
+    output[("z", 3, 1, 0)] = z_pb * output[("z", 3, 0, 0)] + 3 * output["z", 2, 0, 0] / 2 / 0.3
+    output[("x", 3, 2, 0)] = (
+        x_pb * output[("x", 3, 1, 0)]
+        + (3 * output["x", 2, 1, 0] + 1 * output["x", 3, 0, 0]) / 2 / 0.3
+    )
+    output[("y", 3, 2, 0)] = (
+        y_pb * output[("y", 3, 1, 0)]
+        + (3 * output["y", 2, 1, 0] + 1 * output["y", 3, 0, 0]) / 2 / 0.3
+    )
+    output[("z", 3, 2, 0)] = (
+        z_pb * output[("z", 3, 1, 0)]
+        + (3 * output["z", 2, 1, 0] + 1 * output["z", 3, 0, 0]) / 2 / 0.3
+    )
+    output[("x", 3, 3, 0)] = (
+        x_pb * output[("x", 3, 2, 0)]
+        + (3 * output["x", 2, 2, 0] + 2 * output["x", 3, 1, 0]) / 2 / 0.3
+    )
+    output[("y", 3, 3, 0)] = (
+        y_pb * output[("y", 3, 2, 0)]
+        + (3 * output["y", 2, 2, 0] + 2 * output["y", 3, 1, 0]) / 2 / 0.3
+    )
+    output[("z", 3, 3, 0)] = (
+        z_pb * output[("z", 3, 2, 0)]
+        + (3 * output["z", 2, 2, 0] + 2 * output["z", 3, 1, 0]) / 2 / 0.3
+    )
+
+    output[("x", 3, 1, 1)] = (
+        x_pc * output[("x", 3, 1, 0)]
+        + (3 * output["x", 2, 1, 0] + 1 * output["x", 3, 0, 0]) / 2 / 0.3
+    )
+    output[("y", 3, 1, 1)] = (
+        y_pc * output[("y", 3, 1, 0)]
+        + (3 * output["y", 2, 1, 0] + 1 * output["y", 3, 0, 0]) / 2 / 0.3
+    )
+    output[("z", 3, 1, 1)] = (
+        z_pc * output[("z", 3, 1, 0)]
+        + (3 * output["z", 2, 1, 0] + 1 * output["z", 3, 0, 0]) / 2 / 0.3
+    )
+    output[("x", 3, 2, 1)] = (
+        x_pc * output[("x", 3, 2, 0)]
+        + (3 * output["x", 2, 2, 0] + 2 * output["x", 3, 1, 0]) / 2 / 0.3
+    )
+    output[("y", 3, 2, 1)] = (
+        y_pc * output[("y", 3, 2, 0)]
+        + (3 * output["y", 2, 2, 0] + 2 * output["y", 3, 1, 0]) / 2 / 0.3
+    )
+    output[("z", 3, 2, 1)] = (
+        z_pc * output[("z", 3, 2, 0)]
+        + (3 * output["z", 2, 2, 0] + 2 * output["z", 3, 1, 0]) / 2 / 0.3
+    )
+    output[("x", 3, 2, 2)] = (
+        x_pc * output[("x", 3, 2, 1)]
+        + (3 * output["x", 2, 2, 1] + 2 * output["x", 3, 1, 1] + 1 * output["x", 3, 2, 0]) / 2 / 0.3
+    )
+    output[("y", 3, 2, 2)] = (
+        y_pc * output[("y", 3, 2, 1)]
+        + (3 * output["y", 2, 2, 1] + 2 * output["y", 3, 1, 1] + 1 * output["y", 3, 2, 0]) / 2 / 0.3
+    )
+    output[("z", 3, 2, 2)] = (
+        z_pc * output[("z", 3, 2, 1)]
+        + (3 * output["z", 2, 2, 1] + 2 * output["z", 3, 1, 1] + 1 * output["z", 3, 2, 0]) / 2 / 0.3
+    )
+    output[("x", 3, 3, 1)] = (
+        x_pc * output[("x", 3, 3, 0)]
+        + (3 * output["x", 2, 3, 0] + 3 * output["x", 3, 2, 0]) / 2 / 0.3
+    )
+    output[("y", 3, 3, 1)] = (
+        y_pc * output[("y", 3, 3, 0)]
+        + (3 * output["y", 2, 3, 0] + 3 * output["y", 3, 2, 0]) / 2 / 0.3
+    )
+    output[("z", 3, 3, 1)] = (
+        z_pc * output[("z", 3, 3, 0)]
+        + (3 * output["z", 2, 3, 0] + 3 * output["z", 3, 2, 0]) / 2 / 0.3
+    )
+    output[("x", 3, 3, 2)] = (
+        x_pc * output[("x", 3, 3, 1)]
+        + (3 * output["x", 2, 3, 1] + 3 * output["x", 3, 2, 1] + 1 * output["x", 3, 3, 0]) / 2 / 0.3
+    )
+    output[("y", 3, 3, 2)] = (
+        y_pc * output[("y", 3, 3, 1)]
+        + (3 * output["y", 2, 3, 1] + 3 * output["y", 3, 2, 1] + 1 * output["y", 3, 3, 0]) / 2 / 0.3
+    )
+    output[("z", 3, 3, 2)] = (
+        z_pc * output[("z", 3, 3, 1)]
+        + (3 * output["z", 2, 3, 1] + 3 * output["z", 3, 2, 1] + 1 * output["z", 3, 3, 0]) / 2 / 0.3
+    )
+    output[("x", 3, 3, 3)] = (
+        x_pc * output[("x", 3, 3, 2)]
+        + (3 * output["x", 2, 3, 2] + 3 * output["x", 3, 2, 2] + 2 * output["x", 3, 3, 1]) / 2 / 0.3
+    )
+    output[("y", 3, 3, 3)] = (
+        y_pc * output[("y", 3, 3, 2)]
+        + (3 * output["y", 2, 3, 2] + 3 * output["y", 3, 2, 2] + 2 * output["y", 3, 3, 1]) / 2 / 0.3
+    )
+    output[("z", 3, 3, 3)] = (
+        z_pc * output[("z", 3, 3, 2)]
+        + (3 * output["z", 2, 3, 2] + 3 * output["z", 3, 2, 2] + 2 * output["z", 3, 3, 1]) / 2 / 0.3
+    )
+
+    return output[(coord_type, i, j, k)]
+
+
+def test_compute_multipole_moment_integrals_prim_angmom_left_recursion():
+    """Test recursion for the left primitive in moment_int._compute_multipole_moment_integrals."""
+    coord_a = np.array([0.2, 0.4, 0.6])
+    coord_b = np.array([1, 1.5, 2])
+    alphas_a = np.array([0.1])
+    alphas_b = np.array([0.2])
+    coeffs_a = np.array([1.0])
+    coeffs_b = np.array([1.0])
+    angmoms_b = np.array([[0, 0, 0]])
+    coord_moment = np.array([0.0, 1.0, 2.0])
+    order_moment = np.array([[0, 0, 0]])
+
+    # zero moment, zero right angulra momentum
+    for ix, iy, iz in it.product(range(4), range(4), range(4)):
+        assert np.allclose(
+            _compute_multipole_moment_integrals(
+                coord_moment,
+                order_moment,
+                coord_a,
+                np.array([[ix, iy, iz]]),
+                alphas_a,
+                coeffs_a,
+                coord_b,
+                angmoms_b,
+                alphas_b,
+                coeffs_b,
+            ),
+            answer_prim("x", ix, 0, 0) * answer_prim("y", iy, 0, 0) * answer_prim("z", iz, 0, 0),
+        )
+
+
+def test_compute_multipole_moment_integrals_prim_angmom_right_recursion():
+    """Test recursion for the right primitive in moment_int._compute_multipole_moment_integrals."""
+    coord_a = np.array([0.2, 0.4, 0.6])
+    coord_b = np.array([1, 1.5, 2])
+    alphas_a = np.array([0.1])
+    alphas_b = np.array([0.2])
+    coeffs_a = np.array([1.0])
+    coeffs_b = np.array([1.0])
+    angmoms_a = np.array([[3, 3, 3]])
+    coord_moment = np.array([0.0, 1.0, 2.0])
+    order_moment = np.array([[0, 0, 0]])
+
+    # zero moment, three left angular momentum
+    for jx, jy, jz in it.product(range(4), range(4), range(4)):
+        assert np.allclose(
+            _compute_multipole_moment_integrals(
+                coord_moment,
+                order_moment,
+                coord_a,
+                angmoms_a,
+                alphas_a,
+                coeffs_a,
+                coord_b,
+                np.array([[jx, jy, jz]]),
+                alphas_b,
+                coeffs_b,
+            ),
+            answer_prim("x", 3, jx, 0) * answer_prim("y", 3, jy, 0) * answer_prim("z", 3, jz, 0),
+        )
+
+
+def test_compute_multipole_moment_integrals_prim_moment_recursion():
+    """Test recursion for multipole moment in moment_int._compute_multipole_moment_integrals."""
+    coord_a = np.array([0.2, 0.4, 0.6])
+    coord_b = np.array([1, 1.5, 2])
+    alphas_a = np.array([0.1])
+    alphas_b = np.array([0.2])
+    coeffs_a = np.array([1.0])
+    coeffs_b = np.array([1.0])
+    angmoms_a = np.array([[3, 3, 3]])
+    angmoms_b = np.array([[3, 3, 3]])
+    coord_moment = np.array([0.0, 1.0, 2.0])
+
+    # three left angular momentum, three right angular momentum
+    for kx, ky, kz in it.product(range(4), range(4), range(4)):
+        assert np.allclose(
+            _compute_multipole_moment_integrals(
+                coord_moment,
+                np.array([[kx, ky, kz]]),
+                coord_a,
+                angmoms_a,
+                alphas_a,
+                coeffs_a,
+                coord_b,
+                angmoms_b,
+                alphas_b,
+                coeffs_b,
+            ),
+            answer_prim("x", 3, 3, kx) * answer_prim("y", 3, 3, ky) * answer_prim("z", 3, 3, kz),
+        )
+
+
+def test_compute_multipole_moment_integrals_contraction():
+    """Test moment_int._compute_multipole_moment_integrals on contractions.
+
+    Note
+    ----
+    The function itself `_compute_multipole_moment_integrals` is used to test the use case for
+    contractions. It assumes that this function behaves correctly for primitives.
+
+    """
+    coord_a = np.array([0.2, 0.4, 0.6])
+    coord_b = np.array([1, 1.5, 2])
+    angmoms_a = np.array([[3, 3, 3]])
+    angmoms_b = np.array([[3, 3, 3]])
+    coord_moment = np.array([0.0, 1.0, 2.0])
+    order_moment = np.array([[3, 3, 3]])
+
+    alphas_a = np.array([0.1, 0.01])
+    alphas_b = np.array([0.2, 0.02])
+    coeffs_a = np.array([1.0, 2.0])
+    coeffs_b = np.array([3.0, 4.0])
+
+    assert np.allclose(
+        _compute_multipole_moment_integrals(
+            coord_moment,
+            order_moment,
+            coord_a,
+            angmoms_a,
+            alphas_a,
+            coeffs_a,
+            coord_b,
+            angmoms_b,
+            alphas_b,
+            coeffs_b,
+        ),
+        1
+        * 3
+        * _compute_multipole_moment_integrals(
+            coord_moment,
+            order_moment,
+            coord_a,
+            angmoms_a,
+            np.array([0.1]),
+            np.array([1.0]),
+            coord_b,
+            angmoms_b,
+            np.array([0.2]),
+            np.array([1.0]),
+        )
+        + 2
+        * 3
+        * _compute_multipole_moment_integrals(
+            coord_moment,
+            order_moment,
+            coord_a,
+            angmoms_a,
+            np.array([0.01]),
+            np.array([1.0]),
+            coord_b,
+            angmoms_b,
+            np.array([0.2]),
+            np.array([1.0]),
+        )
+        + 1
+        * 4
+        * _compute_multipole_moment_integrals(
+            coord_moment,
+            order_moment,
+            coord_a,
+            angmoms_a,
+            np.array([0.1]),
+            np.array([1.0]),
+            coord_b,
+            angmoms_b,
+            np.array([0.02]),
+            np.array([1.0]),
+        )
+        + 2
+        * 4
+        * _compute_multipole_moment_integrals(
+            coord_moment,
+            order_moment,
+            coord_a,
+            angmoms_a,
+            np.array([0.01]),
+            np.array([1.0]),
+            coord_b,
+            angmoms_b,
+            np.array([0.02]),
+            np.array([1.0]),
+        ),
+    )
+
+
+def test_compute_multipole_moment_integrals_multiarray():
+    """Test _compute_multipole_moment_integrals for computing multiple cases simultaneously.
+
+    Note
+    ----
+    The function itself `_compute_multipole_moment_integrals` is used to test the use case for
+    contractions. It assumes that this function behaves correctly for contractions.
+
+    """
+    coord_a = np.array([0.2, 0.4, 0.6])
+    coord_b = np.array([0.3, 0.5, 0.7])
+    angmoms_a = np.array(
+        [
+            [3, 0, 0],
+            [0, 3, 0],
+            [0, 0, 3],
+            [2, 1, 0],
+            [2, 0, 1],
+            [1, 2, 0],
+            [0, 2, 1],
+            [1, 0, 2],
+            [0, 1, 2],
+        ]
+    )
+    angmoms_b = np.array([[2, 0, 0], [0, 2, 0], [0, 0, 2], [1, 1, 0], [1, 0, 1], [0, 1, 1]])
+    alphas_a = np.array([0.1, 0.01, 0.001])
+    alphas_b = np.array([0.2, 0.02, 0.002])
+    coeffs_a = np.array([1.0, 1.0, 1.0])
+    coeffs_b = np.array([1.0, 1.0, 1.0])
+    coord_moment = np.array([0.25, 0.45, 0.65])
+    orders_moment = np.array(
+        [
+            [3, 0, 0],
+            [0, 3, 0],
+            [0, 0, 3],
+            [2, 1, 0],
+            [2, 0, 1],
+            [1, 2, 0],
+            [0, 2, 1],
+            [1, 0, 2],
+            [0, 1, 2],
+            [2, 0, 0],
+            [0, 2, 0],
+            [0, 0, 2],
+            [1, 1, 0],
+            [1, 0, 1],
+            [0, 1, 1],
+        ]
+    )
+
+    # NOTE: these numbers get big
+    test = _compute_multipole_moment_integrals(
+        coord_moment,
+        orders_moment,
+        coord_a,
+        angmoms_a,
+        alphas_a,
+        coeffs_a,
+        coord_b,
+        angmoms_b,
+        alphas_b,
+        coeffs_b,
+    )
+    assert test.shape == (orders_moment.shape[0], angmoms_b.shape[0], angmoms_a.shape[0])
+    for i, order_moment in enumerate(orders_moment):
+        for j, angmom_a in enumerate(angmoms_a):
+            for k, angmom_b in enumerate(angmoms_b):
+                assert np.allclose(
+                    _compute_multipole_moment_integrals(
+                        coord_moment,
+                        np.array([order_moment]),
+                        coord_a,
+                        np.array([angmom_a]),
+                        alphas_a,
+                        coeffs_a,
+                        coord_b,
+                        np.array([angmom_b]),
+                        alphas_b,
+                        coeffs_b,
+                    ),
+                    test[i, k, j],
+                )


### PR DESCRIPTION
What:
Add _compute_multipole_moment_integrals for computing multipole moment integrals
of different orders for a set of contractions with different angular momentums.

Why:
This function will be used to compute the multipole moments of arbitrary order
which can then be used to compute useful quantities such as overlap and kinetic
energy.

Why Specifics:
1. We do not intend for this function to be the memory bottleneck. The size of
the multidimensional array, `overlaps`, will likely be limited by the
contractions that can be grouped together by their coordinates, exponents, and
coefficients. It doesn't seem likely that neither of the maximum angular
momentum component nor the maximum order of the moment to reach a large enough
number to have memory problems (they will probably be almost always less than
20).
2. We aim to exploit vectorization rather than minimizing the number of
operations. This means that we will likely compute and store many more values
than the minimum necessary. The hope is that the optimization that results from
vectorization will offset the cost of redundant evaluations. Considering that the
optimal path (of recursion) is not trivial to find, and that this path is likely
different depending on different cases (angular momentum vectors and orders of
moments), and that this process will need to be repeated for many different
cases, and that Python is not terribly amenable to repeated for loop structures,
vectorization (via numpy) seems to be a good choice.
3. We pick the following recursion path: first, we recurse over the angular
momentum on the left primitive/contraction until the maximum angular momentum
value (out of all three dimensions) of the contractions on the left side; then,
we recurse over the angular momentum on the right primitive/contraction until
the maximum angular momentum value of the contractions on the right side; and
then we recurse over the order of the moment until the maximum moment
component (out of all three dimensions).
4. We store the integrals for all the values until the maximum angular momentum
and the maximum order of moment. Again, memory is not an issue. Brute force
storage made things easier to code. Also, computation of higher order moments
often requires computation of lower order moments. We will get these integrals
for free.
5. Numpy doesn't play too nicely with recursions. For loops were used instead of
some fancy structure. If necessary, numba should do a nice job speeding things
up.
6. The order of the axis in the intermediate quantity, `integrals`, was
determined in part by trial and error and intuition. First three correspond to
the reverse order of the recursion (moment, angular momentum, angular momentum)
because c-contiguous ordering results in faster lookup (and assignment) for axis
on the left side. The next axis corresponds to dimensions (x, y, z) because
`numpy.prod` seems to be faster over axis in the middle. The last two
axis (primitive, primitive) is better for contraction (for `numpy.tensordot`)
