### PR TITLE
Vectorize order of derivatization

### DIFF
--- a/gbasis/deriv.py
+++ b/gbasis/deriv.py
@@ -61,87 +61,49 @@ def _eval_deriv_contractions(coords, orders, center, angmom_comps, alphas, prim_
     # NOTE: if `angmom_comps` is two-dimensional (3, L), has shape (1, 1, 3, L).
     alphas = alphas[np.newaxis, :, np.newaxis, np.newaxis, np.newaxis, np.newaxis]
     # NOTE: `prim_coeffs` will be used as a 1D array
+    orders = orders[np.newaxis, np.newaxis, :, :, np.newaxis, np.newaxis]
 
     # useful variables
     rel_coords = coords - center
     gauss = np.exp(-alphas * rel_coords ** 2)
 
-    # zeroth order (i.e. no derivatization)
-    bool_noderiv = (orders <= 0)[np.newaxis, np.newaxis, :, :, np.newaxis, np.newaxis]
-    zero_rel_coords, zero_angmom_comps, zero_gauss = (
-        rel_coords * bool_noderiv,
-        angmom_comps * bool_noderiv,
-        gauss * bool_noderiv,
+    # General approach: compute the whole coefficents, zero out the irrelevant parts
+    # NOTE: The following step assumes that there is only one set (nx, ny, nz) of derivatization
+    # orders i.e. we assume that only one axis (axis 2) of `nonzero_orders` has a dimension
+    # greater than 1
+    indices_herm = np.arange(np.max(orders) + 1, dtype=int)[:, None, None, None, None, None]
+    # get indices that are used as powers of the appropriate terms in the derivative
+    # NOTE: the negative indices must be turned into zeros (even though they are turned into
+    # zeros later anyways) because these terms are sometimes zeros (and negative power is
+    # undefined).
+    indices_angmom = angmom_comps - orders + indices_herm
+    indices_angmom[indices_angmom < 0] = 0
+    # get coefficients for all entries
+    coeffs = (
+        comb(orders, indices_herm)
+        * perm(angmom_comps, orders - indices_herm)
+        * (-alphas ** 0.5) ** indices_herm
+        * rel_coords ** indices_angmom
     )
-    zeroth_part = np.zeros(
-        (alphas.shape[1], bool_noderiv.shape[2], angmom_comps.shape[4], rel_coords.shape[5])
-    )
-    for i in range(bool_noderiv.shape[2]):
-        zeroth_part[:, i] = np.prod(
-            zero_rel_coords[:, :, i, bool_noderiv[0, 0, i, :, 0, 0], :, :]
-            ** zero_angmom_comps[:, :, i, bool_noderiv[0, 0, i, :, 0, 0], :, :]
-            * zero_gauss[:, :, i, bool_noderiv[0, 0, i, :, 0, 0], :, :],
-            axis=(0, 2),
-        )
-    # NOTE: `zeroth_part` now has axis 0 for primitives, axis 1 for order of derivatization, and
-    # axis 1 for angular momentum vector, and axis 2 for coordinate
+    # zero out the appropriate terms
+    indices_zero = np.where(indices_herm < np.maximum(0, orders - angmom_comps))
+    coeffs[indices_zero[0], :, indices_zero[2], indices_zero[3], indices_zero[4], :] = 0
+    indices_zero = np.where(orders < indices_herm)
+    coeffs[indices_zero[0], :, indices_zero[2], indices_zero[3], :, :] = 0
+    # compute
+    # TODO: I don't know if the scipy.special.eval_hermite uses some smart vectorizing/caching
+    # to evaluate multiple orders at the same time. Creating/finding a better function for
+    # evaluating the hermite polynomial at different orders (in sequence) may be nice in the
+    # future.
+    hermite = np.sum(coeffs * eval_hermite(indices_herm, alphas ** 0.5 * rel_coords), axis=0)
+    hermite = np.prod(hermite, axis=2)
+    # NOTE: `hermite` now has axis 0 for primitives, 1 for order of derivatization, 2 for
+    # angular momentum vector, axis 3 for coordinates
 
-    deriv_part = 1
-    bool_deriv = (orders > 0)[np.newaxis, np.newaxis, :, :, np.newaxis, np.newaxis]
-    indices_deriv = np.where(bool_deriv)
-    nonzero_rel_coords, nonzero_orders, nonzero_angmom_comps, nonzero_gauss = (
-        rel_coords * bool_deriv,
-        orders[np.newaxis, np.newaxis, :, :, np.newaxis, np.newaxis] * bool_deriv,
-        angmom_comps * bool_deriv,
-        gauss * bool_deriv,
-    )
-
-    # derivatization part
-    if indices_deriv[0].size != 0:
-        # General approach: compute the whole coefficents, zero out the irrelevant parts
-        # NOTE: The following step assumes that there is only one set (nx, ny, nz) of derivatization
-        # orders i.e. we assume that only one axis (axis 2) of `nonzero_orders` has a dimension
-        # greater than 1
-        indices_herm = np.arange(np.max(nonzero_orders) + 1)[:, None, None, None, None, None]
-        # get indices that are used as powers of the appropriate terms in the derivative
-        # NOTE: the negative indices must be turned into zeros (even though they are turned into
-        # zeros later anyways) because these terms are sometimes zeros (and negative power is
-        # undefined).
-        indices_angmom = nonzero_angmom_comps - nonzero_orders + indices_herm
-        indices_angmom[indices_angmom < 0] = 0
-        # get coefficients for all entries
-        coeffs = (
-            comb(nonzero_orders, indices_herm)
-            * perm(nonzero_angmom_comps, nonzero_orders - indices_herm)
-            * (-alphas ** 0.5) ** indices_herm
-            * nonzero_rel_coords ** indices_angmom
-        )
-        # zero out the appropriate terms
-        indices_zero = np.where(indices_herm < np.maximum(0, nonzero_orders - nonzero_angmom_comps))
-        coeffs[indices_zero[0], :, indices_zero[2], indices_zero[3], indices_zero[4], :] = 0
-        indices_zero = np.where(nonzero_orders < indices_herm)
-        coeffs[indices_zero[0], :, indices_zero[2], indices_zero[3], :, :] = 0
-        # compute
-        # TODO: I don't know if the scipy.special.eval_hermite uses some smart vectorizing/caching
-        # to evaluate multiple orders at the same time. Creating/finding a better function for
-        # evaluating the hermite polynomial at different orders (in sequence) may be nice in the
-        # future.
-        hermite = np.sum(
-            coeffs * eval_hermite(indices_herm, alphas ** 0.5 * nonzero_rel_coords), axis=0
-        )
-        hermite = np.prod(hermite, axis=2)
-
-        # NOTE: `hermite` now has axis 0 for primitives, 1 for order of derivatization, 2 for
-        # angular momentum vector, axis 3 for coordinates
-        nonzero_gauss_2 = np.zeros(hermite.shape)
-        for i in range(nonzero_orders.shape[2]):
-            nonzero_gauss_2[:, i] = np.prod(
-                nonzero_gauss[:, :, i, bool_deriv[0, 0, i, :, 0, 0], :, :], axis=(0, 2)
-            )
-        deriv_part = nonzero_gauss_2 * hermite
+    deriv_part = np.prod(gauss, axis=(0, 3)) * hermite
 
     norm = norm.T[:, np.newaxis, :, np.newaxis]
-    return np.tensordot(prim_coeffs, norm * zeroth_part * deriv_part, (0, 0))
+    return np.tensordot(prim_coeffs, norm * deriv_part, (0, 0))
 
 
 def eval_deriv_shell(*, coords, orders, shell):

--- a/tests/test_deriv.py
+++ b/tests/test_deriv.py
@@ -39,7 +39,7 @@ def eval_deriv_prim(coord, orders, center, angmom_comps, alpha):
     """
     return _eval_deriv_contractions(
         coord.reshape(1, 3),
-        orders,
+        orders.reshape(1, 3),
         center,
         angmom_comps.reshape(1, 3),
         np.array([alpha]),
@@ -151,7 +151,7 @@ def test_eval_contractions():
     assert np.allclose(
         _eval_deriv_contractions(
             np.array([[0, 0, 0]]),
-            np.array([0, 0, 0]),
+            np.array([[0, 0, 0]]),
             np.array([0, 0, 0]),
             np.array([[0, 0, 0]]),
             np.array([1.0]),
@@ -163,7 +163,7 @@ def test_eval_contractions():
     assert np.allclose(
         _eval_deriv_contractions(
             np.array([[1.0, 0, 0]]),
-            np.array([0, 0, 0]),
+            np.array([[0, 0, 0]]),
             np.array([0, 0, 0]),
             np.array([[0, 0, 0]]),
             np.array([1.0]),
@@ -175,7 +175,7 @@ def test_eval_contractions():
     assert np.allclose(
         _eval_deriv_contractions(
             np.array([[1.0, 2.0, 0]]),
-            np.array([0, 0, 0]),
+            np.array([[0, 0, 0]]),
             np.array([0, 0, 0]),
             np.array([[0, 0, 0]]),
             np.array([1.0]),
@@ -187,7 +187,7 @@ def test_eval_contractions():
     assert np.allclose(
         _eval_deriv_contractions(
             np.array([[1.0, 2.0, 3.0]]),
-            np.array([0, 0, 0]),
+            np.array([[0, 0, 0]]),
             np.array([0, 0, 0]),
             np.array([[0, 0, 0]]),
             np.array([1.0]),
@@ -200,7 +200,7 @@ def test_eval_contractions():
     assert np.allclose(
         _eval_deriv_contractions(
             np.array([[2.0, 0, 0]]),
-            np.array([0, 0, 0]),
+            np.array([[0, 0, 0]]),
             np.array([0, 0, 0]),
             np.array([[1, 0, 0]]),
             np.array([1.0]),
@@ -213,7 +213,7 @@ def test_eval_contractions():
     assert np.allclose(
         _eval_deriv_contractions(
             np.array([[2.0, 0, 0]]),
-            np.array([0, 0, 0]),
+            np.array([[0, 0, 0]]),
             np.array([0, 3, 4]),
             np.array([[2, 1, 3]]),
             np.array([1.0]),
@@ -226,7 +226,7 @@ def test_eval_contractions():
     assert np.allclose(
         _eval_deriv_contractions(
             np.array([[2, 0, 0]]),
-            np.array([0, 0, 0]),
+            np.array([[0, 0, 0]]),
             np.array([0, 3, 4]),
             np.array([[2, 1, 3]]),
             np.array([0.1, 0.001]),
@@ -240,7 +240,7 @@ def test_eval_contractions():
     assert np.allclose(
         _eval_deriv_contractions(
             np.array([[2, 0, 0]]),
-            np.array([0, 0, 0]),
+            np.array([[0, 0, 0]]),
             np.array([0, 3, 4]),
             np.array([[2, 1, 3], [1, 3, 4]]),
             np.array([0.1, 0.001]),
@@ -266,6 +266,7 @@ def test_eval_deriv_contractions():
     for k in range(3):
         orders = np.zeros(3, dtype=int)
         orders[k] = 1
+        orders = orders.reshape(1, 3)
         for x, y, z in it.product(range(3), range(3), range(3)):
             # only contraction
             assert np.allclose(
@@ -288,16 +289,7 @@ def test_eval_deriv_contractions():
                 ),
             )
             # contraction + multiple angular momentums
-            assert np.allclose(
-                _eval_deriv_contractions(
-                    np.array([[2, 3, 4]]),
-                    orders,
-                    np.array([0.5, 1, 1.5]),
-                    np.array([[x, y, z], [x - 1, y + 2, z + 1]]),
-                    np.array([1, 2]),
-                    np.array([3, 4]),
-                    np.array([[1, 1]]),
-                ),
+            answer = np.array(
                 [
                     3
                     * eval_deriv_prim(
@@ -323,13 +315,26 @@ def test_eval_deriv_contractions():
                         np.array([x - 1, y + 2, z + 1]),
                         2,
                     ),
-                ],
+                ]
+            )
+            assert np.allclose(
+                _eval_deriv_contractions(
+                    np.array([[2, 3, 4]]),
+                    orders,
+                    np.array([0.5, 1, 1.5]),
+                    np.array([[x, y, z], [x - 1, y + 2, z + 1]]),
+                    np.array([1, 2]),
+                    np.array([3, 4]),
+                    np.array([[1, 1]]),
+                ),
+                np.swapaxes(answer, 0, 1),
             )
     # second order
     for k, l in it.product(range(3), range(3)):
         orders = np.zeros(3, dtype=int)
         orders[k] += 1
         orders[l] += 1
+        orders = orders.reshape(1, 3)
         for x, y, z in it.product(range(4), range(4), range(4)):
             assert np.allclose(
                 _eval_deriv_contractions(
@@ -366,16 +371,7 @@ def test_eval_deriv_contractions():
                 ),
             )
             # contraction + multiple angular momentums
-            assert np.allclose(
-                _eval_deriv_contractions(
-                    np.array([[2, 3, 4]]),
-                    orders,
-                    np.array([0.5, 1, 1.5]),
-                    np.array([[x, y, z], [x - 1, y + 2, z + 1]]),
-                    np.array([1, 2]),
-                    np.array([3, 4]),
-                    np.array([[1, 1]]),
-                ),
+            answer = np.array(
                 [
                     3
                     * eval_deriv_prim(
@@ -401,7 +397,19 @@ def test_eval_deriv_contractions():
                         np.array([x - 1, y + 2, z + 1]),
                         2,
                     ),
-                ],
+                ]
+            )
+            assert np.allclose(
+                _eval_deriv_contractions(
+                    np.array([[2, 3, 4]]),
+                    orders,
+                    np.array([0.5, 1, 1.5]),
+                    np.array([[x, y, z], [x - 1, y + 2, z + 1]]),
+                    np.array([1, 2]),
+                    np.array([3, 4]),
+                    np.array([[1, 1]]),
+                ),
+                np.swapaxes(answer, 0, 1),
             )
 
 
@@ -421,7 +429,7 @@ def test_eval_deriv_shell():
     with pytest.raises(ValueError):
         eval_deriv_shell(coords=coords.reshape(3, 1), orders=orders, shell=shell)
     with pytest.raises(ValueError):
-        eval_deriv_shell(coords=coords, orders=orders.reshape(1, 3), shell=shell)
+        eval_deriv_shell(coords=coords, orders=orders.reshape(3, 1), shell=shell)
     assert np.allclose(
         eval_deriv_shell(coords=coords, orders=orders, shell=shell),
         eval_deriv_shell(coords=coords.reshape(3), orders=orders, shell=shell),
@@ -431,6 +439,7 @@ def test_eval_deriv_shell():
     for k in range(3):
         orders = np.zeros(3, dtype=int)
         orders[k] = 1
+        orders = orders.reshape(1, 3)
 
         test = ContractedCartesianGaussians(
             1, np.array([0.5, 1, 1.5]), 0, np.array([1.0, 2.0]), np.array([0.1, 0.01])
@@ -468,6 +477,7 @@ def test_eval_deriv_shell():
         orders = np.zeros(3, dtype=int)
         orders[k] += 1
         orders[l] += 1
+        orders = orders.reshape(1, 3)
 
         test = ContractedCartesianGaussians(
             1, np.array([0.5, 1, 1.5]), 0, np.array([1.0, 2.0]), np.array([0.1, 0.01])
@@ -511,7 +521,7 @@ def test_eval_shell():
         [
             _eval_deriv_contractions(
                 np.array([[2, 3, 4]]),
-                np.array([0, 0, 0]),
+                np.array([[0, 0, 0]]),
                 np.array([0.5, 1, 1.5]),
                 np.array([angmom_comp]),
                 np.array([0.1, 0.01]),
@@ -533,3 +543,90 @@ def test_eval_shell():
         ]
     ).reshape(3, 1)
     assert np.allclose(eval_shell(coords=np.array([[2, 3, 4]]), shell=test), answer)
+
+
+def test_eval_deriv_prim_multiple_orders():
+    """Test gbasis.deriv.eval_deriv_prim."""
+    # duplicate orders
+    orders = np.array([[0, 0, 0], [0, 0, 0]])
+    for x, y, z in it.product(range(3), range(3), range(3)):
+        assert np.allclose(
+            _eval_deriv_contractions(
+                np.array([[2, 3, 4]]),
+                orders,
+                np.array([0.5, 1, 1.5]),
+                np.array([[x, y, z]]),
+                np.array([1]),
+                np.array([1]),
+                np.array([[1]]),
+            ),
+            _eval_deriv_contractions(
+                np.array([[2, 3, 4]]),
+                np.array([[0, 0, 0]]),
+                np.array([0.5, 1, 1.5]),
+                np.array([[x, y, z]]),
+                np.array([1]),
+                np.array([1]),
+                np.array([[1]]),
+            ),
+        )
+    # multiple orders
+    orders = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    for x, y, z in it.product(range(3), range(3), range(3)):
+        test = _eval_deriv_contractions(
+            np.array([[2, 3, 4]]),
+            orders,
+            np.array([0.5, 1, 1.5]),
+            np.array([[x, y, z]]),
+            np.array([1]),
+            np.array([1]),
+            np.array([[1]]),
+        )
+        assert np.allclose(
+            test[0],
+            _eval_deriv_contractions(
+                np.array([[2, 3, 4]]),
+                np.array([[0, 0, 0]]),
+                np.array([0.5, 1, 1.5]),
+                np.array([[x, y, z]]),
+                np.array([1]),
+                np.array([1]),
+                np.array([[1]]),
+            )[0],
+        )
+        assert np.allclose(
+            test[1],
+            _eval_deriv_contractions(
+                np.array([[2, 3, 4]]),
+                np.array([[1, 0, 0]]),
+                np.array([0.5, 1, 1.5]),
+                np.array([[x, y, z]]),
+                np.array([1]),
+                np.array([1]),
+                np.array([[1]]),
+            )[0],
+        )
+        assert np.allclose(
+            test[2],
+            _eval_deriv_contractions(
+                np.array([[2, 3, 4]]),
+                np.array([[0, 1, 0]]),
+                np.array([0.5, 1, 1.5]),
+                np.array([[x, y, z]]),
+                np.array([1]),
+                np.array([1]),
+                np.array([[1]]),
+            )[0],
+        )
+        assert np.allclose(
+            test[3],
+            _eval_deriv_contractions(
+                np.array([[2, 3, 4]]),
+                np.array([[0, 0, 1]]),
+                np.array([0.5, 1, 1.5]),
+                np.array([[x, y, z]]),
+                np.array([1]),
+                np.array([1]),
+                np.array([[1]]),
+            )[0],
+        )


### PR DESCRIPTION
I tried to vectorize the orders of derivatization in `_eval_deriv_contractions`. The end result ended up being slower than the nonvectorized version. I'm still making a pull request for this for record keeping.

What
-------
1. Handle multiple orders of derivatives at the same time.
2. Add tests and everything

Results
----------
Negligible difference in performance (<1%) for adding an extra dimension for the
case of a single order of differentiation.

**Decrease(!)** in performance (both time and memory) in the case of multiple orders of
differentiation. I'm honestly not sure why vectorization results in worse
performance. Since the axis of the orders is linked with the axis for the
coordinate (x, y, z), this vector for the orders coupled with many of the other
vectors that uses the coordinate axis (e.g. coords, angmom_comps). This may have
caused some difficulties in broadcasting, resulting in bad performance.

I've also checked that the fancy boolean indexing (for separating out the zeroth order derivative) is not the cause. Performance actually decreased when the fancy indexing is replaced with a more straight forward broadcasting

Following code was used to test:
1. Single order calculation
```python
import timeit
setup = '''
import numpy as np
from gbasis.deriv import _eval_deriv_contractions

coords = np.random.rand(10000, 3)
orders = np.array([0, 0, 0])
center = np.random.rand(3)
angmom_comps = np.array([(i, j, k) for i in range(5) for j in range(5) for k in range(5)])
alphas = np.random.rand(200)
coeffs = np.random.rand(200)
norm = np.random.rand(125, 200)
    '''
print(timeit.timeit(
    '''
_eval_deriv_contractions(coords, orders, center, angmom_comps, alphas, coeffs, norm, vectorized_orders=0)
    ''',
    setup=setup,
    number=20
) / 20)
print(timeit.timeit(
    '''
_eval_deriv_contractions(coords, np.array([orders]), center, angmom_comps, alphas, coeffs, norm, vectorized_orders=1)
    ''',
    setup=setup,
    number=20
) / 20)
```
2. Multiple order calculation
```python
import timeit
setup = '''
import numpy as np
from gbasis.deriv import _eval_deriv_contractions

coords = np.random.rand(10, 3)
orders = np.array([(i, j, k) for i in range(5) for j in range(5) for k in range(5)])
center = np.random.rand(3)
angmom_comps = np.array([(i, j, k) for i in range(5) for j in range(5) for k in range(5)])
alphas = np.random.rand(200)
coeffs = np.random.rand(200)
norm = np.random.rand(125, 200)
    '''
print(timeit.timeit(
    '''
for order in orders:
    _eval_deriv_contractions(coords, order, center, angmom_comps, alphas, coeffs, norm, vectorize_orders=0)
    ''',
    setup=setup,
    number=1
) / 1)
print(timeit.timeit(
    '''
_eval_deriv_contractions(coords, orders, center, angmom_comps, alphas, coeffs, norm, vectorize_orders=1)
    ''',
    setup=setup,
    number=1
) / 1)
```