### PR TITLE
Class structure for different types of Gaussian related arrays

### DIFF
--- a/gbasis/base.py
+++ b/gbasis/base.py
@@ -82,6 +82,16 @@ class BaseGaussianRelatedArray(abc.ABC):
         array_contraction : np.ndarray
             Array associated with the given instance(s) of ContractedCartesianGaussians.
 
+        Notes
+        -----
+        The next level of classes will be divided by number of indices associated with
+        ContractedCartesianGaussians. Then this method's parameters will likely be different from
+        it's children. This means that using this method's API blindly (by simply copying and
+        pasting) will not be suitable for all its children. Here, we allow arbitrary number of
+        `contractions` to indicate that its children may have different number of `contractions` in
+        its parameters. However, in actual implementations, the number of `contractions` will likely
+        be fixed, in which case, an arbitrary number of `contractions` should not be accepted.
+
         """
 
     @abc.abstractmethod
@@ -135,5 +145,15 @@ class BaseGaussianRelatedArray(abc.ABC):
         array : np.ndarray
             Array associated with the atomic orbitals associated with the given set of contracted
             Cartesian Gaussians.
+
+        Notes
+        -----
+        The next level of classes will be divided by number of indices associated with
+        ContractedCartesianGaussians. Then this method's parameters will likely be different from
+        it's children. This means that using this method's API blindly (by simply copying and
+        pasting) will not be suitable for all its children. Here, we allow arbitrary number of
+        `transform` to indicate that its children may have different number of `transform` in
+        its parameters. However, in actual implementations, the number of `transform` will likely
+        be fixed, in which case, an arbitrary number of `transform` should not be accepted.
 
         """

--- a/gbasis/base.py
+++ b/gbasis/base.py
@@ -1,0 +1,139 @@
+"""Base class for arrays that depends on one or more contracted Gaussians."""
+import abc
+
+from gbasis.contractions import ContractedCartesianGaussians
+
+
+class BaseGaussianRelatedArray(abc.ABC):
+    """Base class for constructing arrays associated with contracted Gaussians.
+
+    Attributes
+    ----------
+    _axes_contractions : tuple of tuple of ContractedCartesianGaussians
+        Contractions that are asosciatd with each index of the array.
+        Each tuple of ContractedCartesianGaussians corresponds to an index of the array.
+
+    Methods
+    -------
+    __init__(self, *axes_contractions)
+        Initialize.
+    construct_array_contraction(self, *contraction, **kwargs) : np.ndarray
+        Return the array associated with a `ContractedCartesianGaussians` instance.
+    construct_array_cartesian(self, **kwargs) : np.ndarray
+        Return the array associated with Cartesian Gaussians.
+    construct_array_spherical(self, **kwargs) : np.ndarray
+        Return the array associated with spherical Gaussians (atomic orbitals).
+    construct_array_spherical_lincomb(self, *transform, **kwargs) : np.ndarray
+        Return the array associated with linear combinations of spherical Gaussians (linear
+        combinations of atomic orbitals).
+
+    """
+
+    def __init__(self, *contractions):
+        """Initialize.
+
+        Parameters
+        ----------
+        contractions : list/tuple of ContractedCartesianGaussians
+            Contractions that are asosciatd with each index of the array.
+            First contractions is associated with the first index, etc.
+
+        Raises
+        ------
+        TypeError
+            If `axes_contractions` is not given as a list or tuple of ContractedCartesianGaussians.
+        ValueError
+            If `axes_contractions` is an empty list or tuple.
+
+        """
+        for each_contractions in contractions:
+            if not isinstance(each_contractions, (list, tuple)):
+                raise TypeError(
+                    "Contractions must be given as a list or tuple of ContractedCartesianGaussians "
+                    "instance"
+                )
+            if not each_contractions:
+                raise ValueError("At least one `ContractedCartesianGaussians` must be given.")
+            for contraction in each_contractions:
+                if not isinstance(contraction, ContractedCartesianGaussians):
+                    raise TypeError(
+                        "Given contractions must be instances of the ContractedCartesianGaussians "
+                        "class."
+                    )
+        self._axes_contractions = tuple(
+            tuple(each_contractions) for each_contractions in contractions
+        )
+
+    @abc.abstractmethod
+    def construct_array_contraction(self, *contractions, **kwargs):
+        """Return the array associated with a contracted Cartesian Gaussian.
+
+        Parameters
+        ----------
+        contractions : ContractedCartesianGaussians
+            Contracted Cartesian Gaussians (of the same shell) that will be used to construct an
+            array.
+            Note that multiple instances may be needed to construct the array.
+        kwargs : dict
+            Other keyword arguments that will be used to construct the array.
+
+        Returns
+        -------
+        array_contraction : np.ndarray
+            Array associated with the given instance(s) of ContractedCartesianGaussians.
+
+        """
+
+    @abc.abstractmethod
+    def construct_array_cartesian(self, **kwargs):
+        """Return the array associated with the given set of contracted Cartesian Gaussians.
+
+        Parameters
+        ----------
+        kwargs : dict
+            Other keyword arguments that will be used to construct the array.
+
+        Returns
+        -------
+        array : np.ndarray
+            Array associated with the given set of contracted Cartesian Gaussians.
+
+        """
+
+    @abc.abstractmethod
+    def construct_array_spherical(self, **kwargs):
+        """Return the array associated with spherical Gaussians (atomic orbitals).
+
+        Parameters
+        ----------
+        kwargs : dict
+            Other keyword arguments that will be used to construct the array.
+
+        Returns
+        -------
+        array : np.ndarray
+            Array associated with the atomic orbitals associated with the given set of contracted
+            Cartesian Gaussians.
+
+        """
+
+    @abc.abstractmethod
+    def construct_array_spherical_lincomb(self, *transform, **kwargs):
+        """Return the array associated with linear combinations of spherical Gaussians (LCAO's).
+
+        Parameters
+        ----------
+        transform : np.ndarray
+            Transformation matrix that will be used for linearly combining the spherical
+            contractions.
+            Note that multiple instances may be needed to construct the array.
+        kwargs : dict
+            Other keyword arguments that will be used to construct the array.
+
+        Returns
+        -------
+        array : np.ndarray
+            Array associated with the atomic orbitals associated with the given set of contracted
+            Cartesian Gaussians.
+
+        """

--- a/gbasis/base_one.py
+++ b/gbasis/base_one.py
@@ -1,0 +1,175 @@
+"""Base class for arrays that depend on one contracted Gaussians."""
+import abc
+
+from gbasis.base import BaseGaussianRelatedArray
+from gbasis.spherical import generate_transformation
+import numpy as np
+
+
+# pylint: disable=W0235
+class BaseOneIndex(BaseGaussianRelatedArray):
+    """Base class for constructing arrays associated with one contracted Gaussian.
+
+    The first dimension (axis 0) of the returned array is associated with a contracted Gaussian (or
+    a linear combination of a set of Gaussians).
+
+    Attributes
+    ----------
+    _axes_contractions : tuple of tuple of ContractedCartesianGaussians
+        Contractions that are asosciatd with each index of the array.
+        Each tuple of ContractedCartesianGaussians corresponds to an index of the array.
+
+    Properties
+    ----------
+    contractions : tuple of ContractedCartesianGaussians
+        Contractions that are associated with the first index of the array.
+
+    Methods
+    -------
+    __init__(self, contractions)
+        Initialize.
+    construct_array_contraction(self, contraction) : np.ndarray
+        Return the array associated with a `ContractedCartesianGaussians` instance.
+    construct_array_cartesian(self) : np.ndarray
+        Return the array associated with Cartesian Gaussians.
+    construct_array_spherical(self) : np.ndarray
+        Return the array associated with spherical Gaussians (atomic orbitals).
+    construct_array_spherical_lincomb(self, transform) : np.ndarray
+        Return the array associated with linear combinations of spherical Gaussians (linear
+        combinations of atomic orbitals).
+
+    """
+
+    def __init__(self, contractions):
+        """Initialize.
+
+        Parameters
+        ----------
+        contractions : list/tuple of ContractedCartesianGaussians
+            Contractions that are associated with the first index of the array.
+
+        """
+        super().__init__(contractions)
+
+    @property
+    def contractions(self):
+        """Contractions that are associated with the first index of the array.
+
+        Returns
+        -------
+        contractions : tuple of ContractedCartesianGaussians
+            Contractions that are associated with the first index of the array.
+
+        """
+        return self._axes_contractions[0]
+
+    @abc.abstractmethod
+    def construct_array_contraction(self, contractions, **kwargs):
+        """Return the array associated with a set of contracted Cartesian Gaussians.
+
+        Parameters
+        ----------
+        contractions : ContractedCartesianGaussians
+            Contracted Cartesian Gaussians (of the same shell) that will be used to construct an
+            array.
+        kwargs : dict
+            Other keyword arguments that will be used to construct the array.
+
+        Returns
+        -------
+        array_contraction : np.ndarray
+            Array associated with the given instance(s) of ContractedCartesianGaussians.
+
+        Notes
+        -----
+        The next level of classes will be the construction of specific arrays given a set of
+        contracted Cartesian Gaussians. The keyword arguments will be different depending on its
+        functionality. You should use explicit keyword arguments when defining this function, rather
+        than the arbitrary number of keywords (as is done here).
+
+        """
+
+    def construct_array_cartesian(self, **kwargs):
+        """Return the array associated with the given set of contracted Cartesian Gaussians.
+
+        Parameters
+        ----------
+        kwargs : dict
+            Other keyword arguments that will be used to construct the array.
+            These keyword arguments are passed entirely to `construct_array_contrations`. See
+            `construct_array_contractions` for details on the keyword arguments.
+
+        Returns
+        -------
+        array : np.ndarray
+            Array associated with the given set of contracted Cartesian Gaussians.
+            First index of the array is associated with the contracted Cartesian Gaussian.
+
+        """
+        matrices = [
+            self.construct_array_contraction(contraction, **kwargs)
+            for contraction in self.contractions
+        ]
+        return np.concatenate(matrices, axis=0)
+
+    def construct_array_spherical(self, **kwargs):
+        """Return the array associated with contracted spherical Gaussians (atomic orbitals).
+
+        Parameters
+        ----------
+        kwargs : dict
+            Other keyword arguments that will be used to construct the array.
+            These keyword arguments are passed entirely to `construct_array_contrations`. See
+            `construct_array_contractions` for details on the keyword arguments.
+
+        Returns
+        -------
+        array : np.ndarray
+            Array associated with the atomic orbitals associated with the given set of contracted
+            Cartesian Gaussians.
+            First index of the array is associated with the contracted spherical Gaussian (atomic
+            orbital).
+
+        """
+        matrices_spherical = []
+        for cont in self.contractions:
+            # get transformation from cartesian to spherical (applied to left)
+            transform = generate_transformation(cont.angmom, cont.angmom_components, "left")
+            # evaluate the function at the given points
+            matrix_contraction = self.construct_array_contraction(cont, **kwargs)
+            # transform
+            matrix_contraction = np.tensordot(transform, matrix_contraction, (1, 0))
+            # store
+            matrices_spherical.append(matrix_contraction)
+
+        return np.concatenate(matrices_spherical, axis=0)
+
+    def construct_array_spherical_lincomb(self, transform, **kwargs):
+        r"""Return the array associated with linear combinations of spherical Gaussians (LCAO's).
+
+        .. math::
+
+            \sum_{j} T_{i j} M_{jklm...} = M^{trans}_{iklm...}
+
+
+        Parameters
+        ----------
+        transform : np.ndarray
+            Array associated with the linear combinations of spherical Gaussians (LCAO's).
+            Transformation is applied to the left, i.e. the sum is over the second index of
+            `transform` and first index of the array for contracted spherical Gaussians.
+        kwargs : dict
+            Other keyword arguments that will be used to construct the array.
+            These keyword arguments are passed directly to `construct_array_spherical`, which will
+            then pass it down to `construct_array_contrations`. See `construct_array_contractions`
+            for details on the keyword arguments.
+
+        Returns
+        -------
+        array : np.ndarray
+            Array whose first index is associated with the linear combinations of the contracted
+            spherical Gaussians.
+
+        """
+        array_spherical = self.construct_array_spherical(**kwargs)
+        return np.tensordot(transform, array_spherical, (1, 0))

--- a/gbasis/base_two_asymm.py
+++ b/gbasis/base_two_asymm.py
@@ -1,0 +1,220 @@
+"""Base class for arrays that depend on two contracted Gaussians."""
+import abc
+
+from gbasis.base import BaseGaussianRelatedArray
+from gbasis.spherical import generate_transformation
+import numpy as np
+
+
+# pylint: disable=W0235
+class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
+    """Base class for constructing arrays with two indices associated with two sets of contractions.
+
+    The first index of the returned array is associated with the first set of contracted Gaussians
+    (or some linear combination of them). The second index of the returned array is associated with
+    the second set of contracted Gaussians (or some linear combination of them).
+
+    Attributes
+    ----------
+    _axes_contractions : tuple of tuple of ContractedCartesianGaussians
+        Sets of contractions associated with each axis of the array.
+
+    Properties
+    ----------
+    contractions_one : tuple of ContractedCartesianGaussians
+        Contractions that are associated with the first index of the array.
+    contractions_two : tuple of ContractedCartesianGaussians
+        Contractions that are associated with the second index of the array.
+
+    Methods
+    -------
+    __init__(self, contractions_one, contractions_two)
+        Initialize.
+    construct_array_contraction(self, contraction_one, contraction_two, **kwargs) : np.ndarray
+        Return the array associated with a `ContractedCartesianGaussians` instance.
+    construct_array_cartesian(self, **kwargs) : np.ndarray
+        Return the array associated with Cartesian Gaussians.
+    construct_array_spherical(self, **kwargs) : np.ndarray
+        Return the array associated with spherical Gaussians (atomic orbitals).
+    construct_array_spherical_lincomb(self, transform_one, transform_two, **kwargs) : np.ndarray
+        Return the array associated with linear combinations of spherical Gaussians (linear
+        combinations of atomic orbitals).
+
+    """
+
+    def __init__(self, contractions_one, contractions_two):
+        """Initialize.
+
+        Parameters
+        ----------
+        contractions_one : list/tuple of ContractedCartesianGaussians
+            Contractions that are associated with the first index of the array.
+        contractions_two : list/tuple of ContractedCartesianGaussians
+            Contractions that are associated with the second index of the array.
+
+        """
+        super().__init__(contractions_one, contractions_two)
+
+    @property
+    def contractions_one(self):
+        """Contractions that are associated with the first index of the array.
+
+        Returns
+        -------
+        contractions_one : tuple of ContractedCartesianGaussians
+            Contractions that are associated with the first index of the array.
+
+        """
+        return self._axes_contractions[0]
+
+    @property
+    def contractions_two(self):
+        """Contractions that are associated with the second index of the array.
+
+        Returns
+        -------
+        contractions_two : tuple of ContractedCartesianGaussians
+            Contractions that are associated with the second index of the array.
+
+        """
+        return self._axes_contractions[1]
+
+    @abc.abstractmethod
+    def construct_array_contraction(self, contractions_one, contractions_two, **kwargs):
+        """Return the array associated with two sets of contracted Cartesian Gaussians.
+
+        Parameters
+        ----------
+        contractions_one : ContractedCartesianGaussians
+            Contracted Cartesian Gaussians (of the same shell) associated with the first index of
+            the array.
+        contractions_two : ContractedCartesianGaussians
+            Contracted Cartesian Gaussians (of the same shell) associated with the second index of
+            the array.
+        kwargs : dict
+            Other keyword arguments that will be used to construct the array.
+
+        Returns
+        -------
+        array_contraction : np.ndarray
+            Array associated with the given instance(s) of ContractedCartesianGaussians.
+
+        Notes
+        -----
+        The next level of classes will be the construction of specific arrays given a set of
+        contracted Cartesian Gaussians. The keyword arguments will be different depending on its
+        functionality. You should use explicit keyword arguments when defining this function, rather
+        than the arbitrary number of keywords (as is done here).
+
+        """
+
+    def construct_array_cartesian(self, **kwargs):
+        """Return the array associated with the given set(s) of contracted Cartesian Gaussians.
+
+        Parameters
+        ----------
+        kwargs : dict
+            Other keyword arguments that will be used to construct the array.
+            These keyword arguments are passed entirely to `construct_array_contrations`. See
+            `construct_array_contractions` for details on the keyword arguments.
+
+        Returns
+        -------
+        array : np.ndarray
+            Array associated with the given set of contracted Cartesian Gaussians.
+            First and second indices of the array is associated with the contracted Cartesian
+            Gaussians.
+
+        """
+        matrices = [
+            np.concatenate(
+                [
+                    self.construct_array_contraction(cont_one, cont_two, **kwargs)
+                    for cont_two in self.contractions_two
+                ],
+                axis=1,
+            )
+            for cont_one in self.contractions_one
+        ]
+        return np.concatenate(matrices, axis=0)
+
+    def construct_array_spherical(self, **kwargs):
+        """Return the array associated with two contracted spherical Gaussians (atomic orbitals).
+
+        Parameters
+        ----------
+        kwargs : dict
+            Other keyword arguments that will be used to construct the array.
+            These keyword arguments are passed entirely to `construct_array_contrations`. See
+            `construct_array_contractions` for details on the keyword arguments.
+
+        Returns
+        -------
+        array : np.ndarray
+            Array associated with the atomic orbitals associated with the given set(s) of contracted
+            Cartesian Gaussians.
+            First and second indices of the array is associated with two contracted spherical
+            Gaussians (atomic orbitals).
+
+        """
+        matrices_spherical = []
+        for cont_one in self.contractions_one:
+            # get transformation from cartesian to spherical for the first index (applied to left)
+            transform_one = generate_transformation(
+                cont_one.angmom, cont_one.angmom_components, "left"
+            )
+            matrices_spherical_cols = []
+            for cont_two in self.contractions_two:
+                # get transformation from cartesian to spherical for the first index (applied to
+                # left)
+                transform_two = generate_transformation(
+                    cont_two.angmom, cont_two.angmom_components, "left"
+                )
+                # evaluate
+                matrix_contraction = self.construct_array_contraction(cont_one, cont_two, **kwargs)
+                # transform
+                matrix_contraction = np.tensordot(transform_one, matrix_contraction, (1, 0))
+                matrix_contraction = np.tensordot(transform_two, matrix_contraction, (1, 1))
+                matrix_contraction = np.swapaxes(matrix_contraction, 0, 1)
+                # store
+                matrices_spherical_cols.append(matrix_contraction)
+            matrices_spherical.append(np.concatenate(matrices_spherical_cols, axis=1))
+        return np.concatenate(matrices_spherical, axis=0)
+
+    def construct_array_spherical_lincomb(self, transform_one, transform_two, **kwargs):
+        r"""Return the array associated with linear combinations of spherical Gaussians (LCAO's).
+
+        .. math::
+
+            \sum_{j} T^{one}_{i_1 j} \sum_{k} T^{two}_{i_2 k} M_{jklm...}
+            = M^{trans}_{i_1 i_2 lm...}
+
+        Parameters
+        ----------
+        transform_one : np.ndarray
+            Array associated with the linear combinations of spherical Gaussians (LCAO's) associated
+            with the first index.
+        transform_two : np.ndarray
+            Array associated with the linear combinations of spherical Gaussians (LCAO's) associated
+            with the second index.
+        kwargs : dict
+            Other keyword arguments that will be used to construct the array.
+            These keyword arguments are passed directly to `construct_array_spherical`, which will
+            then pass it down to `construct_array_contrations`. See `construct_array_contractions`
+            for details on the keyword arguments.
+
+        Returns
+        -------
+        array : np.ndarray
+            Array associated with the given two sets of contracted Cartesian Gaussians.
+            First index of the array corresponds to the linear combination of contracted spherical
+            Gaussians associated with the first set of contractions, `contractions_one`.
+            Second index of the array corresponds to the linear combination of contracted spherical
+            Gaussians associated with the second set of contractions, `contractions_two`.
+
+        """
+        array_transformed = self.construct_array_spherical(**kwargs)
+        array_transformed = np.tensordot(transform_one, array_transformed, (1, 0))
+        array_transformed = np.tensordot(transform_two, array_transformed, (1, 1))
+        array_transformed = np.swapaxes(array_transformed, 0, 1)
+        return array_transformed

--- a/gbasis/base_two_symm.py
+++ b/gbasis/base_two_symm.py
@@ -1,0 +1,230 @@
+"""Base class for arrays that depend on two contracted Gaussians."""
+import abc
+
+from gbasis.base import BaseGaussianRelatedArray
+from gbasis.spherical import generate_transformation
+import numpy as np
+
+
+# pylint: disable=W0235
+class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
+    """Base class for constructing arrays associated with two contracted Gaussian.
+
+    The first two axes of the returned array is associated with the given set of contracted Gaussian
+    (or a linear combination of a set of Gaussians).
+
+    Attributes
+    ----------
+    _axes_contractions : tuple of tuple of ContractedCartesianGaussians
+        Sets of contractions associated with each axis of the array.
+
+    Properties
+    ----------
+    contractions : tuple of ContractedCartesianGaussians
+        Contractions that are associated with the first and second indices of the array.
+
+    Methods
+    -------
+    __init__(self, contractions)
+        Initialize.
+    construct_array_contraction(self, contraction) : np.ndarray
+        Return the array associated with a `ContractedCartesianGaussians` instance.
+    construct_array_cartesian(self) : np.ndarray
+        Return the array associated with Cartesian Gaussians.
+    construct_array_spherical(self) : np.ndarray
+        Return the array associated with spherical Gaussians (atomic orbitals).
+    construct_array_spherical_lincomb(self, transform) : np.ndarray
+        Return the array associated with linear combinations of spherical Gaussians (linear
+        combinations of atomic orbitals).
+
+    """
+
+    def __init__(self, contractions):
+        """Initialize.
+
+        Parameters
+        ----------
+        contractions : list/tuple of ContractedCartesianGaussians
+            Contractions that are associated with the first and second indices of the array.
+
+        """
+        super().__init__(contractions)
+
+    @property
+    def contractions(self):
+        """Contractions that are associated with the first index of the array.
+
+        Returns
+        -------
+        contractions : tuple of ContractedCartesianGaussians
+            Contractions that are associated with the first index of the array.
+
+        """
+        return self._axes_contractions[0]
+
+    # NOTE: check if output is symmetric when contractions_one = contractions_two?
+    @abc.abstractmethod
+    def construct_array_contraction(self, contractions_one, contractions_two, **kwargs):
+        """Return the array associated with a set of contracted Cartesian Gaussians.
+
+        Parameters
+        ----------
+        contractions_one : ContractedCartesianGaussians
+            Contracted Cartesian Gaussians (of the same shell) associated with the first index of
+            the array.
+        contractions_two : ContractedCartesianGaussians
+            Contracted Cartesian Gaussians (of the same shell) associated with the second index of
+            the array.
+        kwargs : dict
+            Other keyword arguments that will be used to construct the array.
+
+        Returns
+        -------
+        array_contraction : np.ndarray
+            Array associated with the given instance(s) of ContractedCartesianGaussians.
+            First axis corresponds to the first set of contractions.
+            Second axis corresponds to the second set of contrations.
+            This array should be symmetric with respect to the swapping of the first and second
+            axes.
+
+        Notes
+        -----
+        The next level of classes will be the construction of specific arrays given a set of
+        contracted Cartesian Gaussians. The keyword arguments will be different depending on its
+        functionality. You should use explicit keyword arguments when defining this function, rather
+        than the arbitrary number of keywords (as is done here).
+
+        """
+
+    def construct_array_cartesian(self, **kwargs):
+        """Return the array associated with the given set(s) of contracted Cartesian Gaussians.
+
+        Parameters
+        ----------
+        kwargs : dict
+            Other keyword arguments that will be used to construct the array.
+            These keyword arguments are passed entirely to `construct_array_contrations`. See
+            `construct_array_contractions` for details on the keyword arguments.
+
+        Returns
+        -------
+        array : np.ndarray
+            Array associated with the given set of contracted Cartesian Gaussians.
+            First and second indices of the array is associated with the contracted Cartesian
+            Gaussians.
+
+        Notes
+        -----
+        For the blocks along the diagonal i.e. blocks where the first two axis belong to the same
+        set of contractions, they are transposed in the processed of constructing the whole array.
+        It is assumed that the array returned from `construct_array_contraction` is symmetric with
+        respect to the swapping of the first and second axes.
+
+        """
+        triu_blocks = [
+            self.construct_array_contraction(cont_one, cont_two, **kwargs)
+            for i, cont_one in enumerate(self.contractions)
+            for cont_two in self.contractions[i:]
+        ]
+        # use numpy triu and tril indices to create blocks
+        num_blocks_side = len(self.contractions)
+        all_blocks = np.zeros((num_blocks_side, num_blocks_side), dtype=object)
+        all_blocks[np.triu_indices(num_blocks_side)] = triu_blocks
+        all_blocks[np.tril_indices(num_blocks_side)] = [
+            np.swapaxes(block, 0, 1) for block in triu_blocks
+        ]
+        # concatenate
+        return np.concatenate(
+            [np.concatenate(row_blocks, axis=1) for row_blocks in all_blocks], axis=0
+        )
+
+    def construct_array_spherical(self, **kwargs):
+        """Return the array associated with two contracted spherical Gaussians (atomic orbitals).
+
+        Parameters
+        ----------
+        kwargs : dict
+            Other keyword arguments that will be used to construct the array.
+            These keyword arguments are passed entirely to `construct_array_contrations`. See
+            `construct_array_contractions` for details on the keyword arguments.
+
+        Returns
+        -------
+        array : np.ndarray
+            Array associated with the atomic orbitals associated with the given set(s) of contracted
+            Cartesian Gaussians.
+            First and second indices of the array is associated with two contracted spherical
+            Gaussians (atomic orbitals).
+
+        Notes
+        -----
+        For the blocks along the diagonal i.e. blocks where the first two axis belong to the same
+        set of contractions, they are transposed in the processed of constructing the whole array.
+        It is assumed that the array returned from `construct_array_contraction` is symmetric with
+        respect to the swapping of the first and second axes.
+
+        """
+        triu_blocks = []
+        for i, cont_one in enumerate(self.contractions):
+            # get transformation from cartesian to spherical (applied to left)
+            transform_one = generate_transformation(
+                cont_one.angmom, cont_one.angmom_components, "left"
+            )
+            for cont_two in self.contractions[i:]:
+                transform_two = generate_transformation(
+                    cont_two.angmom, cont_two.angmom_components, "left"
+                )
+                # evaluate
+                block_sph = self.construct_array_contraction(cont_one, cont_two, **kwargs)
+                # transform
+                block_sph = np.tensordot(transform_one, block_sph, (1, 0))
+                block_sph = np.tensordot(transform_two, block_sph, (1, 1))
+                block_sph = np.swapaxes(block_sph, 0, 1)
+                # store
+                triu_blocks.append(block_sph)
+        # use numpy triu and tril indices to create blocks
+        num_blocks_side = len(self.contractions)
+        all_blocks = np.zeros((num_blocks_side, num_blocks_side), dtype=object)
+        all_blocks[np.triu_indices(num_blocks_side)] = triu_blocks
+        all_blocks[np.tril_indices(num_blocks_side)] = [
+            np.swapaxes(block, 0, 1) for block in triu_blocks
+        ]
+        # concatenate
+        return np.concatenate(
+            [np.concatenate(row_blocks, axis=1) for row_blocks in all_blocks], axis=0
+        )
+
+    def construct_array_spherical_lincomb(self, transform, **kwargs):
+        r"""Return the array associated with linear combinations of spherical Gaussians (LCAO's).
+
+        .. math::
+
+            \sum_{j} T_{i_1 j} \sum_{k} T_{i_2 k} M_{jklm...} = M^{trans}_{i_1 i_2 lm...}
+
+        Parameters
+        ----------
+        transform : np.ndarray
+            Array associated with the linear combinations of spherical Gaussians (LCAO's) associated
+            with the first and second index.
+        kwargs : dict
+            Other keyword arguments that will be used to construct the array.
+            These keyword arguments are passed directly to `construct_array_spherical`, which will
+            then pass it down to `construct_array_contrations`. See `construct_array_contractions`
+            for details on the keyword arguments.
+
+        Returns
+        -------
+        array : np.ndarray
+            Array whose first and second indices associated with the linear combinations of the
+            contracted spherical Gaussians.
+            First index of the array corresponds to the linear combination of contracted spherical
+            Gaussians associated with the first set of contractions, `contractions_one`.
+            Second index of the array corresponds to the linear combination of contracted spherical
+            Gaussians associated with the second set of contractions, `contractions_two`.
+
+        """
+        array_transformed = self.construct_array_spherical(**kwargs)
+        array_transformed = np.tensordot(transform, array_transformed, (1, 0))
+        array_transformed = np.tensordot(transform, array_transformed, (1, 1))
+        array_transformed = np.swapaxes(array_transformed, 0, 1)
+        return array_transformed

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,85 @@
+"""Test gbasis.base.BaseGuassianRelatedArray."""
+from gbasis.base import BaseGaussianRelatedArray
+from gbasis.contractions import ContractedCartesianGaussians
+import numpy as np
+import pytest
+from utils import disable_abstract, skip_init
+
+
+def test_init():
+    """Test base.BaseGaussianRelatedArray."""
+    Test = disable_abstract(BaseGaussianRelatedArray)  # noqa: N806
+    test = skip_init(Test)
+    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    assert not hasattr(test, "_axes_contractions")
+    with pytest.raises(TypeError):
+        Test.__init__(test, set([contractions]))
+    with pytest.raises(ValueError):
+        Test.__init__(test, [])
+    with pytest.raises(TypeError):
+        Test.__init__(test, [1])
+    with pytest.raises(TypeError):
+        Test.__init__(test, [contractions.__dict__])
+
+    Test.__init__(test, [contractions])
+    assert test._axes_contractions == ((contractions,),)
+    Test.__init__(test, [contractions, contractions])
+    assert test._axes_contractions == ((contractions, contractions),)
+    Test.__init__(test, [contractions, contractions], [contractions])
+    assert test._axes_contractions == ((contractions, contractions), (contractions,))
+
+
+def test_contruct_array_contraction():
+    """Test base.BaseGaussianRelatedArray.construct_array_contraction."""
+    # enable only the abstract method construct_array_contraction
+    Test = disable_abstract(  # noqa: N806
+        BaseGaussianRelatedArray,
+        dict_overwrite={
+            "construct_array_contraction": BaseGaussianRelatedArray.construct_array_contraction
+        },
+    )
+    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    with pytest.raises(TypeError):
+        Test([contractions])
+
+
+def test_contruct_array_cartesian():
+    """Test base.BaseGaussianRelatedArray.construct_array_cartesian."""
+    # enable only the abstract method construct_array_cartesian
+    Test = disable_abstract(  # noqa: N806
+        BaseGaussianRelatedArray,
+        dict_overwrite={
+            "construct_array_cartesian": BaseGaussianRelatedArray.construct_array_cartesian
+        },
+    )
+    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    with pytest.raises(TypeError):
+        Test([contractions])
+
+
+def test_contruct_array_spherical():
+    """Test base.BaseGaussianRelatedArray.construct_array_spherical."""
+    # enable only the abstract method construct_array_spherical
+    Test = disable_abstract(  # noqa: N806
+        BaseGaussianRelatedArray,
+        dict_overwrite={
+            "construct_array_spherical": BaseGaussianRelatedArray.construct_array_spherical
+        },
+    )
+    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    with pytest.raises(TypeError):
+        Test([contractions])
+
+
+def test_contruct_array_spherical_lincomb():
+    """Test base.BaseGaussianRelatedArray.construct_array_spherical_lincomb."""
+    # enable only the abstract method construct_array_spherical_lincomb
+    Test = disable_abstract(  # noqa: N806
+        BaseGaussianRelatedArray,
+        dict_overwrite={
+            "construct_array_spherical_lincomb": BaseGaussianRelatedArray.construct_array_spherical_lincomb  # noqa: E501
+        },
+    )
+    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    with pytest.raises(TypeError):
+        Test([contractions])

--- a/tests/test_base_one.py
+++ b/tests/test_base_one.py
@@ -1,0 +1,124 @@
+"""Test gbasis.base_one."""
+from gbasis.base_one import BaseOneIndex
+from gbasis.contractions import ContractedCartesianGaussians
+from gbasis.spherical import generate_transformation
+import numpy as np
+import pytest
+from utils import disable_abstract, skip_init
+
+
+def test_init():
+    """Test BaseOneIndex.__init__."""
+    Test = disable_abstract(BaseOneIndex)  # noqa: N806
+    test = skip_init(Test)
+    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    Test.__init__(test, [contractions])
+    assert test._axes_contractions == ((contractions,),)
+    with pytest.raises(TypeError):
+        Test.__init__(test, [contractions], [contractions])
+
+
+def test_contractions():
+    """Test BaseOneIndex.constractions."""
+    Test = disable_abstract(BaseOneIndex)  # noqa: N806
+    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    test = Test([contractions])
+    assert test.contractions[0] == contractions
+
+
+def test_contruct_array_contraction():
+    """Test BaseOneIndex.construct_array_contraction."""
+    # enable only the abstract method construct_array_contraction
+    Test = disable_abstract(  # noqa: N806
+        BaseOneIndex,
+        dict_overwrite={"construct_array_contraction": BaseOneIndex.construct_array_contraction},
+    )
+    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    with pytest.raises(TypeError):
+        Test([contractions])
+
+
+def test_contruct_array_cartesian():
+    """Test BaseOneIndex.construct_array_cartesian."""
+    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    Test = disable_abstract(  # noqa: N806
+        BaseOneIndex,
+        dict_overwrite={"construct_array_contraction": lambda self, cont, a=2: np.ones(5) * a},
+    )
+    test = Test([contractions])
+    assert np.allclose(test.construct_array_cartesian(), np.ones(5) * 2)
+    assert np.allclose(test.construct_array_cartesian(a=3), np.ones(5) * 3)
+    with pytest.raises(TypeError):
+        test.construct_array_cartesian(bad_keyword=3)
+
+    test = Test([contractions, contractions])
+    assert np.allclose(test.construct_array_cartesian(), np.ones(10) * 2)
+    assert np.allclose(test.construct_array_cartesian(a=3), np.ones(10) * 3)
+
+    Test = disable_abstract(  # noqa: N806
+        BaseOneIndex,
+        dict_overwrite={"construct_array_contraction": lambda self, cont, a=2: np.ones((2, 5)) * a},
+    )
+    test = Test([contractions, contractions])
+    assert np.allclose(test.construct_array_cartesian(), np.ones((4, 5)) * 2)
+    assert np.allclose(test.construct_array_cartesian(a=3), np.ones((4, 5)) * 3)
+
+
+def test_contruct_array_spherical():
+    """Test BaseOneIndex.construct_array_spherical."""
+    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    transform = generate_transformation(1, contractions.angmom_components, "left")
+
+    Test = disable_abstract(  # noqa: N806
+        BaseOneIndex,
+        dict_overwrite={
+            "construct_array_contraction": lambda self, cont, a=2: np.arange(9).reshape(3, 3) * a
+        },
+    )
+    test = Test([contractions])
+    assert np.allclose(
+        test.construct_array_spherical(), transform.dot(np.arange(9).reshape(3, 3)) * 2
+    )
+    assert np.allclose(
+        test.construct_array_spherical(a=3), transform.dot(np.arange(9).reshape(3, 3)) * 3
+    )
+    with pytest.raises(TypeError):
+        test.construct_array_spherical(bad_keyword=3)
+
+    test = Test([contractions, contractions])
+    assert np.allclose(
+        test.construct_array_spherical(),
+        np.vstack([transform.dot(np.arange(9).reshape(3, 3)) * 2] * 2),
+    )
+
+
+def test_contruct_array_spherical_lincomb():
+    """Test BaseOneIndex.construct_array_spherical_lincomb."""
+    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    sph_transform = generate_transformation(1, contractions.angmom_components, "left")
+    orb_transform = np.random.rand(3, 3)
+
+    Test = disable_abstract(  # noqa: N806
+        BaseOneIndex,
+        dict_overwrite={
+            "construct_array_contraction": lambda self, cont, a=2: np.arange(9).reshape(3, 3) * a
+        },
+    )
+    test = Test([contractions])
+    assert np.allclose(
+        test.construct_array_spherical_lincomb(orb_transform),
+        orb_transform.dot(sph_transform).dot(np.arange(9).reshape(3, 3)) * 2,
+    )
+    assert np.allclose(
+        test.construct_array_spherical_lincomb(orb_transform, a=3),
+        orb_transform.dot(sph_transform).dot(np.arange(9).reshape(3, 3)) * 3,
+    )
+    with pytest.raises(TypeError):
+        test.construct_array_spherical_lincomb(bad_keyword=3)
+
+    orb_transform = np.random.rand(3, 6)
+    test = Test([contractions, contractions])
+    assert np.allclose(
+        test.construct_array_spherical_lincomb(orb_transform),
+        orb_transform.dot(np.vstack([sph_transform.dot(np.arange(9).reshape(3, 3)) * 2] * 2)),
+    )

--- a/tests/test_base_two_asymm.py
+++ b/tests/test_base_two_asymm.py
@@ -1,0 +1,165 @@
+"""Test gbasis.base_two_asymm."""
+from gbasis.base_two_asymm import BaseTwoIndexAsymmetric
+from gbasis.contractions import ContractedCartesianGaussians
+from gbasis.spherical import generate_transformation
+import numpy as np
+import pytest
+from utils import disable_abstract, skip_init
+
+
+def test_init():
+    """Test BaseTwoIndexAsymmetric.__init__."""
+    Test = disable_abstract(BaseTwoIndexAsymmetric)  # noqa: N806
+    test = skip_init(Test)
+    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    Test.__init__(test, [contractions], [contractions])
+    assert test._axes_contractions == ((contractions,), (contractions,))
+    with pytest.raises(TypeError):
+        Test.__init__(test, [contractions])
+    with pytest.raises(TypeError):
+        Test.__init__(test, [contractions], [contractions], [contractions])
+
+
+def test_contractions_one():
+    """Test BaseTwoIndexAsymmetric.constractions_one."""
+    Test = disable_abstract(BaseTwoIndexAsymmetric)  # noqa: N806
+    cont_one = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_two = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    test = Test([cont_one], [cont_two])
+    assert test.contractions_one[0] == cont_one
+
+
+def test_contractions_two():
+    """Test BaseTwoIndexAsymmetric.constractions_two."""
+    Test = disable_abstract(BaseTwoIndexAsymmetric)  # noqa: N806
+    cont_one = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_two = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    test = Test([cont_one], [cont_two])
+    assert test.contractions_two[0] == cont_two
+
+
+def test_contruct_array_contraction():
+    """Test BaseTwoIndexAsymmetric.construct_array_contraction."""
+    # enable only the abstract method construct_array_contraction
+    Test = disable_abstract(  # noqa: N806
+        BaseTwoIndexAsymmetric,
+        dict_overwrite={
+            "construct_array_contraction": BaseTwoIndexAsymmetric.construct_array_contraction
+        },
+    )
+    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    with pytest.raises(TypeError):
+        Test([contractions])
+
+
+def test_contruct_array_cartesian():
+    """Test BaseTwoIndexAsymmetric.construct_array_cartesian."""
+    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    Test = disable_abstract(  # noqa: N806
+        BaseTwoIndexAsymmetric,
+        dict_overwrite={
+            "construct_array_contraction": lambda self, cont1, cont2, a=2: np.ones((2, 2)) * a
+        },
+    )
+    test = Test([contractions], [contractions])
+    assert np.allclose(test.construct_array_cartesian(), np.ones((2, 2)) * 2)
+    assert np.allclose(test.construct_array_cartesian(a=3), np.ones((2, 2)) * 3)
+    with pytest.raises(TypeError):
+        test.construct_array_cartesian(bad_keyword=3)
+
+    test = Test([contractions, contractions], [contractions])
+    assert np.allclose(test.construct_array_cartesian(), np.ones((4, 2)) * 2)
+    assert np.allclose(test.construct_array_cartesian(a=3), np.ones((4, 2)) * 3)
+
+    Test = disable_abstract(  # noqa: N806
+        BaseTwoIndexAsymmetric,
+        dict_overwrite={
+            "construct_array_contraction": lambda self, cont_one, cont_two, a=2: np.ones((2, 5)) * a
+        },
+    )
+    test = Test([contractions, contractions], [contractions])
+    assert np.allclose(test.construct_array_cartesian(), np.ones((4, 5)) * 2)
+    assert np.allclose(test.construct_array_cartesian(a=3), np.ones((4, 5)) * 3)
+
+
+def test_contruct_array_spherical():
+    """Test BaseTwoIndexAsymmetric.construct_array_spherical."""
+    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    transform = generate_transformation(1, contractions.angmom_components, "left")
+
+    Test = disable_abstract(  # noqa: N806
+        BaseTwoIndexAsymmetric,
+        dict_overwrite={
+            "construct_array_contraction": (
+                lambda self, cont_one, cont_two, a=2: np.arange(9).reshape(3, 3) * a
+            )
+        },
+    )
+    test = Test([contractions], [contractions])
+    assert np.allclose(
+        test.construct_array_spherical(),
+        transform.dot(np.arange(9).reshape(3, 3)).dot(transform.T) * 2,
+    )
+    assert np.allclose(
+        test.construct_array_spherical(a=3),
+        transform.dot(np.arange(9).reshape(3, 3)).dot(transform.T) * 3,
+    )
+    with pytest.raises(TypeError):
+        test.construct_array_spherical(bad_keyword=3)
+
+    test = Test([contractions, contractions], [contractions])
+    assert np.allclose(
+        test.construct_array_spherical(),
+        np.vstack([transform.dot(np.arange(9).reshape(3, 3).dot(transform.T)) * 2] * 2),
+    )
+
+
+def test_contruct_array_spherical_lincomb():
+    """Test BaseTwoIndexAsymmetric.construct_array_spherical_lincomb."""
+    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    sph_transform = generate_transformation(1, contractions.angmom_components, "left")
+    orb_transform_one = np.random.rand(3, 3)
+    orb_transform_two = np.random.rand(3, 3)
+
+    Test = disable_abstract(  # noqa: N806
+        BaseTwoIndexAsymmetric,
+        dict_overwrite={
+            "construct_array_contraction": (
+                lambda self, cont_one, cont_two, a=2: np.arange(9).reshape(3, 3) * a
+            )
+        },
+    )
+    test = Test([contractions], [contractions])
+    assert np.allclose(
+        test.construct_array_spherical_lincomb(orb_transform_one, orb_transform_two),
+        (
+            orb_transform_one.dot(sph_transform)
+            .dot(np.arange(9).reshape(3, 3))
+            .dot(sph_transform.T)
+            .dot(orb_transform_two.T)
+            * 2
+        ),
+    )
+    assert np.allclose(
+        test.construct_array_spherical_lincomb(orb_transform_one, orb_transform_two, a=3),
+        (
+            orb_transform_one.dot(sph_transform)
+            .dot(np.arange(9).reshape(3, 3))
+            .dot(sph_transform.T)
+            .dot(orb_transform_two.T)
+            * 3
+        ),
+    )
+    with pytest.raises(TypeError):
+        test.construct_array_spherical_lincomb(bad_keyword=3)
+
+    orb_transform_one = np.random.rand(3, 6)
+    test = Test([contractions, contractions], [contractions])
+    assert np.allclose(
+        test.construct_array_spherical_lincomb(orb_transform_one, orb_transform_two),
+        orb_transform_one.dot(
+            np.vstack(
+                [sph_transform.dot(np.arange(9).reshape(3, 3)).dot(sph_transform.T) * 2] * 2
+            ).dot(orb_transform_two.T)
+        ),
+    )

--- a/tests/test_base_two_symm.py
+++ b/tests/test_base_two_symm.py
@@ -1,0 +1,428 @@
+"""Test gbasis.base_two_symm."""
+from gbasis.base_two_asymm import BaseTwoIndexAsymmetric
+from gbasis.base_two_symm import BaseTwoIndexSymmetric
+from gbasis.contractions import ContractedCartesianGaussians
+from gbasis.spherical import generate_transformation
+import numpy as np
+import pytest
+from utils import disable_abstract, skip_init
+
+
+def test_init():
+    """Test BaseTwoIndexSymmetric.__init__."""
+    Test = disable_abstract(BaseTwoIndexSymmetric)  # noqa: N806
+    test = skip_init(Test)
+    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    Test.__init__(test, [contractions])
+    assert test._axes_contractions[0][0] == contractions
+    with pytest.raises(TypeError):
+        Test.__init__(test, [contractions], [contractions])
+
+
+def test_contractions():
+    """Test BaseTwoIndexSymmetric.constractions."""
+    Test = disable_abstract(BaseTwoIndexSymmetric)  # noqa: N806
+    cont = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    test = Test([cont])
+    assert test.contractions[0] == cont
+
+
+def test_contruct_array_contraction():
+    """Test BaseTwoIndexSymmetric.construct_array_contraction."""
+    # enable only the abstract method construct_array_contraction
+    Test = disable_abstract(  # noqa: N806
+        BaseTwoIndexSymmetric,
+        dict_overwrite={
+            "construct_array_contraction": BaseTwoIndexSymmetric.construct_array_contraction
+        },
+    )
+    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    with pytest.raises(TypeError):
+        Test([contractions])
+
+
+def test_contruct_array_cartesian():
+    """Test BaseTwoIndexSymmetric.construct_array_cartesian."""
+    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    Test = disable_abstract(  # noqa: N806
+        BaseTwoIndexSymmetric,
+        dict_overwrite={
+            "construct_array_contraction": lambda self, cont1, cont2, a=2: np.ones((2, 2)) * a
+        },
+    )
+    test = Test([contractions])
+    assert np.allclose(test.construct_array_cartesian(), np.ones((2, 2)) * 2)
+    assert np.allclose(test.construct_array_cartesian(a=3), np.ones((2, 2)) * 3)
+    with pytest.raises(TypeError):
+        test.construct_array_cartesian(bad_keyword=3)
+
+    test = Test([contractions, contractions])
+    assert np.allclose(test.construct_array_cartesian(), np.ones((4, 4)) * 2)
+    assert np.allclose(test.construct_array_cartesian(a=3), np.ones((4, 4)) * 3)
+
+    cont_one = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_two = ContractedCartesianGaussians(2, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    Test = disable_abstract(  # noqa: N806
+        BaseTwoIndexSymmetric,
+        dict_overwrite={
+            "construct_array_contraction": lambda self, cont_one, cont_two, a=2: (
+                np.arange(cont_one.num_contr * cont_two.num_contr).reshape(
+                    cont_one.num_contr, cont_two.num_contr
+                )
+                * a
+            )
+        },
+    )
+    test = Test([cont_one, cont_two])
+    assert np.allclose(
+        test.construct_array_cartesian(),
+        np.vstack(
+            [
+                np.hstack([np.arange(9).reshape(3, 3).T * 2, np.arange(18).reshape(3, 6) * 2]),
+                np.hstack([np.arange(18).reshape(3, 6).T * 2, np.arange(36).reshape(6, 6).T * 2]),
+            ]
+        ),
+    )
+    assert np.allclose(
+        test.construct_array_cartesian(a=3),
+        np.vstack(
+            [
+                np.hstack([np.arange(9).reshape(3, 3).T * 3, np.arange(18).reshape(3, 6) * 3]),
+                np.hstack([np.arange(18).reshape(3, 6).T * 3, np.arange(36).reshape(6, 6).T * 3]),
+            ]
+        ),
+    )
+
+    Test = disable_abstract(  # noqa: N806
+        BaseTwoIndexSymmetric,
+        dict_overwrite={
+            "construct_array_contraction": lambda self, cont_one, cont_two, a=2: (
+                np.arange(cont_one.num_contr * cont_two.num_contr * 2).reshape(
+                    cont_one.num_contr, cont_two.num_contr, 2
+                )
+                * a
+            )
+        },
+    )
+    test = Test([cont_one, cont_two])
+    assert np.allclose(
+        test.construct_array_cartesian(),
+        np.vstack(
+            [
+                np.hstack(
+                    [
+                        np.swapaxes(np.arange(18).reshape(3, 3, 2), 0, 1) * 2,
+                        np.arange(36).reshape(3, 6, 2) * 2,
+                    ]
+                ),
+                np.hstack(
+                    [
+                        np.swapaxes(np.arange(36).reshape(3, 6, 2), 0, 1) * 2,
+                        np.swapaxes(np.arange(72).reshape(6, 6, 2), 0, 1) * 2,
+                    ]
+                ),
+            ]
+        ),
+    )
+    assert np.allclose(
+        test.construct_array_cartesian(a=3),
+        np.concatenate(
+            [
+                np.concatenate(
+                    [
+                        np.swapaxes(np.arange(18).reshape(3, 3, 2), 0, 1) * 3,
+                        np.arange(36).reshape(3, 6, 2) * 3,
+                    ],
+                    axis=1,
+                ),
+                np.concatenate(
+                    [
+                        np.swapaxes(np.arange(36).reshape(3, 6, 2), 0, 1) * 3,
+                        np.swapaxes(np.arange(72).reshape(6, 6, 2), 0, 1) * 3,
+                    ],
+                    axis=1,
+                ),
+            ],
+            axis=0,
+        ),
+    )
+
+
+def test_contruct_array_spherical():
+    """Test BaseTwoIndexSymmetric.construct_array_spherical."""
+    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    transform = generate_transformation(1, contractions.angmom_components, "left")
+
+    Test = disable_abstract(  # noqa: N806
+        BaseTwoIndexSymmetric,
+        dict_overwrite={
+            "construct_array_contraction": (
+                lambda self, cont_one, cont_two, a=2: np.arange(9).reshape(3, 3) * a
+            )
+        },
+    )
+    test = Test([contractions])
+    assert np.allclose(
+        test.construct_array_spherical(),
+        (transform.dot(np.arange(9).reshape(3, 3)).dot(transform.T)).T * 2,
+    )
+    assert np.allclose(
+        test.construct_array_spherical(a=3),
+        (transform.dot(np.arange(9).reshape(3, 3)).dot(transform.T)).T * 3,
+    )
+    with pytest.raises(TypeError):
+        test.construct_array_spherical(bad_keyword=3)
+
+    Test = disable_abstract(  # noqa: N806
+        BaseTwoIndexSymmetric,
+        dict_overwrite={
+            "construct_array_contraction": lambda self, cont_one, cont_two, a=2: (
+                np.arange(cont_one.num_contr * cont_two.num_contr * 2).reshape(
+                    cont_one.num_contr, cont_two.num_contr, 2
+                )
+                * a
+            )
+        },
+    )
+    cont_one = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_two = ContractedCartesianGaussians(2, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    test = Test([cont_one, cont_two])
+    transform_one = generate_transformation(1, cont_one.angmom_components, "left")
+    transform_two = generate_transformation(2, cont_two.angmom_components, "left")
+    assert np.allclose(
+        test.construct_array_spherical(a=4),
+        np.concatenate(
+            [
+                np.concatenate(
+                    [
+                        np.tensordot(
+                            transform_one,
+                            np.tensordot(transform_one, np.arange(18).reshape(3, 3, 2), (1, 0)),
+                            (1, 1),
+                        )
+                        * 4,
+                        np.swapaxes(
+                            np.tensordot(
+                                transform_two,
+                                np.tensordot(transform_one, np.arange(36).reshape(3, 6, 2), (1, 0)),
+                                (1, 1),
+                            ),
+                            0,
+                            1,
+                        )
+                        * 4,
+                    ],
+                    axis=1,
+                ),
+                np.concatenate(
+                    [
+                        np.tensordot(
+                            transform_two,
+                            np.tensordot(transform_one, np.arange(36).reshape(3, 6, 2), (1, 0)),
+                            (1, 1),
+                        )
+                        * 4,
+                        np.tensordot(
+                            transform_two,
+                            np.tensordot(transform_two, np.arange(72).reshape(6, 6, 2), (1, 0)),
+                            (1, 1),
+                        )
+                        * 4,
+                    ],
+                    axis=1,
+                ),
+            ],
+            axis=0,
+        ),
+    )
+
+
+def test_contruct_array_spherical_lincomb():
+    """Test BaseTwoIndexSymmetric.construct_array_spherical_lincomb."""
+    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    sph_transform = generate_transformation(1, contractions.angmom_components, "left")
+    orb_transform = np.random.rand(3, 3)
+
+    Test = disable_abstract(  # noqa: N806
+        BaseTwoIndexSymmetric,
+        dict_overwrite={
+            "construct_array_contraction": (
+                lambda self, cont_one, cont_two, a=2: np.arange(9).reshape(3, 3) * a
+            )
+        },
+    )
+    test = Test([contractions])
+    assert np.allclose(
+        test.construct_array_spherical_lincomb(orb_transform),
+        (
+            orb_transform.dot(sph_transform)
+            .dot(np.arange(9).reshape(3, 3))
+            .dot(sph_transform.T)
+            .dot(orb_transform.T)
+            .T
+            * 2
+        ),
+    )
+    assert np.allclose(
+        test.construct_array_spherical_lincomb(orb_transform, a=3),
+        (
+            orb_transform.dot(sph_transform)
+            .dot(np.arange(9).reshape(3, 3))
+            .dot(sph_transform.T)
+            .dot(orb_transform.T)
+            .T
+            * 3
+        ),
+    )
+    with pytest.raises(TypeError):
+        test.construct_array_spherical_lincomb(bad_keyword=3)
+
+    orb_transform = np.random.rand(8, 8)
+    Test = disable_abstract(  # noqa: N806
+        BaseTwoIndexSymmetric,
+        dict_overwrite={
+            "construct_array_contraction": lambda self, cont_one, cont_two, a=2: (
+                np.arange(cont_one.num_contr * cont_two.num_contr * 2).reshape(
+                    cont_one.num_contr, cont_two.num_contr, 2
+                )
+                * a
+            )
+        },
+    )
+    cont_one = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_two = ContractedCartesianGaussians(2, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    test = Test([cont_one, cont_two])
+    sph_transform_one = generate_transformation(1, cont_one.angmom_components, "left")
+    sph_transform_two = generate_transformation(2, cont_two.angmom_components, "left")
+    orb_transform = np.random.rand(8, 8)
+    assert np.allclose(
+        test.construct_array_spherical_lincomb(orb_transform, a=4),
+        np.swapaxes(
+            np.tensordot(
+                orb_transform,
+                np.tensordot(
+                    orb_transform,
+                    np.concatenate(
+                        [
+                            np.concatenate(
+                                [
+                                    np.tensordot(
+                                        sph_transform_one,
+                                        np.tensordot(
+                                            sph_transform_one,
+                                            np.arange(18).reshape(3, 3, 2),
+                                            (1, 0),
+                                        ),
+                                        (1, 1),
+                                    )
+                                    * 4,
+                                    np.swapaxes(
+                                        np.tensordot(
+                                            sph_transform_two,
+                                            np.tensordot(
+                                                sph_transform_one,
+                                                np.arange(36).reshape(3, 6, 2),
+                                                (1, 0),
+                                            ),
+                                            (1, 1),
+                                        ),
+                                        0,
+                                        1,
+                                    )
+                                    * 4,
+                                ],
+                                axis=1,
+                            ),
+                            np.concatenate(
+                                [
+                                    np.tensordot(
+                                        sph_transform_two,
+                                        np.tensordot(
+                                            sph_transform_one,
+                                            np.arange(36).reshape(3, 6, 2),
+                                            (1, 0),
+                                        ),
+                                        (1, 1),
+                                    )
+                                    * 4,
+                                    np.tensordot(
+                                        sph_transform_two,
+                                        np.tensordot(
+                                            sph_transform_two,
+                                            np.arange(72).reshape(6, 6, 2),
+                                            (1, 0),
+                                        ),
+                                        (1, 1),
+                                    )
+                                    * 4,
+                                ],
+                                axis=1,
+                            ),
+                        ],
+                        axis=0,
+                    ),
+                    (1, 0),
+                ),
+                (1, 1),
+            ),
+            0,
+            1,
+        ),
+    )
+
+
+def test_compare_two_asymm():
+    """Test BaseTwoIndexSymmetric by comparing it against BaseTwoIndexAsymmetric."""
+    cont_one = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_two = ContractedCartesianGaussians(2, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    orb_transform = np.random.rand(8, 8)
+
+    def construct_array_contraction(self, cont_one, cont_two, a=2):
+        """Temporary symmetric function for testing."""
+        one_size = cont_one.num_contr
+        two_size = cont_two.num_contr
+        output = (
+            np.arange(one_size)[:, None, None]
+            + np.arange(two_size)[None, :, None]
+            + np.arange(5, 10)[None, None, :]
+        )
+        return output * a
+
+    TestSymmetric = disable_abstract(  # noqa: N806
+        BaseTwoIndexSymmetric,
+        dict_overwrite={"construct_array_contraction": construct_array_contraction},
+    )
+    TestAsymmetric = disable_abstract(  # noqa: N806
+        BaseTwoIndexAsymmetric,
+        dict_overwrite={"construct_array_contraction": construct_array_contraction},
+    )
+
+    test_symm = TestSymmetric([cont_one, cont_two])
+    test_asymm = TestAsymmetric([cont_one, cont_two], [cont_one, cont_two])
+
+    assert np.allclose(
+        test_symm.construct_array_contraction(cont_one, cont_one),
+        test_asymm.construct_array_contraction(cont_one, cont_one),
+    )
+    assert np.allclose(
+        test_symm.construct_array_contraction(cont_one, cont_two),
+        test_asymm.construct_array_contraction(cont_one, cont_two),
+    )
+    assert np.allclose(
+        test_symm.construct_array_contraction(cont_two, cont_one),
+        test_asymm.construct_array_contraction(cont_two, cont_one),
+    )
+    assert np.allclose(
+        test_symm.construct_array_contraction(cont_two, cont_two),
+        test_asymm.construct_array_contraction(cont_two, cont_two),
+    )
+    assert np.allclose(
+        test_symm.construct_array_cartesian(), test_asymm.construct_array_cartesian()
+    )
+    assert np.allclose(
+        test_symm.construct_array_spherical(), test_asymm.construct_array_spherical()
+    )
+    assert np.allclose(
+        test_symm.construct_array_spherical_lincomb(orb_transform),
+        test_asymm.construct_array_spherical_lincomb(orb_transform, orb_transform),
+    )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -31,6 +31,39 @@ def skip_init(class_obj):
     return NoInitClass()
 
 
+def disable_abstract(abclass, dict_overwrite={}):
+    """Return a class that is a copy of the given abstract class without its abstract methods.
+
+    Parameters
+    ----------
+    abclass : type
+        Class.
+
+    Returns
+    -------
+    new_class : type
+        Child of the given abstract class without its abstract methods.
+
+    Notes
+    -----
+    This code was adapted from
+    https://stackoverflow.com/questions/9757299/python-testing-an-abstract-base-class.
+
+    """
+    if "__abstractmethods__" not in abclass.__dict__:
+        return abclass
+    new_dict = abclass.__dict__.copy()
+    for abstractmethod in abclass.__abstractmethods__:
+        # replace abstract methods with a function that does nothing
+        new_dict[abstractmethod] = lambda *args: None
+    # replace namespace
+    new_dict.update(dict_overwrite)
+    # make subclass of the abstract class with
+    return type(
+        "{} class with abstract methods disabled".format(abclass.__name__), (abclass,), new_dict
+    )
+
+
 def partial_deriv_finite_diff(func, x, order, epsilon=1e-8, num_points=1):
     """Return the first order partial derivative of the given function at the given value.
 

--- a/tox.ini
+++ b/tox.ini
@@ -86,3 +86,8 @@ disable=
  	# %s comes before %s Used when PEP8 import order is not respected (standard
     # imports first, then third-party libraries, then local imports)
     C0411,
+    # arguments-differ (W0221):
+    # Parameters differ from %s %r method Used when a method has a different
+    # number of arguments than in the implemented interface or in an overridden
+    # method.
+    W0221,

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ deps =
     pytest-cov
 commands =
     flake8 gbasis/ tests/ setup.py
-    pylint gbasis --rcfile=tox.ini
+    pylint gbasis --rcfile=tox.ini --disable=similarities
     black -l 100 --check ./
     black -l 100 --diff ./
     bandit -r gbasis
@@ -91,3 +91,6 @@ disable=
     # number of arguments than in the implemented interface or in an overridden
     # method.
     W0221,
+
+[SIMILARITIES]
+min-similarity-lines=5


### PR DESCRIPTION
The general (naive) approach to computing any Gaussian related arrays, e.g. evaluation, derivatization, density, overlap, electron-nuclear attraction integral, electron-electron repulsion integral, seems to have similar procedures:
1. Compute an element of this array by computing the appropriate integral/evaluation/operation with the appropriate number of primitives. This means that each element of the array can be associated with different numbers of primitives.
2. Build up the entire array for all combinations of primitives
3. Transform the array with respect to primitives to that of contracted Cartesian Gaussian-type functions
4. Transform the array with respect to contracted Cartesian Gaussian-type functions to that of contracted spherical Gaussian-type functions
5. Transform the array with respect to contracted spherical Gaussian-type functions to that of linear combinations of contracted spherical Gaussian-type functions.
6. Apply the appropriate operations to the array.

Instead of this procedure, we modify the first three steps so that we compute an element of the array with respect to the contracted Cartesian Gaussian-type functions that have the same angular momentum at the same center with the same primitive coefficients and exponents. Then, we can vectorize this step to compute elements of multiple contractions at the same time, rather than one at a time. We will call this step 3a. Afterwards, we group all of the arrays associated with each "type" of contraction (shell?). We will call this step 3b. Afterwards, we can continue to step 4.

At the moment, **we will assume that all of the arrays produced by this module will follow this procedure**. This means that all of the arrays with the different number of associated primitives (or contractions) will have a similar structure for steps 3a, 3b, 4 and 5. This pull request contains a tentative class structure that enforces this procedure.

What
--------
1. Add base class `BaseGaussianRelatedArray` 
2. Add base class `BaseOneIndex`
3. Add base class `BaseTwoIndexAsymmetric`
4. Add base class `BaseTwoIndexSymmetric`
5. PyLint changes

Why
------
1. The base class `BaseGaussianRelatedArray` contains `__init__` which is the common initialization procedure for different types of arrays, and abstract methods `construct_array_contraction`, `construct_array_cartesian`, `construct_array_spherical`, and `construct_array_spherical_lincomb` which ensures that its children have the functions necessary for the procedure step 3a, 3b, 4, and 5, respectively.
2. The base class `BaseOneIndex` defines the appropriate transformations an array whose first index is associated with the primitive/contraction. The `construct_array_contraction` still needs to be defined for its children to be instantiated.
3. The base class `BaseTwoIndexAsymmetric` defines the appropriate transformations an array whose first and second indices are associated with two different sets of primitives/contractions. The `construct_array_contraction` still needs to be defined for its children to be instantiated.
4. 3. The base class `BaseTwoIndexAsymmetric` defines the appropriate transformations an array whose first and second indices are associated with the same set of primitives/contractions. The `construct_array_contraction` still needs to be defined for its children to be instantiated.

Issues
---------
Apart from the `BaseTwoIndexSymmetric` which will have one child for the moment integral and another for the electron-nuclear attraction integral, each base class will likely only have one child. This may suggest that all of these structures are unnecessary and confuse users even more. They can, however, be used for different structures, but I'm not sure how likely that will be.