### PR TITLE
Add generalized contractions

### DIFF
--- a/gbasis/contractions.py
+++ b/gbasis/contractions.py
@@ -33,8 +33,11 @@ class ContractedCartesianGaussians:
         Coordinate of the center of the Gaussian primitives.
     charge : float
         Charge at the center of the Gaussian primitives.
-    coeffs : np.ndarray(K,)
+    coeffs : {np.ndarray(K,), np.ndarray(K, M)}
         Contraction coefficients, :math:`\{d_i\}`, of the primitives.
+        If a two dimensional array is given, the first axis corresponds to the primitive and the
+        second axis corresponds to the different contractions that have the same exponents (and
+        angular momentum) but different coefficients.
     exps : np.ndarray(K,)
         Exponents of the primitives, :math:`\{\alpha_i\}`.
 
@@ -208,8 +211,17 @@ class ContractedCartesianGaussians:
         """
         if not (isinstance(exps, np.ndarray) and exps.dtype == float):
             raise TypeError("Exponents must be given as a numpy array of data type float.")
-        if hasattr(self, "_coeffs") and exps.shape != self.coeffs.shape:
-            raise ValueError("Exponents array must have the same size as Coefficients array")
+        if hasattr(self, "_coeffs"):
+            if self.coeffs.ndim == 2 and self.coeffs.shape[0] != exps.size:
+                raise ValueError(
+                    "Exponents array must have the same number of elements as the number of rows "
+                    "in the two-dimensional coefficient matrix (for the generalized contractions)."
+                )
+            if self.coeffs.ndim == 1 and self.coeffs.shape != exps.shape:
+                raise ValueError(
+                    "Exponents array must have the same number of elements as the one-dimensional "
+                    "coefficient matrix (for the segmented contractions)."
+                )
 
         self._exps = exps
 
@@ -219,8 +231,11 @@ class ContractedCartesianGaussians:
 
         Returns
         -------
-        coeffs : np.ndarray(K,)
+        coeffs : {np.ndarray(K,), np.ndarray(K, M)}
             Contraction coefficients, :math:`\{d_i\}`, of the primitives.
+            If two dimensional, then the first axis corresponds to the primitive and the second axis
+            corresponds to the different contractions that have the same exponents (and angular
+            momentum) but different coefficients.
 
         """
         return self._coeffs
@@ -231,8 +246,11 @@ class ContractedCartesianGaussians:
 
         Parameters
         ----------
-        coeffs : np.ndarray(K,)
+        coeffs : {np.ndarray(K,), np.ndarray(K, M)}
             Contraction coefficients, :math:`\{d_i\}`, of the primitives.
+            If a two dimensional array is given, the first axis corresponds to the primitive and the
+            second axis corresponds to the different contractions that have the same exponents (and
+            angular momentum) but different coefficients.
 
         Raises
         ------
@@ -244,8 +262,22 @@ class ContractedCartesianGaussians:
         """
         if not (isinstance(coeffs, np.ndarray) and coeffs.dtype == float):
             raise TypeError("Contraction coefficients must be a numpy array of data type float.")
-        if hasattr(self, "_exps") and coeffs.shape != self.exps.shape:
-            raise ValueError("Coefficients array must have the same size as exponents array.")
+        if hasattr(self, "_exps"):
+            if coeffs.ndim not in [1, 2]:
+                raise ValueError(
+                    "Coefficients array must be given as a one- or two-dimensional array."
+                )
+            if coeffs.ndim == 2 and coeffs.shape[0] != self.exps.shape[0]:
+                raise ValueError(
+                    "Coefficients array for generalized contractions must be given as a two-"
+                    "dimensional array with the same number of rows as the size of the exponents "
+                    "array."
+                )
+            if coeffs.ndim == 1 and coeffs.shape != self.exps.shape:
+                raise ValueError(
+                    "Coefficients array for segmented contractions must be given as a one-"
+                    "dimensional array with the same size as the exponents array."
+                )
 
         self._coeffs = coeffs
 

--- a/gbasis/deriv.py
+++ b/gbasis/deriv.py
@@ -28,20 +28,43 @@ def _eval_deriv_contractions(coords, orders, center, angmom_comps, alphas, prim_
         is given.
     alphas : np.ndarray(K,)
         Values of the (square root of the) precisions of the primitives.
-    prim_coeffs : np.ndarray(K,)
+    prim_coeffs : {np.ndarray(K,M), np.ndarray(K,)}
         Contraction coefficients of the primitives.
+        If the coefficients correspond to generalized contractions (i.e. two-dimensional array),
+        then the first index corresponds to the primitive and the second index corresponds to the
+        contraction (with the same exponents and angular momentum).
+        If the coefficients correspond to segmented contractions (i.e. one-dimensional array), then
+        the first index corresponds to the primitive.
     norm : np.ndarray(L, K)
         Normalization constants for the primitives in each contraction.
 
     Returns
     -------
-    derivative : np.ndarray(L, N)
+    derivative : {np.ndarray(M, L, N), np.ndarray(L, N)}
         Evaluation of the derivative at each given coordinate.
+        If the given coefficients is a two-dimensional array (i.e. generalized contracitons), then a
+        three dimensional array is returned, where the first index corresponds to the contraction,
+        second index corrresponds to the angular momentum vector, and the third index corresponds to
+        the coordinate for the evaluation
+        If the given coefficients is a one-dimensional array (i.e. segmented contracitons), then a
+        two dimensional array is returned, where the first index corrresponds to the angular
+        momentum vector, and the second index corresponds to the coordinate for the evaluation
 
     Notes
     -----
     The input is not checked. This means that you must provide the parameters as they are specified
     in the docstring. They must all be numpy arrays with the **correct shape**.
+
+    Pople style basis sets are not supported. If multiple angular momentum vectors (with different
+    angular momentum) and multiple contraction coefficients are provided, it is **not assumed** that
+    the angular momentum vector should be paired up with the contraction coefficients. In fact, each
+    angular momentum vector will create multiple contractions according to the given coefficients.
+
+    Multiple shapes of `prim_coeffs` are supported at the expense of concise API. For example, we
+    assumed that the `prim_coeffs` is always 2-dimensional, such that the coefficients for a
+    segmented contraction will have the shape `(K, 1)`. However, it takes a little more time to
+    evaluate a two-dimensional array over a one-dimensional array, even if their size is the same.
+    We support different shapes of `prim_coeffs` to keep this little bit of performance.
 
     """
     # pylint: disable=R0914

--- a/tests/test_base_one.py
+++ b/tests/test_base_one.py
@@ -43,7 +43,7 @@ def test_contruct_array_cartesian():
     contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     Test = disable_abstract(  # noqa: N806
         BaseOneIndex,
-        dict_overwrite={"construct_array_contraction": lambda self, cont, a=2: np.ones(5) * a},
+        dict_overwrite={"construct_array_contraction": lambda self, cont, a=2: np.ones((1, 5)) * a},
     )
     test = Test([contractions])
     assert np.allclose(test.construct_array_cartesian(), np.ones(5) * 2)
@@ -60,8 +60,18 @@ def test_contruct_array_cartesian():
         dict_overwrite={"construct_array_contraction": lambda self, cont, a=2: np.ones((2, 5)) * a},
     )
     test = Test([contractions, contractions])
-    assert np.allclose(test.construct_array_cartesian(), np.ones((4, 5)) * 2)
-    assert np.allclose(test.construct_array_cartesian(a=3), np.ones((4, 5)) * 3)
+    assert np.allclose(test.construct_array_cartesian(), np.ones(20) * 2)
+    assert np.allclose(test.construct_array_cartesian(a=3), np.ones(20) * 3)
+
+    Test = disable_abstract(  # noqa: N806
+        BaseOneIndex,
+        dict_overwrite={
+            "construct_array_contraction": lambda self, cont, a=2: np.ones((2, 5, 4)) * a
+        },
+    )
+    test = Test([contractions, contractions])
+    assert np.allclose(test.construct_array_cartesian(), np.ones((20, 4)) * 2)
+    assert np.allclose(test.construct_array_cartesian(a=3), np.ones((20, 4)) * 3)
 
 
 def test_contruct_array_spherical():
@@ -72,7 +82,7 @@ def test_contruct_array_spherical():
     Test = disable_abstract(  # noqa: N806
         BaseOneIndex,
         dict_overwrite={
-            "construct_array_contraction": lambda self, cont, a=2: np.arange(9).reshape(3, 3) * a
+            "construct_array_contraction": lambda self, cont, a=2: np.arange(9).reshape(1, 3, 3) * a
         },
     )
     test = Test([contractions])
@@ -91,6 +101,49 @@ def test_contruct_array_spherical():
         np.vstack([transform.dot(np.arange(9).reshape(3, 3)) * 2] * 2),
     )
 
+    Test = disable_abstract(  # noqa: N806
+        BaseOneIndex,
+        dict_overwrite={
+            "construct_array_contraction": (
+                lambda self, cont, a=2: np.arange(18).reshape(2, 3, 3) * a
+            )
+        },
+    )
+    test = Test([contractions])
+    assert np.allclose(
+        test.construct_array_spherical(),
+        np.vstack(
+            [
+                transform.dot(np.arange(9).reshape(3, 3)),
+                transform.dot(np.arange(9, 18).reshape(3, 3)),
+            ]
+        )
+        * 2,
+    )
+    assert np.allclose(
+        test.construct_array_spherical(a=3),
+        np.vstack(
+            [
+                transform.dot(np.arange(9).reshape(3, 3)),
+                transform.dot(np.arange(9, 18).reshape(3, 3)),
+            ]
+        )
+        * 3,
+    )
+
+    test = Test([contractions, contractions])
+    assert np.allclose(
+        test.construct_array_spherical(),
+        np.vstack(
+            [
+                transform.dot(np.arange(9).reshape(3, 3)),
+                transform.dot(np.arange(9, 18).reshape(3, 3)),
+            ]
+            * 2
+        )
+        * 2,
+    )
+
 
 def test_contruct_array_spherical_lincomb():
     """Test BaseOneIndex.construct_array_spherical_lincomb."""
@@ -101,7 +154,7 @@ def test_contruct_array_spherical_lincomb():
     Test = disable_abstract(  # noqa: N806
         BaseOneIndex,
         dict_overwrite={
-            "construct_array_contraction": lambda self, cont, a=2: np.arange(9).reshape(3, 3) * a
+            "construct_array_contraction": lambda self, cont, a=2: np.arange(9).reshape(1, 3, 3) * a
         },
     )
     test = Test([contractions])

--- a/tests/test_base_two_asymm.py
+++ b/tests/test_base_two_asymm.py
@@ -58,7 +58,7 @@ def test_contruct_array_cartesian():
     Test = disable_abstract(  # noqa: N806
         BaseTwoIndexAsymmetric,
         dict_overwrite={
-            "construct_array_contraction": lambda self, cont1, cont2, a=2: np.ones((2, 2)) * a
+            "construct_array_contraction": lambda self, cont1, cont2, a=2: np.ones((1, 2, 1, 2)) * a
         },
     )
     test = Test([contractions], [contractions])
@@ -74,12 +74,26 @@ def test_contruct_array_cartesian():
     Test = disable_abstract(  # noqa: N806
         BaseTwoIndexAsymmetric,
         dict_overwrite={
-            "construct_array_contraction": lambda self, cont_one, cont_two, a=2: np.ones((2, 5)) * a
+            "construct_array_contraction": (
+                lambda self, cont_one, cont_two, a=2: np.ones((1, 2, 1, 5)) * a
+            )
         },
     )
     test = Test([contractions, contractions], [contractions])
     assert np.allclose(test.construct_array_cartesian(), np.ones((4, 5)) * 2)
     assert np.allclose(test.construct_array_cartesian(a=3), np.ones((4, 5)) * 3)
+
+    Test = disable_abstract(  # noqa: N806
+        BaseTwoIndexAsymmetric,
+        dict_overwrite={
+            "construct_array_contraction": (
+                lambda self, cont_one, cont_two, a=2: np.ones((2, 2, 2, 5)) * a
+            )
+        },
+    )
+    test = Test([contractions, contractions], [contractions])
+    assert np.allclose(test.construct_array_cartesian(), np.ones((8, 10)) * 2)
+    assert np.allclose(test.construct_array_cartesian(a=3), np.ones((8, 10)) * 3)
 
 
 def test_contruct_array_spherical():
@@ -91,7 +105,7 @@ def test_contruct_array_spherical():
         BaseTwoIndexAsymmetric,
         dict_overwrite={
             "construct_array_contraction": (
-                lambda self, cont_one, cont_two, a=2: np.arange(9).reshape(3, 3) * a
+                lambda self, cont_one, cont_two, a=2: np.arange(9).reshape(1, 3, 1, 3) * a
             )
         },
     )
@@ -113,6 +127,57 @@ def test_contruct_array_spherical():
         np.vstack([transform.dot(np.arange(9).reshape(3, 3).dot(transform.T)) * 2] * 2),
     )
 
+    matrix = np.arange(36).reshape(2, 3, 2, 3)
+    Test = disable_abstract(  # noqa: N806
+        BaseTwoIndexAsymmetric,
+        dict_overwrite={
+            "construct_array_contraction": lambda self, cont_one, cont_two, a=2: matrix * a
+        },
+    )
+    test = Test([contractions], [contractions])
+    assert np.allclose(
+        test.construct_array_spherical(),
+        np.vstack(
+            [
+                np.hstack(
+                    [
+                        transform.dot(matrix[0, :, 0, :]).dot(transform.T),
+                        transform.dot(matrix[0, :, 1, :]).dot(transform.T),
+                    ]
+                ),
+                np.hstack(
+                    [
+                        transform.dot(matrix[1, :, 0, :]).dot(transform.T),
+                        transform.dot(matrix[1, :, 1, :]).dot(transform.T),
+                    ]
+                ),
+            ]
+        )
+        * 2,
+    )
+    test = Test([contractions, contractions], [contractions])
+    assert np.allclose(
+        test.construct_array_spherical(),
+        np.vstack(
+            [
+                np.hstack(
+                    [
+                        transform.dot(matrix[0, :, 0, :]).dot(transform.T),
+                        transform.dot(matrix[0, :, 1, :]).dot(transform.T),
+                    ]
+                ),
+                np.hstack(
+                    [
+                        transform.dot(matrix[1, :, 0, :]).dot(transform.T),
+                        transform.dot(matrix[1, :, 1, :]).dot(transform.T),
+                    ]
+                ),
+            ]
+            * 2
+        )
+        * 2,
+    )
+
 
 def test_contruct_array_spherical_lincomb():
     """Test BaseTwoIndexAsymmetric.construct_array_spherical_lincomb."""
@@ -125,7 +190,7 @@ def test_contruct_array_spherical_lincomb():
         BaseTwoIndexAsymmetric,
         dict_overwrite={
             "construct_array_contraction": (
-                lambda self, cont_one, cont_two, a=2: np.arange(9).reshape(3, 3) * a
+                lambda self, cont_one, cont_two, a=2: np.arange(9).reshape(1, 3, 1, 3) * a
             )
         },
     )

--- a/tests/test_contractions.py
+++ b/tests/test_contractions.py
@@ -109,6 +109,9 @@ def test_exps_setter():
     with pytest.raises(ValueError):
         test.coeffs = np.array([1.0, 2.0, 3.0])
         test.exps = np.array([4.0, 5.0])
+    with pytest.raises(ValueError):
+        test.coeffs = np.array([[1.0], [2.0], [3.0]])
+        test.exps = np.array([4.0, 5.0])
 
 
 def test_exps_getter():
@@ -138,6 +141,24 @@ def test_coeffs_setter():
     )
 
     test = skip_init(ContractedCartesianGaussians)
+    test.exps = np.array([4.0, 5.0, 6.0])
+    test.coeffs = np.array([[1.0], [2.0], [3.0]])
+    assert (
+        isinstance(test._coeffs, np.ndarray)
+        and test._coeffs.dtype == float
+        and np.allclose(test._coeffs, np.array([[1], [2], [3]]))
+    )
+
+    test = skip_init(ContractedCartesianGaussians)
+    test.exps = np.array([4.0, 5.0, 6.0])
+    test.coeffs = np.array([[1.0, 4.0], [2.0, 5.0], [3.0, 6.0]])
+    assert (
+        isinstance(test._coeffs, np.ndarray)
+        and test._coeffs.dtype == float
+        and np.allclose(test._coeffs, np.array([[1, 4], [2, 5], [3, 6]]))
+    )
+
+    test = skip_init(ContractedCartesianGaussians)
     with pytest.raises(TypeError):
         test.coeffs = [1, 2, 3]
     with pytest.raises(TypeError):
@@ -145,6 +166,15 @@ def test_coeffs_setter():
     with pytest.raises(ValueError):
         test.exps = np.array([4.0, 5.0])
         test.coeffs = np.array([1.0, 2.0, 3.0])
+    with pytest.raises(ValueError):
+        test.exps = np.array([4.0, 5.0, 6.0])
+        test.coeffs = np.array([[[1.0, 2.0, 3.0]]])
+    with pytest.raises(ValueError):
+        test.exps = np.array([4.0, 5.0, 6.0])
+        test.coeffs = np.array([[1.0, 2.0, 3.0]])
+    with pytest.raises(ValueError):
+        test.exps = np.array([4.0, 5.0])
+        test.coeffs = np.array([[1.0], [2.0], [3.0]])
 
 
 def test_coeffs_getter():

--- a/tests/test_deriv.py
+++ b/tests/test_deriv.py
@@ -533,3 +533,85 @@ def test_eval_shell():
         ]
     ).reshape(3, 1)
     assert np.allclose(eval_shell(coords=np.array([[2, 3, 4]]), shell=test), answer)
+
+
+def test_eval_deriv_generalized_contraction():
+    """Test gbasis.deriv._eval_deriv_contractions for generalized contractions."""
+    for k, l in it.product(range(3), range(3)):
+        orders = np.zeros(3, dtype=int)
+        orders[k] += 1
+        orders[l] += 1
+        for x, y, z in it.product(range(4), range(4), range(4)):
+            # primitive
+            assert np.allclose(
+                _eval_deriv_contractions(
+                    np.array([[2, 3, 4]]),
+                    orders,
+                    np.array([0.5, 1, 1.5]),
+                    np.array([[x, y, z]]),
+                    np.array([1]),
+                    np.array([1]),
+                    np.array([[1]]),
+                ),
+                eval_deriv_prim(
+                    np.array([2, 3, 4]), orders, np.array([0.5, 1, 1.5]), np.array([x, y, z]), 1
+                ),
+            )
+            # only contraction
+            assert np.allclose(
+                _eval_deriv_contractions(
+                    np.array([[2, 3, 4]]),
+                    orders,
+                    np.array([0.5, 1, 1.5]),
+                    np.array([[x, y, z]]),
+                    np.array([1, 2]),
+                    np.array([3, 4]),
+                    np.array([[1, 1]]),
+                ),
+                3
+                * eval_deriv_prim(
+                    np.array([2, 3, 4]), orders, np.array([0.5, 1, 1.5]), np.array([x, y, z]), 1
+                )
+                + 4
+                * eval_deriv_prim(
+                    np.array([2, 3, 4]), orders, np.array([0.5, 1, 1.5]), np.array([x, y, z]), 2
+                ),
+            )
+            # contraction + multiple angular momentums
+            assert np.allclose(
+                _eval_deriv_contractions(
+                    np.array([[2, 3, 4]]),
+                    orders,
+                    np.array([0.5, 1, 1.5]),
+                    np.array([[x, y, z], [x - 1, y + 2, z + 1]]),
+                    np.array([1, 2]),
+                    np.array([3, 4]),
+                    np.array([[1, 1]]),
+                ),
+                [
+                    3
+                    * eval_deriv_prim(
+                        np.array([2, 3, 4]), orders, np.array([0.5, 1, 1.5]), np.array([x, y, z]), 1
+                    )
+                    + 4
+                    * eval_deriv_prim(
+                        np.array([2, 3, 4]), orders, np.array([0.5, 1, 1.5]), np.array([x, y, z]), 2
+                    ),
+                    3
+                    * eval_deriv_prim(
+                        np.array([2, 3, 4]),
+                        orders,
+                        np.array([0.5, 1, 1.5]),
+                        np.array([x - 1, y + 2, z + 1]),
+                        1,
+                    )
+                    + 4
+                    * eval_deriv_prim(
+                        np.array([2, 3, 4]),
+                        orders,
+                        np.array([0.5, 1, 1.5]),
+                        np.array([x - 1, y + 2, z + 1]),
+                        2,
+                    ),
+                ],
+            )


### PR DESCRIPTION
Support for generalized contractions (contractions with the same exponents and angular momentum, but different coefficients) have been added.

At the low level (`gbasis.deriv._eval_deriv_contractions`), there was not much of a difference to the code. 

We didn't make the generalized contraction the default for all of the contractions because the segmented contractions (which should be more commonly used) will lose some (minor) performance. To do so, we needed to assume that the abstract method `construct_array_contraction` returns a specific shape for the output. Maybe it'll be better to assume that all contractions are generalized contractions. 