### PR TITLE
Fix generalized contractions

### DIFF
--- a/gbasis/base_one.py
+++ b/gbasis/base_one.py
@@ -28,15 +28,20 @@ class BaseOneIndex(BaseGaussianRelatedArray):
     -------
     __init__(self, contractions)
         Initialize.
-    construct_array_contraction(self, contraction) : np.ndarray
+    construct_array_contraction(self, contraction) : np.ndarray(M, L_cart, ...)
         Return the array associated with a `ContractedCartesianGaussians` instance.
-    construct_array_cartesian(self) : np.ndarray
+        `M` is the number of segmented contractions with the same exponents (and angular momentum).
+        `L_cart` is the number of Cartesian contractions for the given angular momentum.
+    construct_array_cartesian(self) : np.ndarray(K_cart, ...)
         Return the array associated with Cartesian Gaussians.
-    construct_array_spherical(self) : np.ndarray
+        `K_cart` is the total number of Cartesian contractions within the instance.
+    construct_array_spherical(self) : np.ndarray(K_sph, ...)
         Return the array associated with spherical Gaussians (atomic orbitals).
-    construct_array_spherical_lincomb(self, transform) : np.ndarray
+        `K_sph` is the total number of spherical contractions within the instance.
+    construct_array_spherical_lincomb(self, transform) : np.ndarray(K_orbs, ...)
         Return the array associated with linear combinations of spherical Gaussians (linear
         combinations of atomic orbitals).
+        `K_orbs` is the number of basis functions produced after the linear combinations.
 
     """
 
@@ -77,12 +82,13 @@ class BaseOneIndex(BaseGaussianRelatedArray):
 
         Returns
         -------
-        array_contraction : np.ndarray(M, L, N)
+        array_contraction : np.ndarray(M, L_cart, ...)
             Array associated with the given instance(s) of ContractedCartesianGaussians.
-            First index corresponds to contractions that have the same exponents (and angular
-            momentum), but different coefficients.
-            Second index corresponds to angular momentum vector.
-            Third index corresponds to coordinates at which the contractions are evaluated.
+            First index corresponds to segmented contractions within the given generalized
+            contraction (same exponents and angular momentum, but different coefficients). `M` is
+            the number of segmented contractions with the same exponents (and angular momentum).
+            Second index corresponds to angular momentum vector. `L_cart` is the number of Cartesian
+            contractions for the given angular momentum.
 
         Notes
         -----
@@ -113,9 +119,10 @@ class BaseOneIndex(BaseGaussianRelatedArray):
 
         Returns
         -------
-        array : np.ndarray
+        array : np.ndarray(K_cart, ...)
             Array associated with the given set of contracted Cartesian Gaussians.
-            First index of the array is associated with the contracted Cartesian Gaussian.
+            First index of the array is associated with the contracted Cartesian Gaussian. `K_cart`
+            is the total number of Cartesian contractions within the instance.
 
         """
         matrices = []
@@ -140,11 +147,11 @@ class BaseOneIndex(BaseGaussianRelatedArray):
 
         Returns
         -------
-        array : np.ndarray
+        array : np.ndarray(K_sph, ...)
             Array associated with the atomic orbitals associated with the given set of contracted
             Cartesian Gaussians.
-            First index of the array is associated with the contracted spherical Gaussian (atomic
-            orbital).
+            First index of the array is associated with the contracted spherical Gaussian. `K_sph`
+            is the total number of Cartesian contractions within the instance.
 
         """
         matrices_spherical = []
@@ -176,7 +183,7 @@ class BaseOneIndex(BaseGaussianRelatedArray):
 
         Parameters
         ----------
-        transform : np.ndarray
+        transform : np.ndarray(K_orbs, K_sph)
             Array associated with the linear combinations of spherical Gaussians (LCAO's).
             Transformation is applied to the left, i.e. the sum is over the second index of
             `transform` and first index of the array for contracted spherical Gaussians.
@@ -188,9 +195,10 @@ class BaseOneIndex(BaseGaussianRelatedArray):
 
         Returns
         -------
-        array : np.ndarray
+        array : np.ndarray(K_orbs, ...)
             Array whose first index is associated with the linear combinations of the contracted
             spherical Gaussians.
+            `K_orbs` is the number of basis functions produced after the linear combinations.
 
         """
         array_spherical = self.construct_array_spherical(**kwargs)

--- a/gbasis/base_two_asymm.py
+++ b/gbasis/base_two_asymm.py
@@ -30,15 +30,33 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
     -------
     __init__(self, contractions_one, contractions_two)
         Initialize.
-    construct_array_contraction(self, contraction_one, contraction_two, **kwargs) : np.ndarray
+    construct_array_contraction(self, contractions_one, contractions_two, **kwargs) :
+    np.ndarray(M_1, L_cart_1, M_2, L_cart_2, ...)
         Return the array associated with a `ContractedCartesianGaussians` instance.
-    construct_array_cartesian(self, **kwargs) : np.ndarray
+        `M_1` is the number of segmented contractions with the same exponents (and angular momentum)
+        associated with the first index.
+        `L_cart_1` is the number of Cartesian contractions for the given angular momentum associated
+        with the first index.
+        `M_2` is the number of segmented contractions with the same exponents (and angular momentum)
+        associated with the second index.
+        `L_cart_2` is the number of Cartesian contractions for the given angular momentum associated
+        with the second index.
+    construct_array_cartesian(self, **kwargs) : np.ndarray(K_cart_1, K_cart_2, ...)
         Return the array associated with Cartesian Gaussians.
-    construct_array_spherical(self, **kwargs) : np.ndarray
+        `K_cart_1` is the total number of Cartesian contractions within the `contractions_one`.
+        `K_cart_2` is the total number of Cartesian contractions within the `contractions_two`.
+    construct_array_spherical(self, **kwargs) : np.ndarray(K_sph_1, K_sph_2, ...)
         Return the array associated with spherical Gaussians (atomic orbitals).
-    construct_array_spherical_lincomb(self, transform_one, transform_two, **kwargs) : np.ndarray
+        `K_sph_1` is the total number of spherical contractions within the `contractions_one`.
+        `K_sph_2` is the total number of spherical contractions within the `contractions_two`.
+    construct_array_spherical_lincomb(self, transform_one, transform_two, **kwargs) :
+    np.ndarray(K_orbs_1, K_orbs_2, ...)
         Return the array associated with linear combinations of spherical Gaussians (linear
         combinations of atomic orbitals).
+        `K_orbs_1` is the number of basis functions produced after the linear combinations of the
+        spherical contractions associated with `contractions_one`.
+        `K_orbs_2` is the number of basis functions produced after the linear combinations of the
+        spherical contractions associated with `contractions_two`.
 
     """
 
@@ -96,12 +114,20 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
 
         Returns
         -------
-        array_contraction : np.ndarray(M_1, L_1, M_2, L_2)
+        array_contraction : np.ndarray(M_1, L_cart_1, M_2, L_cart_2, ...)
             Array associated with the given instance(s) of ContractedCartesianGaussians.
-            First axis corresponds to the segmented contraction within `contraction_one`.
-            Second axis corresponds to the angular momentum vector of the `contraction_one`.
-            Third axis corresponds to the segmented contraction within `contraction_two`.
-            Fourth axis corresponds to the angular momentum vector of the `contraction_two`.
+            First axis corresponds to the segmented contraction within `contractions_one`. `M_1` is
+            the number of segmented contractions with the same exponents (and angular momentum)
+            associated with the first index.
+            Second axis corresponds to the angular momentum vector of the `contractions_one`.
+            `L_cart_1` is the number of Cartesian contractions for the given angular momentum
+            associated with the first index.
+            Third axis corresponds to the segmented contraction within `contractions_two`. `M_2` is
+            the number of segmented contractions with the same exponents (and angular momentum)
+            associated with the second index.
+            Fourth axis corresponds to the angular momentum vector of the `contractions_two`.
+            `L_cart_2` is the number of Cartesian contractions for the given angular momentum
+            associated with the second index.
 
         Notes
         -----
@@ -116,7 +142,7 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
         the angular momentum vector of `contration_one`, and third and fourth indices corresponds to
         the contraction (within a generalized contraction) and the angular momentum vector of
         `contration_two`,. These other methods **will** fail with little warning if the shape of the
-        output is different. Even if both `contraction_one` and `contraction_two` are segmented
+        output is different. Even if both `contractions_one` and `contractions_two` are segmented
         contractions, the first and third indices must correspond to the contraction. In other
         words, the shape must still be (1, L_1, 1, L_2).
 
@@ -134,10 +160,12 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
 
         Returns
         -------
-        array : np.ndarray
+        array :  np.ndarray(K_cart_1, K_cart_2, ...)
             Array associated with the given set of contracted Cartesian Gaussians.
-            First and second indices of the array is associated with the contracted Cartesian
-            Gaussians.
+            First index corresponds to the Cartesian contraction within the `contractions_one`.
+            `K_cart_1` is the total number of Cartesian contractions within the `contractions_one`.
+            Second index corresponds to the Cartesian contraction within the `contractions_two`.
+            `K_cart_2` is the total number of Cartesian contractions within the `contractions_two`.
 
         """
         matrices = []
@@ -174,11 +202,13 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
 
         Returns
         -------
-        array : np.ndarray
+        array : np.ndarray(K_sph_1, K_sph_2, ...)
             Array associated with the atomic orbitals associated with the given set(s) of contracted
             Cartesian Gaussians.
-            First and second indices of the array is associated with two contracted spherical
-            Gaussians (atomic orbitals).
+            First index corresponds to the spherical contraction within the `contractions_one`.
+            `K_sph_1` is the total number of spherical contractions within the `contractions_one`.
+            Second index corresponds to the spherical contraction within the `contractions_two`.
+            `K_sph_2` is the total number of spherical contractions within the `contractions_two`.
 
         """
         matrices_spherical = []
@@ -249,9 +279,13 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
         array : np.ndarray
             Array associated with the given two sets of contracted Cartesian Gaussians.
             First index of the array corresponds to the linear combination of contracted spherical
-            Gaussians associated with the first set of contractions, `contractions_one`.
+            Gaussians associated with the first set of contractions, `contractions_one`. `K_orbs_1`
+            is the number of basis functions produced after the linear combinations of the spherical
+            contractions associated with `contractions_one`.
             Second index of the array corresponds to the linear combination of contracted spherical
-            Gaussians associated with the second set of contractions, `contractions_two`.
+            Gaussians associated with the second set of contractions, `contractions_two`. `K_orbs_2`
+            is the number of basis functions produced after the linear combinations of the spherical
+            contractions associated with `contractions_two`.
 
         """
         array_transformed = self.construct_array_spherical(**kwargs)

--- a/gbasis/base_two_symm.py
+++ b/gbasis/base_two_symm.py
@@ -27,15 +27,27 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
     -------
     __init__(self, contractions)
         Initialize.
-    construct_array_contraction(self, contraction) : np.ndarray
+    construct_array_contraction(self, contraction, **kwargs) :
+    np.ndarray(M_1, L_cart_1, M_2, L_cart_2, ...)
         Return the array associated with a `ContractedCartesianGaussians` instance.
-    construct_array_cartesian(self) : np.ndarray
+        `M_1` is the number of segmented contractions with the same exponents (and angular momentum)
+        associated with the first index.
+        `L_cart_1` is the number of Cartesian contractions for the given angular momentum associated
+        with the first index.
+        `M_2` is the number of segmented contractions with the same exponents (and angular momentum)
+        associated with the second index.
+        `L_cart_2` is the number of Cartesian contractions for the given angular momentum associated
+        with the second index.
+    construct_array_cartesian(self, **kwargs) : np.ndarray(K_cart, K_cart, ...)
         Return the array associated with Cartesian Gaussians.
-    construct_array_spherical(self) : np.ndarray
+        `K_cart` is the total number of Cartesian contractions within the instance.
+    construct_array_spherical(self, **kwargs) : np.ndarray(K_sph, K_sph, ...)
         Return the array associated with spherical Gaussians (atomic orbitals).
-    construct_array_spherical_lincomb(self, transform) : np.ndarray
+        `K_sph` is the total number of spherical contractions within the instance.
+    construct_array_spherical_lincomb(self, transform, **kwargs) : np.ndarray(K_orbs, K_orbs, ...)
         Return the array associated with linear combinations of spherical Gaussians (linear
         combinations of atomic orbitals).
+        `K_orbs` is the number of basis functions produced after the linear combinations.
 
     """
 
@@ -80,12 +92,20 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
 
         Returns
         -------
-        array_contraction : np.ndarray(M_1, L_1, M_2, L_2)
-            Array associated with the given instance(s) of ContractedCartesianGaussians.
-            First axis corresponds to the segmented contraction within `contraction_one`.
+        array_contraction : np.ndarray(M_1, L_cart_1, M_2, L_cart_2, ...)
+            Array associated with the given instances of ContractedCartesianGaussians.
+            First axis corresponds to the segmented contraction within `contraction_one`. `M_1` is
+            the number of segmented contractions with the same exponents (and angular momentum)
+            associated with the first index.
             Second axis corresponds to the angular momentum vector of the `contraction_one`.
-            Third axis corresponds to the segmented contraction within `contraction_two`.
+            `L_cart_1` is the number of Cartesian contractions for the given angular momentum
+            associated with the first index.
+            Third axis corresponds to the segmented contraction within `contraction_two`. `M_2` is
+            the number of segmented contractions with the same exponents (and angular momentum)
+            associated with the second index.
             Fourth axis corresponds to the angular momentum vector of the `contraction_two`.
+            `L_cart_2` is the number of Cartesian contractions for the given angular momentum
+            associated with the second index.
             This array should be symmetric with respect to the swapping of the first and second
             axes.
 
@@ -120,10 +140,10 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
 
         Returns
         -------
-        array : np.ndarray
+        array : np.ndarray(K_cart, K_cart, ...)
             Array associated with the given set of contracted Cartesian Gaussians.
             First and second indices of the array is associated with the contracted Cartesian
-            Gaussians.
+            Gaussians. `K_cart` is the total number of Cartesian contractions within the instance.
 
         Notes
         -----
@@ -175,11 +195,12 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
 
         Returns
         -------
-        array : np.ndarray
+        array : np.ndarray(K_sph, K_sph, ...)
             Array associated with the atomic orbitals associated with the given set(s) of contracted
             Cartesian Gaussians.
             First and second indices of the array is associated with two contracted spherical
-            Gaussians (atomic orbitals).
+            Gaussians (atomic orbitals). `K_sph` is the total number of spherical contractions
+            within the instance.
 
         Notes
         -----
@@ -254,13 +275,12 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
 
         Returns
         -------
-        array : np.ndarray
+        array : np.ndarray(K_orbs, K_orbs, ...)
             Array whose first and second indices associated with the linear combinations of the
             contracted spherical Gaussians.
-            First index of the array corresponds to the linear combination of contracted spherical
-            Gaussians associated with the first set of contractions, `contractions_one`.
-            Second index of the array corresponds to the linear combination of contracted spherical
-            Gaussians associated with the second set of contractions, `contractions_two`.
+            First and second indices of the array correspond to the linear combination of contracted
+            spherical Gaussians. `K_orbs` is the number of basis functions produced after the linear
+            combinations.
 
         """
         array_transformed = self.construct_array_spherical(**kwargs)

--- a/gbasis/contractions.py
+++ b/gbasis/contractions.py
@@ -33,11 +33,10 @@ class ContractedCartesianGaussians:
         Coordinate of the center of the Gaussian primitives.
     charge : float
         Charge at the center of the Gaussian primitives.
-    coeffs : {np.ndarray(K,), np.ndarray(K, M)}
+    coeffs : np.ndarray(K, M)
         Contraction coefficients, :math:`\{d_i\}`, of the primitives.
-        If a two dimensional array is given, the first axis corresponds to the primitive and the
-        second axis corresponds to the different contractions that have the same exponents (and
-        angular momentum) but different coefficients.
+        First axis corresponds to the primitive and the second axis corresponds to the different
+        segmented contractions (same exponents and angular momentum but different coefficients).
     exps : np.ndarray(K,)
         Exponents of the primitives, :math:`\{\alpha_i\}`.
 
@@ -58,8 +57,12 @@ class ContractedCartesianGaussians:
             Coordinate of the center of the Gaussian primitives.
         charge : float
             Charge at the center of the Gaussian primitives.
-        coeffs : np.ndarray(K,)
+        coeffs : {np.ndarray(K,), np.ndarray(K, M)}
             Contraction coefficients, :math:`\{d_i\}`, of the primitives.
+            If a two-dimensional array is given, the first axis corresponds to the primitive and the
+            second axis corresponds to the different contractions that have the same exponents (and
+            angular momentum) but different coefficients.
+            If a one-dimensional array is given, a newaxis will be inserted in the second dimension.
         exps : np.ndarray(K,)
             Exponents of the primitives, :math:`\{\alpha_i\}`.
 
@@ -211,17 +214,11 @@ class ContractedCartesianGaussians:
         """
         if not (isinstance(exps, np.ndarray) and exps.dtype == float):
             raise TypeError("Exponents must be given as a numpy array of data type float.")
-        if hasattr(self, "_coeffs"):
-            if self.coeffs.ndim == 2 and self.coeffs.shape[0] != exps.size:
-                raise ValueError(
-                    "Exponents array must have the same number of elements as the number of rows "
-                    "in the two-dimensional coefficient matrix (for the generalized contractions)."
-                )
-            if self.coeffs.ndim == 1 and self.coeffs.shape != exps.shape:
-                raise ValueError(
-                    "Exponents array must have the same number of elements as the one-dimensional "
-                    "coefficient matrix (for the segmented contractions)."
-                )
+        if hasattr(self, "_coeffs") and self.coeffs.shape[0] != exps.size:
+            raise ValueError(
+                "Exponents array must have the same number of elements as the number of rows "
+                "in the two-dimensional coefficient matrix (for the generalized contractions)."
+            )
 
         self._exps = exps
 
@@ -231,11 +228,10 @@ class ContractedCartesianGaussians:
 
         Returns
         -------
-        coeffs : {np.ndarray(K,), np.ndarray(K, M)}
+        coeffs : np.ndarray(K, M)
             Contraction coefficients, :math:`\{d_i\}`, of the primitives.
-            If two dimensional, then the first axis corresponds to the primitive and the second axis
-            corresponds to the different contractions that have the same exponents (and angular
-            momentum) but different coefficients.
+            First axis corresponds to the primitive and the second axis corresponds to the different
+            segmented contractions (same exponents and angular momentum but different coefficients).
 
         """
         return self._coeffs
@@ -248,9 +244,10 @@ class ContractedCartesianGaussians:
         ----------
         coeffs : {np.ndarray(K,), np.ndarray(K, M)}
             Contraction coefficients, :math:`\{d_i\}`, of the primitives.
-            If a two dimensional array is given, the first axis corresponds to the primitive and the
+            If a two-dimensional array is given, the first axis corresponds to the primitive and the
             second axis corresponds to the different contractions that have the same exponents (and
             angular momentum) but different coefficients.
+            If a one-dimensional array is given, a newaxis will be inserted in the second dimension.
 
         Raises
         ------
@@ -278,8 +275,10 @@ class ContractedCartesianGaussians:
                     "Coefficients array for segmented contractions must be given as a one-"
                     "dimensional array with the same size as the exponents array."
                 )
-
-        self._coeffs = coeffs
+        if coeffs.ndim == 1:
+            self._coeffs = coeffs[:, np.newaxis]
+        else:
+            self._coeffs = coeffs
 
     @property
     def angmom_components(self):

--- a/gbasis/deriv.py
+++ b/gbasis/deriv.py
@@ -28,27 +28,21 @@ def _eval_deriv_contractions(coords, orders, center, angmom_comps, alphas, prim_
         is given.
     alphas : np.ndarray(K,)
         Values of the (square root of the) precisions of the primitives.
-    prim_coeffs : {np.ndarray(K,M), np.ndarray(K,)}
+    prim_coeffs : np.ndarray(K, M)
         Contraction coefficients of the primitives.
-        If the coefficients correspond to generalized contractions (i.e. two-dimensional array),
-        then the first index corresponds to the primitive and the second index corresponds to the
+        The coefficients always correspond to generalized contractions, i.e. two-dimensional array
+        where the first index corresponds to the primitive and the second index corresponds to the
         contraction (with the same exponents and angular momentum).
-        If the coefficients correspond to segmented contractions (i.e. one-dimensional array), then
-        the first index corresponds to the primitive.
     norm : np.ndarray(L, K)
         Normalization constants for the primitives in each contraction.
 
     Returns
     -------
-    derivative : {np.ndarray(M, L, N), np.ndarray(L, N)}
+    derivative : np.ndarray(M, L, N)
         Evaluation of the derivative at each given coordinate.
-        If the given coefficients is a two-dimensional array (i.e. generalized contracitons), then a
-        three dimensional array is returned, where the first index corresponds to the contraction,
-        second index corrresponds to the angular momentum vector, and the third index corresponds to
-        the coordinate for the evaluation
-        If the given coefficients is a one-dimensional array (i.e. segmented contracitons), then a
-        two dimensional array is returned, where the first index corrresponds to the angular
-        momentum vector, and the second index corresponds to the coordinate for the evaluation
+        Array is three dimensional, where the first index corresponds to the contraction, second
+        index corrresponds to the angular momentum vector, and the third index corresponds to the
+        coordinate for the evaluation.
 
     Notes
     -----
@@ -59,12 +53,6 @@ def _eval_deriv_contractions(coords, orders, center, angmom_comps, alphas, prim_
     angular momentum) and multiple contraction coefficients are provided, it is **not assumed** that
     the angular momentum vector should be paired up with the contraction coefficients. In fact, each
     angular momentum vector will create multiple contractions according to the given coefficients.
-
-    Multiple shapes of `prim_coeffs` are supported at the expense of concise API. For example, we
-    assumed that the `prim_coeffs` is always 2-dimensional, such that the coefficients for a
-    segmented contraction will have the shape `(K, 1)`. However, it takes a little more time to
-    evaluate a two-dimensional array over a one-dimensional array, even if their size is the same.
-    We support different shapes of `prim_coeffs` to keep this little bit of performance.
 
     """
     # pylint: disable=R0914

--- a/tests/test_contractions.py
+++ b/tests/test_contractions.py
@@ -128,7 +128,7 @@ def test_coeffs_setter():
     assert (
         isinstance(test._coeffs, np.ndarray)
         and test._coeffs.dtype == float
-        and np.allclose(test._coeffs, np.array([1, 2, 3]))
+        and np.allclose(test._coeffs, np.array([[1], [2], [3]]))
     )
 
     test = skip_init(ContractedCartesianGaussians)
@@ -137,7 +137,7 @@ def test_coeffs_setter():
     assert (
         isinstance(test._coeffs, np.ndarray)
         and test._coeffs.dtype == float
-        and np.allclose(test._coeffs, np.array([1, 2, 3]))
+        and np.allclose(test._coeffs, np.array([[1], [2], [3]]))
     )
 
     test = skip_init(ContractedCartesianGaussians)
@@ -196,7 +196,7 @@ def tests_init():
     assert test._angmom == 1
     assert np.allclose(test._coord, np.array([0, 1, 2]))
     assert test._charge == 0
-    assert np.allclose(test._coeffs, np.array([1, 2, 3, 4]))
+    assert np.allclose(test._coeffs, np.array([[1], [2], [3], [4]]))
     assert np.allclose(test._exps, np.array([5, 6, 7, 8]))
 
 

--- a/tests/test_deriv.py
+++ b/tests/test_deriv.py
@@ -542,21 +542,6 @@ def test_eval_deriv_generalized_contraction():
         orders[k] += 1
         orders[l] += 1
         for x, y, z in it.product(range(4), range(4), range(4)):
-            # primitive
-            assert np.allclose(
-                _eval_deriv_contractions(
-                    np.array([[2, 3, 4]]),
-                    orders,
-                    np.array([0.5, 1, 1.5]),
-                    np.array([[x, y, z]]),
-                    np.array([1]),
-                    np.array([1]),
-                    np.array([[1]]),
-                ),
-                eval_deriv_prim(
-                    np.array([2, 3, 4]), orders, np.array([0.5, 1, 1.5]), np.array([x, y, z]), 1
-                ),
-            )
             # only contraction
             assert np.allclose(
                 _eval_deriv_contractions(
@@ -565,17 +550,61 @@ def test_eval_deriv_generalized_contraction():
                     np.array([0.5, 1, 1.5]),
                     np.array([[x, y, z]]),
                     np.array([1, 2]),
-                    np.array([3, 4]),
+                    np.array([[3, 4, 5], [6, 7, 8]]),
                     np.array([[1, 1]]),
                 ),
-                3
-                * eval_deriv_prim(
-                    np.array([2, 3, 4]), orders, np.array([0.5, 1, 1.5]), np.array([x, y, z]), 1
-                )
-                + 4
-                * eval_deriv_prim(
-                    np.array([2, 3, 4]), orders, np.array([0.5, 1, 1.5]), np.array([x, y, z]), 2
-                ),
+                np.array(
+                    [
+                        3
+                        * eval_deriv_prim(
+                            np.array([2, 3, 4]),
+                            orders,
+                            np.array([0.5, 1, 1.5]),
+                            np.array([x, y, z]),
+                            1,
+                        )
+                        + 6
+                        * eval_deriv_prim(
+                            np.array([2, 3, 4]),
+                            orders,
+                            np.array([0.5, 1, 1.5]),
+                            np.array([x, y, z]),
+                            2,
+                        ),
+                        4
+                        * eval_deriv_prim(
+                            np.array([2, 3, 4]),
+                            orders,
+                            np.array([0.5, 1, 1.5]),
+                            np.array([x, y, z]),
+                            1,
+                        )
+                        + 7
+                        * eval_deriv_prim(
+                            np.array([2, 3, 4]),
+                            orders,
+                            np.array([0.5, 1, 1.5]),
+                            np.array([x, y, z]),
+                            2,
+                        ),
+                        5
+                        * eval_deriv_prim(
+                            np.array([2, 3, 4]),
+                            orders,
+                            np.array([0.5, 1, 1.5]),
+                            np.array([x, y, z]),
+                            1,
+                        )
+                        + 8
+                        * eval_deriv_prim(
+                            np.array([2, 3, 4]),
+                            orders,
+                            np.array([0.5, 1, 1.5]),
+                            np.array([x, y, z]),
+                            2,
+                        ),
+                    ]
+                ).reshape(3, 1, 1),
             )
             # contraction + multiple angular momentums
             assert np.allclose(
@@ -585,33 +614,113 @@ def test_eval_deriv_generalized_contraction():
                     np.array([0.5, 1, 1.5]),
                     np.array([[x, y, z], [x - 1, y + 2, z + 1]]),
                     np.array([1, 2]),
-                    np.array([3, 4]),
+                    np.array([[3, 4, 5], [6, 7, 8]]),
                     np.array([[1, 1]]),
                 ),
-                [
-                    3
-                    * eval_deriv_prim(
-                        np.array([2, 3, 4]), orders, np.array([0.5, 1, 1.5]), np.array([x, y, z]), 1
-                    )
-                    + 4
-                    * eval_deriv_prim(
-                        np.array([2, 3, 4]), orders, np.array([0.5, 1, 1.5]), np.array([x, y, z]), 2
-                    ),
-                    3
-                    * eval_deriv_prim(
-                        np.array([2, 3, 4]),
-                        orders,
-                        np.array([0.5, 1, 1.5]),
-                        np.array([x - 1, y + 2, z + 1]),
-                        1,
-                    )
-                    + 4
-                    * eval_deriv_prim(
-                        np.array([2, 3, 4]),
-                        orders,
-                        np.array([0.5, 1, 1.5]),
-                        np.array([x - 1, y + 2, z + 1]),
-                        2,
-                    ),
-                ],
+                np.array(
+                    [
+                        [
+                            3
+                            * eval_deriv_prim(
+                                np.array([2, 3, 4]),
+                                orders,
+                                np.array([0.5, 1, 1.5]),
+                                np.array([x, y, z]),
+                                1,
+                            )
+                            + 6
+                            * eval_deriv_prim(
+                                np.array([2, 3, 4]),
+                                orders,
+                                np.array([0.5, 1, 1.5]),
+                                np.array([x, y, z]),
+                                2,
+                            ),
+                            3
+                            * eval_deriv_prim(
+                                np.array([2, 3, 4]),
+                                orders,
+                                np.array([0.5, 1, 1.5]),
+                                np.array([x - 1, y + 2, z + 1]),
+                                1,
+                            )
+                            + 6
+                            * eval_deriv_prim(
+                                np.array([2, 3, 4]),
+                                orders,
+                                np.array([0.5, 1, 1.5]),
+                                np.array([x - 1, y + 2, z + 1]),
+                                2,
+                            ),
+                        ],
+                        [
+                            4
+                            * eval_deriv_prim(
+                                np.array([2, 3, 4]),
+                                orders,
+                                np.array([0.5, 1, 1.5]),
+                                np.array([x, y, z]),
+                                1,
+                            )
+                            + 7
+                            * eval_deriv_prim(
+                                np.array([2, 3, 4]),
+                                orders,
+                                np.array([0.5, 1, 1.5]),
+                                np.array([x, y, z]),
+                                2,
+                            ),
+                            4
+                            * eval_deriv_prim(
+                                np.array([2, 3, 4]),
+                                orders,
+                                np.array([0.5, 1, 1.5]),
+                                np.array([x - 1, y + 2, z + 1]),
+                                1,
+                            )
+                            + 7
+                            * eval_deriv_prim(
+                                np.array([2, 3, 4]),
+                                orders,
+                                np.array([0.5, 1, 1.5]),
+                                np.array([x - 1, y + 2, z + 1]),
+                                2,
+                            ),
+                        ],
+                        [
+                            5
+                            * eval_deriv_prim(
+                                np.array([2, 3, 4]),
+                                orders,
+                                np.array([0.5, 1, 1.5]),
+                                np.array([x, y, z]),
+                                1,
+                            )
+                            + 8
+                            * eval_deriv_prim(
+                                np.array([2, 3, 4]),
+                                orders,
+                                np.array([0.5, 1, 1.5]),
+                                np.array([x, y, z]),
+                                2,
+                            ),
+                            5
+                            * eval_deriv_prim(
+                                np.array([2, 3, 4]),
+                                orders,
+                                np.array([0.5, 1, 1.5]),
+                                np.array([x - 1, y + 2, z + 1]),
+                                1,
+                            )
+                            + 8
+                            * eval_deriv_prim(
+                                np.array([2, 3, 4]),
+                                orders,
+                                np.array([0.5, 1, 1.5]),
+                                np.array([x - 1, y + 2, z + 1]),
+                                2,
+                            ),
+                        ],
+                    ]
+                ),
             )

--- a/tests/test_moment_int.py
+++ b/tests/test_moment_int.py
@@ -284,8 +284,8 @@ def test_compute_multipole_moment_integrals_prim_angmom_left_recursion():
     coord_b = np.array([1, 1.5, 2])
     alphas_a = np.array([0.1])
     alphas_b = np.array([0.2])
-    coeffs_a = np.array([1.0])
-    coeffs_b = np.array([1.0])
+    coeffs_a = np.array([[1.0]])
+    coeffs_b = np.array([[1.0]])
     angmoms_b = np.array([[0, 0, 0]])
     coord_moment = np.array([0.0, 1.0, 2.0])
     order_moment = np.array([[0, 0, 0]])
@@ -327,8 +327,8 @@ def test_compute_multipole_moment_integrals_prim_angmom_right_recursion():
     coord_b = np.array([1, 1.5, 2])
     alphas_a = np.array([0.1])
     alphas_b = np.array([0.2])
-    coeffs_a = np.array([1.0])
-    coeffs_b = np.array([1.0])
+    coeffs_a = np.array([[1.0]])
+    coeffs_b = np.array([[1.0]])
     angmoms_a = np.array([[3, 3, 3]])
     coord_moment = np.array([0.0, 1.0, 2.0])
     order_moment = np.array([[0, 0, 0]])
@@ -374,8 +374,8 @@ def test_compute_multipole_moment_integrals_prim_moment_recursion():
     coord_b = np.array([1, 1.5, 2])
     alphas_a = np.array([0.1])
     alphas_b = np.array([0.2])
-    coeffs_a = np.array([1.0])
-    coeffs_b = np.array([1.0])
+    coeffs_a = np.array([[1.0]])
+    coeffs_b = np.array([[1.0]])
     angmoms_a = np.array([[3, 3, 3]])
     angmoms_b = np.array([[3, 3, 3]])
     coord_moment = np.array([0.0, 1.0, 2.0])
@@ -430,7 +430,7 @@ def test_compute_multipole_moment_integrals_contraction_norm():
 
     angmoms_a = np.array([[0, 0, 0]])
     alphas_a = np.array([0.2])
-    coeffs_a = np.array([1.0])
+    coeffs_a = np.array([[1.0]])
     norm_a = np.prod(
         np.sqrt(
             (2 * alphas_a[np.newaxis, np.newaxis, :] / np.pi) ** (1 / 2)
@@ -476,7 +476,7 @@ def test_compute_multipole_moment_integrals_contraction_norm():
 
     angmoms_a = np.array([[3, 3, 3]])
     alphas_a = np.array([0.2])
-    coeffs_a = np.array([1.0])
+    coeffs_a = np.array([[1.0]])
     norm_a = np.prod(
         np.sqrt(
             (2 * alphas_a[np.newaxis, np.newaxis, :] / np.pi) ** (1 / 2)
@@ -522,7 +522,7 @@ def test_compute_multipole_moment_integrals_contraction_norm():
 
     angmoms_a = np.array([[3, 3, 3]])
     alphas_a = np.array([0.2, 0.4])
-    coeffs_a = np.array([1.0, 1.0])
+    coeffs_a = np.array([[1.0], [1.0]])
     norm_a = np.prod(
         np.sqrt(
             (2 * alphas_a[np.newaxis, np.newaxis, :] / np.pi) ** (1 / 2)
@@ -621,8 +621,8 @@ def test_compute_multipole_moment_integrals_contraction():
 
     alphas_a = np.array([0.1, 0.01])
     alphas_b = np.array([0.2, 0.02])
-    coeffs_a = np.array([1.0, 2.0])
-    coeffs_b = np.array([3.0, 4.0])
+    coeffs_a = np.array([[1.0], [2.0]])
+    coeffs_b = np.array([[3.0], [4.0]])
     norm_a = np.prod(
         np.sqrt(
             (2 * alphas_a[np.newaxis, np.newaxis, :] / np.pi) ** (1 / 2)
@@ -661,12 +661,12 @@ def test_compute_multipole_moment_integrals_contraction():
             coord_a,
             angmoms_a,
             np.array([0.1]),
-            np.array([1.0]),
+            np.array([[1.0]]),
             norm_a[:, 0:1],
             coord_b,
             angmoms_b,
             np.array([0.2]),
-            np.array([3.0]),
+            np.array([[3.0]]),
             norm_b[:, 0:1],
         )
         + _compute_multipole_moment_integrals(
@@ -675,12 +675,12 @@ def test_compute_multipole_moment_integrals_contraction():
             coord_a,
             angmoms_a,
             np.array([0.01]),
-            np.array([2.0]),
+            np.array([[2.0]]),
             norm_a[:, 1:],
             coord_b,
             angmoms_b,
             np.array([0.2]),
-            np.array([3.0]),
+            np.array([[3.0]]),
             norm_b[:, 0:1],
         )
         + _compute_multipole_moment_integrals(
@@ -689,12 +689,12 @@ def test_compute_multipole_moment_integrals_contraction():
             coord_a,
             angmoms_a,
             np.array([0.1]),
-            np.array([1.0]),
+            np.array([[1.0]]),
             norm_a[:, 1:],
             coord_b,
             angmoms_b,
             np.array([0.02]),
-            np.array([4.0]),
+            np.array([[4.0]]),
             norm_b[:, 0:1],
         )
         + _compute_multipole_moment_integrals(
@@ -703,12 +703,12 @@ def test_compute_multipole_moment_integrals_contraction():
             coord_a,
             angmoms_a,
             np.array([0.01]),
-            np.array([2.0]),
+            np.array([[2.0]]),
             norm_a[:, 1:],
             coord_b,
             angmoms_b,
             np.array([0.02]),
-            np.array([4.0]),
+            np.array([[4.0]]),
             norm_b[:, 1:],
         ),
     )
@@ -741,8 +741,8 @@ def test_compute_multipole_moment_integrals_multiarray():
     angmoms_b = np.array([[2, 0, 0], [0, 2, 0], [0, 0, 2], [1, 1, 0], [1, 0, 1], [0, 1, 1]])
     alphas_a = np.array([5.4471780, 0.8245470])
     alphas_b = np.array([0.1831920])
-    coeffs_a = np.array([0.1562850, 0.9046910])
-    coeffs_b = np.array([1.0])
+    coeffs_a = np.array([[0.1562850], [0.9046910]])
+    coeffs_b = np.array([[1.0]])
     coord_moment = np.array([0.25, 0.45, 0.65])
     orders_moment = np.array(
         [
@@ -794,7 +794,7 @@ def test_compute_multipole_moment_integrals_multiarray():
         coeffs_b,
         norm_b,
     )
-    assert test.shape == (orders_moment.shape[0], angmoms_b.shape[0], angmoms_a.shape[0])
+    assert test.shape == (orders_moment.shape[0], 1, angmoms_a.shape[0], 1, angmoms_b.shape[0])
     for i, order_moment in enumerate(orders_moment):
         for j, angmom_a in enumerate(angmoms_a):
             for k, angmom_b in enumerate(angmoms_b):
@@ -811,4 +811,91 @@ def test_compute_multipole_moment_integrals_multiarray():
                     alphas_b,
                     coeffs_b,
                     norm_b,
-                ) == test[i, k, j]
+                ) == test[i, 0, j, 0, k]
+
+
+def test_compute_multipole_moment_integrals_generalized_contraction():
+    """Test moment_int._compute_multipole_moment_integrals for generalized contractions."""
+    moment_orders = [[0, 0, 0], [1, 0, 0], [3, 1, 2]]
+    angmoms = [[0, 0, 0], [0, 1, 0], [0, 2, 1], [3, 2, 1]]
+    test = _compute_multipole_moment_integrals(
+        np.array([2, 3, 4]),
+        np.array(moment_orders),
+        np.array([0.5, 1, 1.5]),
+        np.array(angmoms),
+        np.array([1, 2]),
+        np.array([[3, 4], [5, 6]]),
+        np.array([[1, 1], [1, 1], [1, 1], [1, 1]]),
+        np.array([1.0, 1.5, 2.0]),
+        np.array(angmoms),
+        np.array([1.2, 2.2]),
+        np.array([[3.2, 4.2], [5.2, 6.2]]),
+        np.array([[1.1, 0.9], [1.1, 0.9], [1.1, 0.9], [1.1, 0.9]]),
+    )
+    answer = np.array(
+        [
+            [
+                _compute_multipole_moment_integrals(
+                    np.array([2, 3, 4]),
+                    np.array(moment_orders),
+                    np.array([0.5, 1, 1.5]),
+                    np.array(angmoms),
+                    np.array([1, 2]),
+                    np.array([[3], [5]]),
+                    np.array([[1, 1], [1, 1], [1, 1], [1, 1]]),
+                    np.array([1.0, 1.5, 2.0]),
+                    np.array(angmoms),
+                    np.array([1.2, 2.2]),
+                    np.array([[3.2], [5.2]]),
+                    np.array([[1.1, 0.9], [1.1, 0.9], [1.1, 0.9], [1.1, 0.9]]),
+                ),
+                _compute_multipole_moment_integrals(
+                    np.array([2, 3, 4]),
+                    np.array(moment_orders),
+                    np.array([0.5, 1, 1.5]),
+                    np.array(angmoms),
+                    np.array([1, 2]),
+                    np.array([[3], [5]]),
+                    np.array([[1, 1], [1, 1], [1, 1], [1, 1]]),
+                    np.array([1.0, 1.5, 2.0]),
+                    np.array(angmoms),
+                    np.array([1.2, 2.2]),
+                    np.array([[4.2], [6.2]]),
+                    np.array([[1.1, 0.9], [1.1, 0.9], [1.1, 0.9], [1.1, 0.9]]),
+                ),
+            ],
+            [
+                _compute_multipole_moment_integrals(
+                    np.array([2, 3, 4]),
+                    np.array(moment_orders),
+                    np.array([0.5, 1, 1.5]),
+                    np.array(angmoms),
+                    np.array([1, 2]),
+                    np.array([[4], [6]]),
+                    np.array([[1, 1], [1, 1], [1, 1], [1, 1]]),
+                    np.array([1.0, 1.5, 2.0]),
+                    np.array(angmoms),
+                    np.array([1.2, 2.2]),
+                    np.array([[3.2], [5.2]]),
+                    np.array([[1.1, 0.9], [1.1, 0.9], [1.1, 0.9], [1.1, 0.9]]),
+                ),
+                _compute_multipole_moment_integrals(
+                    np.array([2, 3, 4]),
+                    np.array(moment_orders),
+                    np.array([0.5, 1, 1.5]),
+                    np.array(angmoms),
+                    np.array([1, 2]),
+                    np.array([[4], [6]]),
+                    np.array([[1, 1], [1, 1], [1, 1], [1, 1]]),
+                    np.array([1.0, 1.5, 2.0]),
+                    np.array(angmoms),
+                    np.array([1.2, 2.2]),
+                    np.array([[4.2], [6.2]]),
+                    np.array([[1.1, 0.9], [1.1, 0.9], [1.1, 0.9], [1.1, 0.9]]),
+                ),
+            ],
+        ]
+    )
+    answer = np.squeeze(answer, (3, 5))
+    answer = np.transpose(answer, (2, 0, 3, 1, 4))
+    assert np.allclose(test, answer)


### PR DESCRIPTION
1. Make generalized contractions the default for ContractedCartesianGaussians. I've found that there wasn't a significant difference in performance in adding an extra dimension for the segmented contractions. Since the data structure is controlled entirely by COntractedCartesianGaussians, fixing the numpy array shape for the coefficient matrix makes it much easier to have a stable API in the other parts of the code (the index classes)
2. Update docstrings
3. Fix bad test for generalized contractions and gbasis.deriv._eval_deriv_contractions
4. Add test for generalized contractions and gbasis.moment_int._compute_multipole_moment_integrals.