### PR TITLE
Fix docstring typos

### DIFF
--- a/gbasis/base.py
+++ b/gbasis/base.py
@@ -1,4 +1,4 @@
-"""Base class for arrays that depends on one or more contracted Gaussians."""
+"""Base class for arrays that depend on one or more contracted Gaussians."""
 import abc
 
 from gbasis.contractions import ContractedCartesianGaussians
@@ -10,7 +10,7 @@ class BaseGaussianRelatedArray(abc.ABC):
     Attributes
     ----------
     _axes_contractions : tuple of tuple of ContractedCartesianGaussians
-        Contractions that are asosciatd with each index of the array.
+        Contractions that are associated with each index of the array.
         Each tuple of ContractedCartesianGaussians corresponds to an index of the array.
 
     Methods
@@ -35,7 +35,7 @@ class BaseGaussianRelatedArray(abc.ABC):
         Parameters
         ----------
         contractions : list/tuple of ContractedCartesianGaussians
-            Contractions that are asosciatd with each index of the array.
+            Contractions that are associated with each index of the array.
             First contractions is associated with the first index, etc.
 
         Raises

--- a/gbasis/base_one.py
+++ b/gbasis/base_one.py
@@ -1,4 +1,4 @@
-"""Base class for arrays that depend on one contracted Gaussians."""
+"""Base class for arrays that depend on one contracted Gaussian."""
 import abc
 
 from gbasis.base import BaseGaussianRelatedArray
@@ -16,7 +16,7 @@ class BaseOneIndex(BaseGaussianRelatedArray):
     Attributes
     ----------
     _axes_contractions : tuple of tuple of ContractedCartesianGaussians
-        Contractions that are asosciatd with each index of the array.
+        Contractions that are associated with each index of the array.
         Each tuple of ContractedCartesianGaussians corresponds to an index of the array.
 
     Properties
@@ -102,8 +102,8 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         index corresponds to the contraction (within a generalized contraction) and second index
         corresponds to the angular momentum vector. These other methods **will** fail with little
         warning if the shape of the output is different. Even if there is only one contraction (i.e.
-        segmented contraction), the first index must correspond to contraction. In other words, the
-        shape must still be (1, L, N).
+        segmented contraction), the first index must correspond to the contraction. In other words,
+        the shape must still be (1, L, N).
 
         """
 
@@ -114,8 +114,8 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         ----------
         kwargs : dict
             Other keyword arguments that will be used to construct the array.
-            These keyword arguments are passed entirely to `construct_array_contrations`. See
-            `construct_array_contractions` for details on the keyword arguments.
+            These keyword arguments are passed entirely to `construct_array_contraction`. See
+            `construct_array_contraction` for details on the keyword arguments.
 
         Returns
         -------
@@ -142,8 +142,8 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         ----------
         kwargs : dict
             Other keyword arguments that will be used to construct the array.
-            These keyword arguments are passed entirely to `construct_array_contrations`. See
-            `construct_array_contractions` for details on the keyword arguments.
+            These keyword arguments are passed entirely to `construct_array_contraction`. See
+            `construct_array_contraction` for details on the keyword arguments.
 
         Returns
         -------
@@ -190,7 +190,7 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         kwargs : dict
             Other keyword arguments that will be used to construct the array.
             These keyword arguments are passed directly to `construct_array_spherical`, which will
-            then pass it down to `construct_array_contrations`. See `construct_array_contractions`
+            then pass it down to `construct_array_contraction`. See `construct_array_contraction`
             for details on the keyword arguments.
 
         Returns

--- a/gbasis/base_two_asymm.py
+++ b/gbasis/base_two_asymm.py
@@ -138,13 +138,13 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
 
         The methods `construct_array_cartesian`, `construct_array_spherical`, and
         `construct_array_spherical_lincomb` depend on this function to produce an array whose first
-        and second indices corresponds to the contraction (within a generalized contraction) and
-        the angular momentum vector of `contration_one`, and third and fourth indices corresponds to
-        the contraction (within a generalized contraction) and the angular momentum vector of
-        `contration_two`,. These other methods **will** fail with little warning if the shape of the
-        output is different. Even if both `contractions_one` and `contractions_two` are segmented
-        contractions, the first and third indices must correspond to the contraction. In other
-        words, the shape must still be (1, L_1, 1, L_2).
+        and second indices correspond to the contraction (within a generalized contraction) and
+        the angular momentum vector of `contractions_one`, and third and fourth indices correspond
+        to the contraction (within a generalized contraction) and the angular momentum vector of
+        `contractions_two`,. These other methods **will** fail with little warning if the shape of
+        the output is different. Even if both `contractions_one` and `contractions_two` are
+        segmented contractions, the first and third indices must correspond to the contraction.
+        In other words, the shape must still be (1, L_1, 1, L_2).
 
         """
 
@@ -155,8 +155,8 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
         ----------
         kwargs : dict
             Other keyword arguments that will be used to construct the array.
-            These keyword arguments are passed entirely to `construct_array_contrations`. See
-            `construct_array_contractions` for details on the keyword arguments.
+            These keyword arguments are passed entirely to `construct_array_contraction`. See
+            `construct_array_contraction` for details on the keyword arguments.
 
         Returns
         -------
@@ -197,8 +197,8 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
         ----------
         kwargs : dict
             Other keyword arguments that will be used to construct the array.
-            These keyword arguments are passed entirely to `construct_array_contrations`. See
-            `construct_array_contractions` for details on the keyword arguments.
+            These keyword arguments are passed entirely to `construct_array_contraction`. See
+            `construct_array_contraction` for details on the keyword arguments.
 
         Returns
         -------
@@ -271,7 +271,7 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
         kwargs : dict
             Other keyword arguments that will be used to construct the array.
             These keyword arguments are passed directly to `construct_array_spherical`, which will
-            then pass it down to `construct_array_contrations`. See `construct_array_contractions`
+            then pass it down to `construct_array_contraction`. See `construct_array_contraction`
             for details on the keyword arguments.
 
         Returns

--- a/gbasis/base_two_symm.py
+++ b/gbasis/base_two_symm.py
@@ -94,16 +94,16 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
         -------
         array_contraction : np.ndarray(M_1, L_cart_1, M_2, L_cart_2, ...)
             Array associated with the given instances of ContractedCartesianGaussians.
-            First axis corresponds to the segmented contraction within `contraction_one`. `M_1` is
+            First axis corresponds to the segmented contraction within `contractions_one`. `M_1` is
             the number of segmented contractions with the same exponents (and angular momentum)
             associated with the first index.
-            Second axis corresponds to the angular momentum vector of the `contraction_one`.
+            Second axis corresponds to the angular momentum vector of the `contractions_one`.
             `L_cart_1` is the number of Cartesian contractions for the given angular momentum
             associated with the first index.
-            Third axis corresponds to the segmented contraction within `contraction_two`. `M_2` is
+            Third axis corresponds to the segmented contraction within `contractions_two`. `M_2` is
             the number of segmented contractions with the same exponents (and angular momentum)
             associated with the second index.
-            Fourth axis corresponds to the angular momentum vector of the `contraction_two`.
+            Fourth axis corresponds to the angular momentum vector of the `contractions_two`.
             `L_cart_2` is the number of Cartesian contractions for the given angular momentum
             associated with the second index.
             This array should be symmetric with respect to the swapping of the first and second
@@ -118,13 +118,13 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
 
         The methods `construct_array_cartesian`, `construct_array_spherical`, and
         `construct_array_spherical_lincomb` depend on this function to produce an array whose first
-        and second indices corresponds to the contraction (within a generalized contraction) and
-        the angular momentum vector of `contration_one`, and third and fourth indices corresponds to
-        the contraction (within a generalized contraction) and the angular momentum vector of
-        `contration_two`,. These other methods **will** fail with little warning if the shape of the
-        output is different. Even if both `contraction_one` and `contraction_two` are segmented
-        contractions, the first and third indices must correspond to the contraction. In other
-        words, the shape must still be (1, L_1, 1, L_2).
+        and second indices correspond to the contraction (within a generalized contraction) and
+        the angular momentum vector of `contractions_one`, and third and fourth indices correspond
+        to the contraction (within a generalized contraction) and the angular momentum vector of
+        `contractions_two`,. These other methods **will** fail with little warning if the shape of
+        the output is different. Even if both `contractions_one` and `contractions_two` are
+        segmented contractions, the first and third indices must correspond to the contraction.
+        In other words, the shape must still be (1, L_1, 1, L_2).
 
         """
 
@@ -135,20 +135,20 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
         ----------
         kwargs : dict
             Other keyword arguments that will be used to construct the array.
-            These keyword arguments are passed entirely to `construct_array_contrations`. See
-            `construct_array_contractions` for details on the keyword arguments.
+            These keyword arguments are passed entirely to `construct_array_contraction`. See
+            `construct_array_contraction` for details on the keyword arguments.
 
         Returns
         -------
         array : np.ndarray(K_cart, K_cart, ...)
             Array associated with the given set of contracted Cartesian Gaussians.
-            First and second indices of the array is associated with the contracted Cartesian
+            First and second indices of the array are associated with the contracted Cartesian
             Gaussians. `K_cart` is the total number of Cartesian contractions within the instance.
 
         Notes
         -----
-        For the blocks along the diagonal i.e. blocks where the first two axis belong to the same
-        set of contractions, they are transposed in the processed of constructing the whole array.
+        The blocks along the diagonal, i.e. blocks where the first two axes belong to the same
+        set of contractions, are transposed in the process of constructing the whole array.
         It is assumed that the array returned from `construct_array_contraction` is symmetric with
         respect to the swapping of the first and second axes.
 
@@ -190,22 +190,22 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
         ----------
         kwargs : dict
             Other keyword arguments that will be used to construct the array.
-            These keyword arguments are passed entirely to `construct_array_contrations`. See
-            `construct_array_contractions` for details on the keyword arguments.
+            These keyword arguments are passed entirely to `construct_array_contraction`. See
+            `construct_array_contraction` for details on the keyword arguments.
 
         Returns
         -------
         array : np.ndarray(K_sph, K_sph, ...)
             Array associated with the atomic orbitals associated with the given set(s) of contracted
             Cartesian Gaussians.
-            First and second indices of the array is associated with two contracted spherical
+            First and second indices of the array are associated with two contracted spherical
             Gaussians (atomic orbitals). `K_sph` is the total number of spherical contractions
             within the instance.
 
         Notes
         -----
-        For the blocks along the diagonal i.e. blocks where the first two axis belong to the same
-        set of contractions, they are transposed in the processed of constructing the whole array.
+        The blocks along the diagonal, i.e. blocks where the first two axes belong to the same
+        set of contractions, are transposed in the process of constructing the whole array.
         It is assumed that the array returned from `construct_array_contraction` is symmetric with
         respect to the swapping of the first and second axes.
 
@@ -270,13 +270,13 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
         kwargs : dict
             Other keyword arguments that will be used to construct the array.
             These keyword arguments are passed directly to `construct_array_spherical`, which will
-            then pass it down to `construct_array_contrations`. See `construct_array_contractions`
+            then pass it down to `construct_array_contraction`. See `construct_array_contraction`
             for details on the keyword arguments.
 
         Returns
         -------
         array : np.ndarray(K_orbs, K_orbs, ...)
-            Array whose first and second indices associated with the linear combinations of the
+            Array whose first and second indices are associated with the linear combinations of the
             contracted spherical Gaussians.
             First and second indices of the array correspond to the linear combination of contracted
             spherical Gaussians. `K_orbs` is the number of basis functions produced after the linear

--- a/gbasis/deriv.py
+++ b/gbasis/deriv.py
@@ -40,7 +40,7 @@ def _eval_deriv_contractions(coords, orders, center, angmom_comps, alphas, prim_
     derivative : np.ndarray(M, L, N)
         Evaluation of the derivative at each given coordinate.
         Array is three dimensional, where the first index corresponds to the contraction, second
-        index corrresponds to the angular momentum vector, and the third index corresponds to the
+        index corresponds to the angular momentum vector, and the third index corresponds to the
         coordinate for the evaluation.
 
     Notes

--- a/gbasis/eval.py
+++ b/gbasis/eval.py
@@ -14,7 +14,7 @@ class Eval(BaseOneIndex):
     Attributes
     ----------
     _axes_contractions : tuple of tuple of ContractedCartesianGaussians
-        Contractions that are asosciatd with each index of the array.
+        Contractions that are associated with each index of the array.
         Each tuple of ContractedCartesianGaussians corresponds to an index of the array.
 
     Properties
@@ -42,8 +42,8 @@ class Eval(BaseOneIndex):
         `K_sph` is the total number of spherical contractions within the instance.
         `N` is the number of coordinates at which the contractions are evaluated.
     construct_array_spherical_lincomb(self, transform, coords) : np.ndarray(K_orbs, N)
-        Return the evalutions of the linear combinations of spherical Gaussians (linear combinations
-        of atomic orbitals).
+        Return the evaluations of the linear combinations of spherical Gaussians (linear
+        combinations of atomic orbitals).
         `K_orbs` is the number of basis functions produced after the linear combinations.
         `N` is the number of coordinates at which the contractions are evaluated.
 
@@ -76,7 +76,7 @@ class Eval(BaseOneIndex):
         Raises
         ------
         TypeError
-            If contractions is not a ContractedCartesianGaussians.
+            If contractions is not a ContractedCartesianGaussians instance.
             If coords is not a two-dimensional numpy array with 3 columns.
 
         Note

--- a/gbasis/eval_deriv.py
+++ b/gbasis/eval_deriv.py
@@ -14,7 +14,7 @@ class EvalDeriv(BaseOneIndex):
     Attributes
     ----------
     _axes_contractions : tuple of tuple of ContractedCartesianGaussians
-        Contractions that are asosciatd with each index of the array.
+        Contractions that are associated with each index of the array.
         Each tuple of ContractedCartesianGaussians corresponds to an index of the array.
 
     Properties
@@ -42,8 +42,8 @@ class EvalDeriv(BaseOneIndex):
         `K_sph` is the total number of spherical contractions within the instance.
         `N` is the number of coordinates at which the contractions are evaluated.
     construct_array_spherical_lincomb(self, transform, coords, orders) : np.ndarray(K_orbs, N)
-        Return the evalutions of the linear combinations of spherical Gaussians (linear combinations
-        of atomic orbitals).
+        Return the evaluations of the linear combinations of spherical Gaussians (linear
+        combinations of atomic orbitals).
         `K_orbs` is the number of basis functions produced after the linear combinations.
         `N` is the number of coordinates at which the contractions are evaluated.
 
@@ -57,7 +57,8 @@ class EvalDeriv(BaseOneIndex):
         ----------
         contractions : ContractedCartesianGaussians
             Contracted Cartesian Gaussians (of the same shell) that will be used to construct an
-            array. coords : np.ndarray(N, 3)
+            array.
+        coords : np.ndarray(N, 3)
             Points in space where the contractions are evaluated.
         orders : np.ndarray(3,)
             Orders of the derivative.
@@ -77,7 +78,7 @@ class EvalDeriv(BaseOneIndex):
         Raises
         ------
         TypeError
-            If contractions is not a ContractedCartesianGaussians.
+            If contractions is not a ContractedCartesianGaussians instance.
             If coords is not a two-dimensional numpy array with 3 columns.
             If orders is not a one-dimensional numpy array with 3 elements.
         ValueError

--- a/gbasis/moment_int.py
+++ b/gbasis/moment_int.py
@@ -19,7 +19,7 @@ def _compute_multipole_moment_integrals(
     coeffs_b,
     norm_b,
 ):
-    """Return the multipole moment integrals of two contraction.
+    """Return the multipole moment integrals of two contractions.
 
     Parameters
     ----------
@@ -27,13 +27,13 @@ def _compute_multipole_moment_integrals(
         Center of the moment.
     orders_moment : np.ndarray(D, 3)
         Orders of the moment for each dimension (x, y, z).
-        Note that two dimensional array must be given, even if there is only one set of orders of
+        Note that a two dimensional array must be given, even if there is only one set of orders of
         the moment.
     coord_a : np.ndarray(3,)
         Center of the contraction on the left side.
     angmoms_a : np.ndarray(L_a, 3)
         Angular momentum vectors (lx, ly, lz) for the contractions on the left side.
-        Note that two dimensional array must be given, even if there is only one angular momentum
+        Note that a two dimensional array must be given, even if there is only one angular momentum
         vector.
     alphas_a : np.ndarray(K_a,)
         Values of the (square root of the) precisions of the primitives on the left side.
@@ -48,7 +48,7 @@ def _compute_multipole_moment_integrals(
         Center of the contraction on the right side.
     angmoms_b : np.ndarray(L_b, 3)
         Angular momentum vectors (lx, ly, lz) for the contractions on the right side.
-        Note that two dimensional array must be given, even if there is only one angular momentum
+        Note that a two dimensional array must be given, even if there is only one angular momentum
         vector.
     alphas_b : np.ndarray(K_b,)
         Values of the (square root of the) precisions of the primitives on the right side.


### PR DESCRIPTION
Mainly just typos propagated through docstring for similar code. Only notable change was to be sure to correctly refer to the function `construct_array_contraction` without the s and `contractions_one`, etc. with the s. 