### PR TITLE
Add porcelain for evaluating basis set and their derivatives

### DIFF
--- a/gbasis/eval.py
+++ b/gbasis/eval.py
@@ -103,3 +103,71 @@ class Eval(BaseOneIndex):
             coords, np.zeros(3), center, angmom_comps, alphas, prim_coeffs, norm
         )
         return output
+
+
+def evaluate_basis_cartesian(basis, coords):
+    """Evaluate a basis set in the Cartesian form at the given coordinates.
+
+    Parameters
+    ----------
+    basis : list/tuple of ContractedCartesianGaussians
+        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
+    coords : np.ndarray(N, 3)
+        Points in space where the contractions are evaluated.
+
+    Returns
+    -------
+    eval_array : np.ndarray(K_cart, N)
+        Evaluations of the Cartesian contractions of the instance at the given coordinates.
+        `K_cart` is the total number of Cartesian contractions within the instance.
+        `N` is the number of coordinates at which the contractions are evaluated.
+
+    """
+    return Eval(basis).construct_array_cartesian(coords=coords)
+
+
+def evaluate_basis_spherical(basis, coords):
+    """Evaluate a basis set in the spherical form at the given coordinates.
+
+    Parameters
+    ----------
+    basis : list/tuple of ContractedCartesianGaussians
+        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
+    coords : np.ndarray(N, 3)
+        Points in space where the contractions are evaluated.
+
+    Returns
+    -------
+    eval_array : np.ndarray(K_sph, N)
+        Evaluations of the spherical contractions of the instance at the given coordinates.
+        `K_sph` is the total number of spherical contractions within the instance.
+        `N` is the number of coordinates at which the contractions are evaluated.
+
+    """
+    return Eval(basis).construct_array_spherical(coords=coords)
+
+
+def evaluate_basis_spherical_lincomb(basis, coords, transform):
+    """Evaluate a basis set in the spherical form at the given coordinates.
+
+    Parameters
+    ----------
+    basis : list/tuple of ContractedCartesianGaussians
+        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
+    coords : np.ndarray(N, 3)
+        Points in space where the contractions are evaluated.
+    transform : np.ndarray(K_orbs, K_sph)
+        Array associated with the linear combinations of spherical Gaussians (LCAO's).
+        Transformation is applied to the left, i.e. the sum is over the second index of `transform`
+        and first index of the array for contracted spherical Gaussians.
+
+    Returns
+    -------
+    eval_array : np.ndarray(K_orbs, N)
+        Evaluations of the linear combinations of spherical Gaussians (linear combinations of atomic
+        orbitals).
+        `K_orbs` is the number of basis functions produced after the linear combinations.
+        `N` is the number of coordinates at which the contractions are evaluated.
+
+    """
+    return Eval(basis).construct_array_spherical_lincomb(transform, coords=coords)

--- a/gbasis/eval_deriv.py
+++ b/gbasis/eval_deriv.py
@@ -117,3 +117,81 @@ class EvalDeriv(BaseOneIndex):
             coords, orders, center, angmom_comps, alphas, prim_coeffs, norm
         )
         return output
+
+
+def evaluate_deriv_basis_cartesian(basis, coords, orders):
+    """Evaluate a basis set in the Cartesian form at the given coordinates.
+
+    Parameters
+    ----------
+    basis : list/tuple of ContractedCartesianGaussians
+        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
+    coords : np.ndarray(N, 3)
+        Points in space where the contractions are evaluated.
+    orders : np.ndarray(3,)
+        Orders of the derivative.
+
+    Returns
+    -------
+    eval_array : np.ndarray(K_cart, N)
+        Evaluations of the derivatives of the Cartesian contractions of the instance at the given
+        coordinates.
+        `K_cart` is the total number of Cartesian contractions within the instance.
+        `N` is the number of coordinates at which the contractions are evaluated.
+
+    """
+    return EvalDeriv(basis).construct_array_cartesian(coords=coords, orders=orders)
+
+
+def evaluate_deriv_basis_spherical(basis, coords, orders):
+    """Evaluate a basis set in the spherical form at the given coordinates.
+
+    Parameters
+    ----------
+    basis : list/tuple of ContractedCartesianGaussians
+        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
+    coords : np.ndarray(N, 3)
+        Points in space where the contractions are evaluated.
+    orders : np.ndarray(3,)
+        Orders of the derivative.
+
+    Returns
+    -------
+    eval_array : np.ndarray(K_sph, N)
+        Evaluations of the derivatives of the spherical contractions of the instance at the given
+        coordinates.
+        `K_sph` is the total number of spherical contractions within the instance.
+        `N` is the number of coordinates at which the contractions are evaluated.
+
+    """
+    return EvalDeriv(basis).construct_array_spherical(coords=coords, orders=orders)
+
+
+def evaluate_deriv_basis_spherical_lincomb(basis, coords, orders, transform):
+    """Evaluate a basis set in the spherical form at the given coordinates.
+
+    Parameters
+    ----------
+    basis : list/tuple of ContractedCartesianGaussians
+        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
+    coords : np.ndarray(N, 3)
+        Points in space where the contractions are evaluated.
+    orders : np.ndarray(3,)
+        Orders of the derivative.
+    transform : np.ndarray(K_orbs, K_sph)
+        Array associated with the linear combinations of spherical Gaussians (LCAO's).
+        Transformation is applied to the left, i.e. the sum is over the second index of `transform`
+        and first index of the array for contracted spherical Gaussians.
+
+    Returns
+    -------
+    eval_array : np.ndarray(K_orbs, N)
+        Evaluations of derivatives of the linear combinations of spherical Gaussians (linear
+        combinations of atomic orbitals).
+        `K_orbs` is the number of basis functions produced after the linear combinations.
+        `N` is the number of coordinates at which the contractions are evaluated.
+
+    """
+    return EvalDeriv(basis).construct_array_spherical_lincomb(
+        transform, coords=coords, orders=orders
+    )

--- a/tests/test_contractions.py
+++ b/tests/test_contractions.py
@@ -1,11 +1,9 @@
 """Test gbasis.contractions."""
-import os
-
 from gbasis.contractions import ContractedCartesianGaussians, make_contractions
 from gbasis.parsers import parse_nwchem
 import numpy as np
 import pytest
-from utils import skip_init
+from utils import find_datafile, skip_init
 
 
 def test_charge_setter():
@@ -258,7 +256,7 @@ def test_num_contr():
 
 def test_make_contractions():
     """Test gbasis.contractions.make_contractions."""
-    with open(os.path.join(os.path.dirname(__file__), "data_sto6g.nwchem"), "r") as f:
+    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
         test_basis = f.read()
     basis_dict = parse_nwchem(test_basis)
     with pytest.raises(TypeError):

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -14,8 +14,8 @@ from scipy.special import factorial2
 from utils import find_datafile
 
 
-def test_eval_shell():
-    """Test gbasis.deriv.eval_shell."""
+def test_eval_construct_array_contraction():
+    """Test gbasis.eval.Eval.construct_array_contraction."""
     test = ContractedCartesianGaussians(
         1, np.array([0.5, 1, 1.5]), 0, np.array([1.0, 2.0]), np.array([0.1, 0.01])
     )

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,10 +1,17 @@
 """Test gbasis.eval."""
-from gbasis.contractions import ContractedCartesianGaussians
+from gbasis.contractions import ContractedCartesianGaussians, make_contractions
 from gbasis.deriv import _eval_deriv_contractions
-from gbasis.eval import Eval
+from gbasis.eval import (
+    Eval,
+    evaluate_basis_cartesian,
+    evaluate_basis_spherical,
+    evaluate_basis_spherical_lincomb,
+)
+from gbasis.parsers import parse_nwchem
 import numpy as np
 import pytest
 from scipy.special import factorial2
+from utils import find_datafile
 
 
 def test_eval_shell():
@@ -49,3 +56,72 @@ def test_eval_shell():
         Eval.construct_array_contraction(coords=np.array([2, 3, 4]), contractions=test)
     with pytest.raises(TypeError):
         Eval.construct_array_contraction(coords=np.array([[3, 4]]), contractions=test)
+
+
+def test_evaluate_basis_cartesian():
+    """Test gbasis.eval.evaluate_basis_cartesian."""
+    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
+        test_basis = f.read()
+    basis_dict = parse_nwchem(test_basis)
+    basis = make_contractions(basis_dict, ["H"], np.array([[0, 0, 0]]))
+    eval_obj = Eval(basis)
+    assert np.allclose(
+        eval_obj.construct_array_cartesian(coords=np.array([[0, 0, 0]])),
+        evaluate_basis_cartesian(basis, np.array([[0, 0, 0]])),
+    )
+
+
+def test_evaluate_basis_spherical():
+    """Test gbasis.eval.evaluate_basis_spherical."""
+    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
+        test_basis = f.read()
+    basis_dict = parse_nwchem(test_basis)
+
+    # cartesian and spherical are the same for s orbital
+    basis = make_contractions(basis_dict, ["H"], np.array([[0, 0, 0]]))
+    eval_obj = Eval(basis)
+    assert np.allclose(
+        eval_obj.construct_array_cartesian(coords=np.array([[0, 0, 0]])),
+        evaluate_basis_spherical(basis, np.array([[0, 0, 0]])),
+    )
+    # p orbitals are zero at center
+    basis = make_contractions(basis_dict, ["Li"], np.array([[0, 0, 0]]))
+    eval_obj = Eval(basis)
+    assert np.allclose(
+        eval_obj.construct_array_cartesian(coords=np.array([[0, 0, 0]])),
+        evaluate_basis_spherical(basis, np.array([[0, 0, 0]])),
+    )
+    # z dimension is untouched when transforming to spherical
+    assert np.allclose(
+        eval_obj.construct_array_cartesian(coords=np.array([[1, 0, 0]])),
+        evaluate_basis_spherical(basis, np.array([[1, 0, 0]])),
+    )
+    assert not np.allclose(
+        eval_obj.construct_array_cartesian(coords=np.array([[0, 0, 1]])),
+        evaluate_basis_spherical(basis, np.array([[0, 0, 1]])),
+    )
+    assert np.allclose(
+        eval_obj.construct_array_spherical(coords=np.array([[0, 0, 1]])),
+        evaluate_basis_spherical(basis, np.array([[0, 0, 1]])),
+    )
+
+    basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
+    eval_obj = Eval(basis)
+    assert np.allclose(
+        eval_obj.construct_array_spherical(coords=np.array([[1, 1, 1]])),
+        evaluate_basis_spherical(basis, np.array([[1, 1, 1]])),
+    )
+
+
+def test_evaluate_basis_spherical_lincomb():
+    """Test gbasis.eval.evaluate_basis_spherical_lincomb."""
+    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
+        test_basis = f.read()
+    basis_dict = parse_nwchem(test_basis)
+    basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
+    eval_obj = Eval(basis)
+    transform = np.random.rand(14, 18)
+    assert np.allclose(
+        eval_obj.construct_array_spherical_lincomb(transform, coords=np.array([[1, 1, 1]])),
+        evaluate_basis_spherical_lincomb(basis, np.array([[1, 1, 1]]), transform),
+    )

--- a/tests/test_eval_deriv.py
+++ b/tests/test_eval_deriv.py
@@ -17,7 +17,7 @@ from utils import find_datafile
 
 
 def test_eval_deriv_construct_array_contraction():
-    """Test gbasis.eval_deriv.EvalDeriv."""
+    """Test gbasis.eval_deriv.EvalDeriv.construct_array_contraction."""
     coords = np.array([[2, 3, 4]])
     orders = np.array([0, 0, 0])
     contractions = ContractedCartesianGaussians(

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,13 +1,12 @@
 """Test gbasis.parsers."""
-import os
-
 from gbasis.parsers import parse_nwchem
 import numpy as np
+from utils import find_datafile
 
 
 def test_parse_nwchem_sto6g():
     """Test gbasis.parsers.parse_nwchem for sto6g."""
-    with open(os.path.join(os.path.dirname(__file__), "data_sto6g.nwchem"), "r") as f:
+    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
         test_basis = f.read()
     test = parse_nwchem(test_basis)
     # test specific cases
@@ -199,7 +198,7 @@ def test_parse_nwchem_sto6g():
 
 def test_parse_nwchem_anorcc():
     """Test gbasis.parsers.parse_nwchem for anorcc."""
-    with open(os.path.join(os.path.dirname(__file__), "data_anorcc.nwchem"), "r") as f:
+    with open(find_datafile("data_anorcc.nwchem"), "r") as f:
         test_basis = f.read()
     test = parse_nwchem(test_basis)
     # test specific cases

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,6 @@
 """Utility functions for running tests."""
 import itertools as it
+import os
 
 import numpy as np
 
@@ -144,3 +145,26 @@ def test_finite_diff():
     assert np.allclose(test, func(x))
     test = partial_deriv_finite_diff(func, x, [0, 2], epsilon=1e-5, num_points=2)
     assert np.allclose(test, func(x))
+
+
+def find_datafile(file_name):
+    """Find data file from the current (tests) directory.
+
+    Parameters
+    ----------
+    file_name : str
+        Name of the file that is in the same directory as this module.
+
+    Returns
+    -------
+    file_path : str
+        Absolute path of the file.
+
+    Raises
+    ------
+    IOError
+        If file cannot be found.
+        If more than one file is found.
+
+    """
+    return os.path.join(os.path.dirname(__file__), file_name)


### PR DESCRIPTION
1. Add porcelain for evaluating the cartesian, spherical, and linear combinations of spherical forms of the basis set
2. Add porcelain for evaluating the derivatives of the cartesian, spherical, and linear combinations of spherical forms of the basis set
3. Add utility function for finding basis set from tests directory