### PR TITLE
Fix bug assigning tril blocks from triu blocks in BaseTwoIndexSymmetric

### DIFF
--- a/gbasis/base_two_symm.py
+++ b/gbasis/base_two_symm.py
@@ -176,7 +176,7 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
         all_blocks = np.zeros((num_blocks_side, num_blocks_side), dtype=object)
         all_blocks[np.triu_indices(num_blocks_side)] = triu_blocks
         all_blocks[np.tril_indices(num_blocks_side)] = [
-            np.swapaxes(block, 0, 1) for block in triu_blocks
+            np.swapaxes(block, 0, 1) for block in all_blocks.T[np.tril_indices(num_blocks_side)]
         ]
         # concatenate
         return np.concatenate(
@@ -248,7 +248,7 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
         all_blocks = np.zeros((num_blocks_side, num_blocks_side), dtype=object)
         all_blocks[np.triu_indices(num_blocks_side)] = triu_blocks
         all_blocks[np.tril_indices(num_blocks_side)] = [
-            np.swapaxes(block, 0, 1) for block in triu_blocks
+            np.swapaxes(block, 0, 1) for block in all_blocks.T[np.tril_indices(num_blocks_side)]
         ]
         # concatenate
         return np.concatenate(

--- a/tests/test_base_two_symm.py
+++ b/tests/test_base_two_symm.py
@@ -41,6 +41,12 @@ def test_contruct_array_contraction():
         Test([contractions])
 
 
+# TODO: test only involves four blocks. This is not big enough to catch the difference between the
+# ordering of the triu and tril indices. For example, triu_indices for a 3x3 matrix is 0, 1, 2, 4,
+# 5, 8 and tril_indices is 0, 3, 4, 6, 7, 8. We aim to assign the triu blocks to the tril blocks
+# after taking their transpose. To do so, the mapping from triu to tril indices is 0 -> 0, 1
+# -> 3, 2 -> 6, 4 -> 4, 5 -> 7, and 8 -> 8. The triu blocks cannot simply assigned in the same order
+# to the tril blocks because the ordering is different.
 def test_contruct_array_cartesian():
     """Test BaseTwoIndexSymmetric.construct_array_cartesian."""
     contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
@@ -210,6 +216,12 @@ def test_contruct_array_cartesian():
     )
 
 
+# TODO: test only involves four blocks. This is not big enough to catch the difference between the
+# ordering of the triu and tril indices. For example, triu_indices for a 3x3 matrix is 0, 1, 2, 4,
+# 5, 8 and tril_indices is 0, 3, 4, 6, 7, 8. We aim to assign the triu blocks to the tril blocks
+# after taking their transpose. To do so, the mapping from triu to tril indices is 0 -> 0, 1
+# -> 3, 2 -> 6, 4 -> 4, 5 -> 7, and 8 -> 8. The triu blocks cannot simply assigned in the same order
+# to the tril blocks because the ordering is different.
 def test_contruct_array_spherical():
     """Test BaseTwoIndexSymmetric.construct_array_spherical."""
     contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))


### PR DESCRIPTION
Each block within an overlap matrix (for cartesian and spherical) corresponds to
different contractions on the left side (row) and the right side (column). Since
the overlap is symmetric, we only need to compute the upper triangle blocks to
be able to construct the whole overlap matrix. To do so, I simply assigned the
tril blocks with the transpose of the corresponding triu blocks. However, I
didn't account for the fact that the ordering for the tril blocks is different
from the ordering of the triu blocks and I was using the same ordering for both
triu and tril blocks. Then, incorrect blocks are assigned to incorrect
positions, resulting in bad stack or wrong results.

To fix, blocks were ordered correctly and then assigned.

Issues:
We were unable to detect this bug in the tests because the overlap consisted of
only 4 blocks (2x2) which does not have this problem (same ordering for triu and
tril indices). The correct procedure is to add a better test (at least 9 blocks)
to catch this bug. However, these tests were quite painful to write (and I don't
want to do them) so I wrote some TODO's instead.