### PR TITLE
Add functions for evaluating density related arrays

### DIFF
--- a/gbasis/density.py
+++ b/gbasis/density.py
@@ -1,4 +1,5 @@
 """Density Evaluation."""
+from gbasis.eval import evaluate_basis_spherical_lincomb
 import numpy as np
 
 
@@ -56,3 +57,34 @@ def eval_density_using_evaluated_orbs(one_density_matrix, orb_eval):
     density = one_density_matrix.dot(orb_eval)
     density *= orb_eval
     return np.sum(density, axis=0)
+
+
+def eval_density_using_basis(one_density_matrix, basis, coords, transform):
+    """Return the density of the given transformed basis set at the given coordinates.
+
+    Parameters
+    ----------
+    one_density_matrix : np.ndarray(K_orb, K_orb)
+        One-electron density matrix.
+    basis : list/tuple of ContractedCartesianGaussians
+        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
+    coords : np.ndarray(N, 3)
+        Points in space where the contractions are evaluated.
+    transform : np.ndarray(K_orbs, K_sph)
+        Array associated with the linear combinations of spherical Gaussians (LCAO's).
+        Transformation is applied to the left, i.e. the sum is over the second index of `transform`
+        and first index of the array for contracted spherical Gaussians.
+
+    Returns
+    -------
+    density : np.ndarray(N,)
+        Density evaluated at different grid points.
+
+    Notes
+    -----
+    The transformation matrix corresponds to the spherical contractions. If your transformation
+    matrix corresponds to Cartesian contractions, please raise an issue.
+
+    """
+    orb_eval = evaluate_basis_spherical_lincomb(basis, coords, transform)
+    return eval_density_using_evaluated_orbs(one_density_matrix, orb_eval)

--- a/gbasis/density.py
+++ b/gbasis/density.py
@@ -61,7 +61,7 @@ def eval_density_using_evaluated_orbs(one_density_matrix, orb_eval):
     return np.sum(density, axis=0)
 
 
-def eval_density_using_basis(one_density_matrix, basis, coords, transform):
+def eval_density(one_density_matrix, basis, coords, transform):
     """Return the density of the given transformed basis set at the given coordinates.
 
     Parameters
@@ -92,7 +92,7 @@ def eval_density_using_basis(one_density_matrix, basis, coords, transform):
     return eval_density_using_evaluated_orbs(one_density_matrix, orb_eval)
 
 
-def eval_deriv_density_using_basis(orders, one_density_matrix, basis, coords, transform):
+def eval_deriv_density(orders, one_density_matrix, basis, coords, transform):
     """Return the derivative of density of the given transformed basis set at the given coordinates.
 
     Parameters
@@ -171,14 +171,8 @@ def eval_density_gradient(one_density_matrix, basis, coords, transform):
     """
     return np.array(
         [
-            eval_deriv_density_using_basis(
-                np.array([1, 0, 0]), one_density_matrix, basis, coords, transform
-            ),
-            eval_deriv_density_using_basis(
-                np.array([0, 1, 0]), one_density_matrix, basis, coords, transform
-            ),
-            eval_deriv_density_using_basis(
-                np.array([0, 0, 1]), one_density_matrix, basis, coords, transform
-            ),
+            eval_deriv_density(np.array([1, 0, 0]), one_density_matrix, basis, coords, transform),
+            eval_deriv_density(np.array([0, 1, 0]), one_density_matrix, basis, coords, transform),
+            eval_deriv_density(np.array([0, 0, 1]), one_density_matrix, basis, coords, transform),
         ]
     )

--- a/gbasis/density.py
+++ b/gbasis/density.py
@@ -2,56 +2,57 @@
 import numpy as np
 
 
-def eval_density(density_mat, orb_eval):
-    """Return the evaluation of the density at different points.
+def eval_density_using_evaluated_orbs(one_density_matrix, orb_eval):
+    """Return the evaluation of the density given the evaluated orbitals.
 
     Parameters
     ----------
-    density_mat : np.ndarray(L, L)
-        One electron density matrix.
-    orb_eval : {np.ndarray(L), np.ndarray(L, N), np.ndarray(L, N, N, N)}
-        Array of orbitals evaluated at different grid points.
-        The set of orbitals must be the same basis set used to build the charge density matrix.
+    one_density_matrix : np.ndarray(K_orb, K_orb)
+        One-electron density matrix.
+    orb_eval : np.ndarray(K_orb, N)
+        Orbitals evaluated at different grid points.
+        The set of orbitals must be the same basis set used to build the one-electron density
+        matrix.
 
     Returns
     -------
-    total_density : {np.ndarray(N, 1), np.ndarray(N, N, N)}
+    density : np.ndarray(N,)
         Density evaluated at different grid points.
-        Dimension of the density will match the dimension the grid part of orb_eval.
 
     Raises
     ------
     TypeError
-        If orb_eval is not an array of floats.
-        If density_mat is not an array of floats.
+        If orb_eval is not a 2-dimensional numpy array with dtype float.
+        If density_matrix is not a 2-dimensional numpy array with dtype float.
     ValueError
-        If density_mat is not a 2-dimensional matrix.
-        If first dimension of density_mat and orb_eval are not equal.
+        If one-electron density matrix is not square.
+        If the number of columns (or rows) of the one-electron density matrix is not equal to the
+        number of rows of the orbital evaluations.
 
     """
     # test that inputs have the correct shape and type
-    if not (isinstance(orb_eval, np.ndarray) and orb_eval.dtype == float):
-        raise TypeError("Evaluation of orbitals must be a numpy array of data type float.")
-    if not (isinstance(density_mat, np.ndarray) and density_mat.dtype == float):
-        raise TypeError("Density matrix must be a numpy array of data type float.")
-    if density_mat.ndim != 2 or density_mat.shape[0] != density_mat.shape[1]:
-        raise ValueError("Density matrix must be a square matrix.")
-    if density_mat.shape[0] != orb_eval.shape[0]:
-        raise ValueError("Size of 1st dimension of the density matrix and orbitals must match.")
+    if not (
+        isinstance(one_density_matrix, np.ndarray)
+        and one_density_matrix.ndim == 2
+        and one_density_matrix.dtype == float
+    ):
+        raise TypeError(
+            "One-electron density matrix must be a two-dimensional numpy array with dtype float."
+        )
+    if not (isinstance(orb_eval, np.ndarray) and orb_eval.ndim == 2 and orb_eval.dtype == float):
+        raise TypeError(
+            "Evaluation of orbitals must be a two-dimensional numpy array with dtype float."
+        )
+    if one_density_matrix.shape[0] != one_density_matrix.shape[1]:
+        raise ValueError("One-electron density matrix must be a square matrix.")
+    if not np.allclose(one_density_matrix, one_density_matrix.T):
+        raise ValueError("One-electron density matrix must be symmetric.")
+    if one_density_matrix.shape[0] != orb_eval.shape[0]:
+        raise ValueError(
+            "Number of rows (and columns) of the density matrix must be equal to the number of rows"
+            " of the orbital evaluations."
+        )
 
-    # resize orbital array to 2 dimensions
-    old_shape = orb_eval.shape
-    orb_eval.shape = (orb_eval.shape[0], np.prod(old_shape[1:]))
-
-    # evaluate partial density contributions
-    partial_density = (
-        orb_eval[np.newaxis, :] * orb_eval[:, np.newaxis] * density_mat[:, :, np.newaxis]
-    )
-
-    # sum over all orbital pairs
-    total_density = partial_density.sum(axis=(0, 1))
-
-    # resize density array
-    total_density.shape = old_shape[1:]
-
-    return total_density
+    density = one_density_matrix.dot(orb_eval)
+    density *= orb_eval
+    return np.sum(density, axis=0)

--- a/gbasis/density.py
+++ b/gbasis/density.py
@@ -145,3 +145,40 @@ def eval_deriv_density_using_basis(orders, one_density_matrix, basis, coords, tr
                 density = np.sum(density, axis=0)
                 output += factor * num_occurence * density
     return output
+
+
+def eval_density_gradient(one_density_matrix, basis, coords, transform):
+    """Return the gradient of the density evaluated at the given coordinates.
+
+    Parameters
+    ----------
+    one_density_matrix : np.ndarray(K_orb, K_orb)
+        One-electron density matrix.
+    basis : list/tuple of ContractedCartesianGaussians
+        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
+    coords : np.ndarray(N, 3)
+        Points in space where the contractions are evaluated.
+    transform : np.ndarray(K_orbs, K_sph)
+        Array associated with the linear combinations of spherical Gaussians (LCAO's).
+        Transformation is applied to the left, i.e. the sum is over the second index of `transform`
+        and first index of the array for contracted spherical Gaussians.
+
+    Returns
+    -------
+    density_gradient : np.ndarray(N,)
+        Gradient of the density evaluated at the given coordinates.
+
+    """
+    return np.array(
+        [
+            eval_deriv_density_using_basis(
+                np.array([1, 0, 0]), one_density_matrix, basis, coords, transform
+            ),
+            eval_deriv_density_using_basis(
+                np.array([0, 1, 0]), one_density_matrix, basis, coords, transform
+            ),
+            eval_deriv_density_using_basis(
+                np.array([0, 0, 1]), one_density_matrix, basis, coords, transform
+            ),
+        ]
+    )

--- a/gbasis/density.py
+++ b/gbasis/density.py
@@ -1,6 +1,8 @@
 """Density Evaluation."""
 from gbasis.eval import evaluate_basis_spherical_lincomb
+from gbasis.eval_deriv import evaluate_deriv_basis_spherical_lincomb
 import numpy as np
+from scipy.special import comb
 
 
 def eval_density_using_evaluated_orbs(one_density_matrix, orb_eval):
@@ -88,3 +90,58 @@ def eval_density_using_basis(one_density_matrix, basis, coords, transform):
     """
     orb_eval = evaluate_basis_spherical_lincomb(basis, coords, transform)
     return eval_density_using_evaluated_orbs(one_density_matrix, orb_eval)
+
+
+def eval_deriv_density_using_basis(orders, one_density_matrix, basis, coords, transform):
+    """Return the derivative of density of the given transformed basis set at the given coordinates.
+
+    Parameters
+    ----------
+    orders : np.ndarray(3,)
+        Orders of the derivative.
+    one_density_matrix : np.ndarray(K_orb, K_orb)
+        One-electron density matrix.
+    basis : list/tuple of ContractedCartesianGaussians
+        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
+    coords : np.ndarray(N, 3)
+        Points in space where the contractions are evaluated.
+    transform : np.ndarray(K_orbs, K_sph)
+        Array associated with the linear combinations of spherical Gaussians (LCAO's).
+        Transformation is applied to the left, i.e. the sum is over the second index of `transform`
+        and first index of the array for contracted spherical Gaussians.
+
+    Returns
+    -------
+    density_deriv : np.ndarray(N,)
+        Derivative of the density evaluated at different grid points.
+
+    """
+    # pylint: disable=R0914
+    total_l_x, total_l_y, total_l_z = orders
+
+    output = np.zeros(coords.shape[0])
+    for l_x in range(total_l_x // 2 + 1):
+        # prevent double counting for the middle of the even total_l_x
+        # e.g. If total_l_x == 4, then l_x is in [0, 1, 2, 3, 4]. Exploiting symmetry we only need
+        # to loop over [0, 1, 2] because l_x in [0, 4] and l_x in [1, 3] give the same result.
+        # However, l_x = 2 needs to avoid double counting.
+        if total_l_x % 2 == 0 and l_x == total_l_x / 2:
+            factor = 1
+        else:
+            factor = 2
+        for l_y in range(total_l_y + 1):
+            for l_z in range(total_l_z + 1):
+                num_occurence = comb(total_l_x, l_x) * comb(total_l_y, l_y) * comb(total_l_z, l_z)
+                orders_one = np.array([l_x, l_y, l_z])
+                orders_two = orders - orders_one
+                deriv_orb_eval_one = evaluate_deriv_basis_spherical_lincomb(
+                    basis, coords, orders_one, transform
+                )
+                deriv_orb_eval_two = evaluate_deriv_basis_spherical_lincomb(
+                    basis, coords, orders_two, transform
+                )
+                density = one_density_matrix.dot(deriv_orb_eval_two)
+                density *= deriv_orb_eval_one
+                density = np.sum(density, axis=0)
+                output += factor * num_occurence * density
+    return output

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -1,7 +1,12 @@
 """Test gbasis.density."""
 from gbasis.contractions import make_contractions
-from gbasis.density import eval_density_using_basis, eval_density_using_evaluated_orbs
+from gbasis.density import (
+    eval_density_using_basis,
+    eval_density_using_evaluated_orbs,
+    eval_deriv_density_using_basis,
+)
 from gbasis.eval import evaluate_basis_spherical_lincomb
+from gbasis.eval_deriv import evaluate_deriv_basis_spherical_lincomb
 from gbasis.parsers import parse_nwchem
 import numpy as np
 import pytest
@@ -66,4 +71,151 @@ def test_eval_density_using_basis():
     assert np.allclose(
         eval_density_using_basis(density, basis, coords, transform),
         np.einsum("ij,ik,jk->k", density, eval_orbs, eval_orbs),
+    )
+
+
+def test_eval_deriv_density_using_basis():
+    """Test gbasis.density.eval_deriv_density_using_basis."""
+    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
+        test_basis = f.read()
+    basis_dict = parse_nwchem(test_basis)
+    basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
+    transform = np.random.rand(14, 18)
+    density = np.random.rand(14, 14)
+    density += density.T
+    coords = np.random.rand(10, 3)
+
+    assert np.allclose(
+        eval_deriv_density_using_basis(np.array([1, 0, 0]), density, basis, coords, transform),
+        np.einsum(
+            "ij,ik,jk->k",
+            density,
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([1, 0, 0]), transform),
+            evaluate_basis_spherical_lincomb(basis, coords, transform),
+        )
+        + np.einsum(
+            "ij,ik,jk->k",
+            density,
+            evaluate_basis_spherical_lincomb(basis, coords, transform),
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([1, 0, 0]), transform),
+        ),
+    )
+
+    assert np.allclose(
+        eval_deriv_density_using_basis(np.array([0, 1, 0]), density, basis, coords, transform),
+        np.einsum(
+            "ij,ik,jk->k",
+            density,
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([0, 1, 0]), transform),
+            evaluate_basis_spherical_lincomb(basis, coords, transform),
+        )
+        + np.einsum(
+            "ij,ik,jk->k",
+            density,
+            evaluate_basis_spherical_lincomb(basis, coords, transform),
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([0, 1, 0]), transform),
+        ),
+    )
+
+    assert np.allclose(
+        eval_deriv_density_using_basis(np.array([0, 0, 1]), density, basis, coords, transform),
+        np.einsum(
+            "ij,ik,jk->k",
+            density,
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([0, 0, 1]), transform),
+            evaluate_basis_spherical_lincomb(basis, coords, transform),
+        )
+        + np.einsum(
+            "ij,ik,jk->k",
+            density,
+            evaluate_basis_spherical_lincomb(basis, coords, transform),
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([0, 0, 1]), transform),
+        ),
+    )
+
+    assert np.allclose(
+        eval_deriv_density_using_basis(np.array([2, 3, 0]), density, basis, coords, transform),
+        np.einsum(
+            "ij,ik,jk->k",
+            density,
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([0, 0, 0]), transform),
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([2, 3, 0]), transform),
+        )
+        + 3
+        * np.einsum(
+            "ij,ik,jk->k",
+            density,
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([0, 1, 0]), transform),
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([2, 2, 0]), transform),
+        )
+        + 3
+        * np.einsum(
+            "ij,ik,jk->k",
+            density,
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([0, 2, 0]), transform),
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([2, 1, 0]), transform),
+        )
+        + np.einsum(
+            "ij,ik,jk->k",
+            density,
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([0, 3, 0]), transform),
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([2, 0, 0]), transform),
+        )
+        + 2
+        * np.einsum(
+            "ij,ik,jk->k",
+            density,
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([1, 0, 0]), transform),
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([1, 3, 0]), transform),
+        )
+        + 2
+        * 3
+        * np.einsum(
+            "ij,ik,jk->k",
+            density,
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([1, 1, 0]), transform),
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([1, 2, 0]), transform),
+        )
+        + 2
+        * 3
+        * np.einsum(
+            "ij,ik,jk->k",
+            density,
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([1, 2, 0]), transform),
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([1, 1, 0]), transform),
+        )
+        + 2
+        * np.einsum(
+            "ij,ik,jk->k",
+            density,
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([1, 3, 0]), transform),
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([1, 0, 0]), transform),
+        )
+        + np.einsum(
+            "ij,ik,jk->k",
+            density,
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([2, 0, 0]), transform),
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([0, 3, 0]), transform),
+        )
+        + 3
+        * np.einsum(
+            "ij,ik,jk->k",
+            density,
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([2, 1, 0]), transform),
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([0, 2, 0]), transform),
+        )
+        + 3
+        * np.einsum(
+            "ij,ik,jk->k",
+            density,
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([2, 2, 0]), transform),
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([0, 1, 0]), transform),
+        )
+        + np.einsum(
+            "ij,ik,jk->k",
+            density,
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([2, 3, 0]), transform),
+            evaluate_deriv_basis_spherical_lincomb(basis, coords, np.array([0, 0, 0]), transform),
+        ),
+    )
     )

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -1,44 +1,47 @@
 """Test gbasis.density."""
-from gbasis.density import eval_density
+from gbasis.density import eval_density_using_evaluated_orbs
 import numpy as np
 import pytest
 
 
-def test_eval_density():
-    """Test gbasis.density.eval_density."""
-    density_mat = np.array([[1.0, 2.0], [3.0, 4.0]])
+def test_eval_density_using_evaluated_orbs():
+    """Test gbasis.density.eval_density_using_evaluated_orbs."""
+    density_mat = np.array([[1.0, 2.0], [2.0, 3.0]])
     orb_eval = np.array([[1.0], [2.0]])
-    assert np.allclose(eval_density(density_mat, orb_eval), np.array([27.0]))
-    density_mat = np.array([[1.0, 2.0], [3.0, 4.0]])
-    orb_eval = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
-    assert np.allclose(eval_density(density_mat, orb_eval), np.array([85.0, 154.0, 243.0]))
-    density_mat = np.array([[1.0, 2.0], [3.0, 4.0]])
-    orb_eval = np.array([[[1.0, 3.0, 5.0], [2.0, 4.0, 6.0]], [[7.0, 9.0, 11.0], [8.0, 10.0, 12.0]]])
     assert np.allclose(
-        eval_density(density_mat, orb_eval),
-        np.array([[232.0, 468.0, 784.0], [340.0, 616.0, 972.0]]),
+        eval_density_using_evaluated_orbs(density_mat, orb_eval),
+        np.einsum("ij,ik,jk->k", density_mat, orb_eval, orb_eval),
+    )
+    density_mat = np.array([[1.0, 2.0], [2.0, 3.0]])
+    orb_eval = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    assert np.allclose(
+        eval_density_using_evaluated_orbs(density_mat, orb_eval),
+        np.einsum("ij,ik,jk->k", density_mat, orb_eval, orb_eval),
     )
 
     with pytest.raises(TypeError):
         orb_eval = [[1.0, 2.0], [1.0, 2.0]]
-        eval_density(density_mat, orb_eval)
+        eval_density_using_evaluated_orbs(density_mat, orb_eval)
     with pytest.raises(TypeError):
         orb_eval = np.array([[1, 2], [1, 2]], dtype=bool)
-        eval_density(density_mat, orb_eval)
+        eval_density_using_evaluated_orbs(density_mat, orb_eval)
 
     orb_eval = np.array([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]])
     with pytest.raises(TypeError):
         density_mat = [[1.0, 2.0], [1.0, 2.0]]
-        eval_density(density_mat, orb_eval)
+        eval_density_using_evaluated_orbs(density_mat, orb_eval)
     with pytest.raises(TypeError):
         density_mat = np.array([[1, 2], [1, 2]], dtype=bool)
-        eval_density(density_mat, orb_eval)
-    with pytest.raises(ValueError):
+        eval_density_using_evaluated_orbs(density_mat, orb_eval)
+    with pytest.raises(TypeError):
         density_mat = np.array([1.0, 2.0, 3.0])
-        eval_density(density_mat, orb_eval)
+        eval_density_using_evaluated_orbs(density_mat, orb_eval)
     with pytest.raises(ValueError):
         density_mat = np.array([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]])
-        eval_density(density_mat, orb_eval)
+        eval_density_using_evaluated_orbs(density_mat, orb_eval)
     with pytest.raises(ValueError):
-        density_mat = np.array([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0], [1.0, 2.0, 3.0]])
-        eval_density(density_mat, orb_eval)
+        density_mat = np.array([[1.0, 2.0, 3.0], [2.0, 4.0, 5.0], [3.0, 5.0, 6.0]])
+        eval_density_using_evaluated_orbs(density_mat, orb_eval)
+    with pytest.raises(ValueError):
+        density_mat = np.array([[1.0, 2.0], [3.0, 4.0]])
+        eval_density_using_evaluated_orbs(density_mat, orb_eval)

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -1,7 +1,11 @@
 """Test gbasis.density."""
-from gbasis.density import eval_density_using_evaluated_orbs
+from gbasis.contractions import make_contractions
+from gbasis.density import eval_density_using_basis, eval_density_using_evaluated_orbs
+from gbasis.eval import evaluate_basis_spherical_lincomb
+from gbasis.parsers import parse_nwchem
 import numpy as np
 import pytest
+from utils import find_datafile
 
 
 def test_eval_density_using_evaluated_orbs():
@@ -45,3 +49,21 @@ def test_eval_density_using_evaluated_orbs():
     with pytest.raises(ValueError):
         density_mat = np.array([[1.0, 2.0], [3.0, 4.0]])
         eval_density_using_evaluated_orbs(density_mat, orb_eval)
+
+
+def test_eval_density_using_basis():
+    """Test gbasis.density.eval_density_using_basis."""
+    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
+        test_basis = f.read()
+    basis_dict = parse_nwchem(test_basis)
+    basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
+    transform = np.random.rand(14, 18)
+    density = np.random.rand(14, 14)
+    density += density.T
+    coords = np.random.rand(10, 3)
+
+    eval_orbs = evaluate_basis_spherical_lincomb(basis, coords, transform)
+    assert np.allclose(
+        eval_density_using_basis(density, basis, coords, transform),
+        np.einsum("ij,ik,jk->k", density, eval_orbs, eval_orbs),
+    )

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -1,10 +1,10 @@
 """Test gbasis.density."""
 from gbasis.contractions import make_contractions
 from gbasis.density import (
+    eval_density,
     eval_density_gradient,
-    eval_density_using_basis,
     eval_density_using_evaluated_orbs,
-    eval_deriv_density_using_basis,
+    eval_deriv_density,
 )
 from gbasis.eval import evaluate_basis_spherical_lincomb
 from gbasis.eval_deriv import evaluate_deriv_basis_spherical_lincomb
@@ -57,8 +57,8 @@ def test_eval_density_using_evaluated_orbs():
         eval_density_using_evaluated_orbs(density_mat, orb_eval)
 
 
-def test_eval_density_using_basis():
-    """Test gbasis.density.eval_density_using_basis."""
+def test_eval_density():
+    """Test gbasis.density.eval_density."""
     with open(find_datafile("data_sto6g.nwchem"), "r") as f:
         test_basis = f.read()
     basis_dict = parse_nwchem(test_basis)
@@ -70,13 +70,13 @@ def test_eval_density_using_basis():
 
     eval_orbs = evaluate_basis_spherical_lincomb(basis, coords, transform)
     assert np.allclose(
-        eval_density_using_basis(density, basis, coords, transform),
+        eval_density(density, basis, coords, transform),
         np.einsum("ij,ik,jk->k", density, eval_orbs, eval_orbs),
     )
 
 
-def test_eval_deriv_density_using_basis():
-    """Test gbasis.density.eval_deriv_density_using_basis."""
+def test_eval_deriv_density():
+    """Test gbasis.density.eval_deriv_density."""
     with open(find_datafile("data_sto6g.nwchem"), "r") as f:
         test_basis = f.read()
     basis_dict = parse_nwchem(test_basis)
@@ -87,7 +87,7 @@ def test_eval_deriv_density_using_basis():
     coords = np.random.rand(10, 3)
 
     assert np.allclose(
-        eval_deriv_density_using_basis(np.array([1, 0, 0]), density, basis, coords, transform),
+        eval_deriv_density(np.array([1, 0, 0]), density, basis, coords, transform),
         np.einsum(
             "ij,ik,jk->k",
             density,
@@ -103,7 +103,7 @@ def test_eval_deriv_density_using_basis():
     )
 
     assert np.allclose(
-        eval_deriv_density_using_basis(np.array([0, 1, 0]), density, basis, coords, transform),
+        eval_deriv_density(np.array([0, 1, 0]), density, basis, coords, transform),
         np.einsum(
             "ij,ik,jk->k",
             density,
@@ -119,7 +119,7 @@ def test_eval_deriv_density_using_basis():
     )
 
     assert np.allclose(
-        eval_deriv_density_using_basis(np.array([0, 0, 1]), density, basis, coords, transform),
+        eval_deriv_density(np.array([0, 0, 1]), density, basis, coords, transform),
         np.einsum(
             "ij,ik,jk->k",
             density,
@@ -135,7 +135,7 @@ def test_eval_deriv_density_using_basis():
     )
 
     assert np.allclose(
-        eval_deriv_density_using_basis(np.array([2, 3, 0]), density, basis, coords, transform),
+        eval_deriv_density(np.array([2, 3, 0]), density, basis, coords, transform),
         np.einsum(
             "ij,ik,jk->k",
             density,


### PR DESCRIPTION
What
--------
1. Add function for evaluating density from basis set (list/tuple of `ContractedCartesianGaussians`)
2. Add function for evaluating arbitrary order derivative of density from basis set (list/tuple of `ContractedCartesianGaussians`)
3. Add function for evaluating the gradient of density
4. Clean up existing density code

Why
------
1. Since basis set is the data object used for most methods, this function will make it easier to utilize these functions (i.e. `evaluate_basis_spherical_lincomb` and `evaluate_deriv_basis_spherical_lincomb`)
2. Arbitrary order derivative will be used to get higher order derivative of the density (e.g. gradient, Laplacian, second-derivative tensor, etc)
3. Example of an application of the arbitrary order derivative
4. For consistent API