### PR TITLE
Fix discrepancy in the usage of norm

### DIFF
--- a/gbasis/base_one.py
+++ b/gbasis/base_one.py
@@ -129,8 +129,7 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         for contraction in self.contractions:
             array = self.construct_array_contraction(contraction, **kwargs)
             # normalize contractions
-            norm_cont = contraction.norm_cont
-            array *= (norm_cont ** (-0.5)).reshape(*array.shape[:2], *[1 for i in array.shape[2:]])
+            array *= contraction.norm_cont.reshape(*array.shape[:2], *[1 for i in array.shape[2:]])
             # ASSUME array always has shape (M, L, ...)
             if array.shape[0] == 1:
                 matrices.append(np.squeeze(array, axis=0))

--- a/gbasis/base_two_asymm.py
+++ b/gbasis/base_two_asymm.py
@@ -174,12 +174,8 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
             for cont_two in self.contractions_two:
                 block = self.construct_array_contraction(cont_one, cont_two, **kwargs)
                 # normalize contractions
-                norm_cont_one = cont_one.norm_cont
-                norm_cont_two = cont_two.norm_cont
-                block *= (norm_cont_one ** (-0.5)).reshape(
-                    *block.shape[:2], *[1 for i in block.shape[2:]]
-                )
-                block *= (norm_cont_two ** (-0.5)).reshape(
+                block *= cont_one.norm_cont.reshape(*block.shape[:2], *[1 for i in block.shape[2:]])
+                block *= cont_two.norm_cont.reshape(
                     1, 1, *block.shape[2:4], *[1 for i in block.shape[4:]]
                 )
                 # assume array always has shape (M_1, L_1, M_2, L_2, ...)
@@ -236,12 +232,10 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
                 # evaluate
                 matrix_contraction = self.construct_array_contraction(cont_one, cont_two, **kwargs)
                 # normalize contractions
-                norm_cont_one = cont_one.norm_cont
-                norm_cont_two = cont_two.norm_cont
-                matrix_contraction *= (norm_cont_one ** (-0.5)).reshape(
+                matrix_contraction *= cont_one.norm_cont.reshape(
                     *matrix_contraction.shape[:2], *[1 for i in matrix_contraction.shape[2:]]
                 )
-                matrix_contraction *= (norm_cont_two ** (-0.5)).reshape(
+                matrix_contraction *= cont_two.norm_cont.reshape(
                     1, 1, *matrix_contraction.shape[2:4], *[1 for i in matrix_contraction.shape[4:]]
                 )
                 # transform

--- a/gbasis/base_two_symm.py
+++ b/gbasis/base_two_symm.py
@@ -156,12 +156,8 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
             for cont_two in self.contractions[i:]:
                 block = self.construct_array_contraction(cont_one, cont_two, **kwargs)
                 # normalize contractions
-                norm_cont_one = cont_one.norm_cont
-                norm_cont_two = cont_two.norm_cont
-                block *= (norm_cont_one ** (-0.5)).reshape(
-                    *block.shape[:2], *[1 for i in block.shape[2:]]
-                )
-                block *= (norm_cont_two ** (-0.5)).reshape(
+                block *= cont_one.norm_cont.reshape(*block.shape[:2], *[1 for i in block.shape[2:]])
+                block *= cont_two.norm_cont.reshape(
                     1, 1, *block.shape[2:4], *[1 for i in block.shape[4:]]
                 )
                 # assume array always has shape (M_1, L_1, M_2, L_2, ...)
@@ -230,12 +226,10 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
                 # evaluate
                 block_sph = self.construct_array_contraction(cont_one, cont_two, **kwargs)
                 # normalize contractions
-                norm_cont_one = cont_one.norm_cont
-                norm_cont_two = cont_two.norm_cont
-                block_sph *= (norm_cont_one ** (-0.5)).reshape(
+                block_sph *= cont_one.norm_cont.reshape(
                     *block_sph.shape[:2], *[1 for i in block_sph.shape[2:]]
                 )
-                block_sph *= (norm_cont_two ** (-0.5)).reshape(
+                block_sph *= cont_two.norm_cont.reshape(
                     1, 1, *block_sph.shape[2:4], *[1 for i in block_sph.shape[4:]]
                 )
                 # assume array has shape (M_1, L_1, M_2, L_2, ...)

--- a/gbasis/contractions.py
+++ b/gbasis/contractions.py
@@ -43,6 +43,8 @@ class ContractedCartesianGaussians:
         Exponents of the primitives, :math:`\{\alpha_i\}`.
     norm_prim : np.ndarray(L, K)
         The normalization constant for each Cartesian Gaussian primitive.
+    norm_const : np.ndarray(M, L)
+        Normalization constants of the contractions of each angular momentum.
     num_contr : int
         The number of Cartesian Gaussian primitives in the shell (L).
 
@@ -357,12 +359,17 @@ class ContractedCartesianGaussians:
         return (self.angmom + 1) * (self.angmom + 2) // 2
 
     def assign_norm_cont(self):
-        """Normalize the contractions to have an overlap of 1.
+        r"""Store the normalization constants of the contractions.
 
-        Returns
-        -------
-        norms : np.ndarray(M, L)
-            Norms of the contractions of the angular momentum of the instance.
+        .. math::
+
+            \int \phi_i(\mathbf{r}) \phi_i(\mathbf{r}) d\mathbf{r} &= N\\
+            \frac{1}{N} \int \phi_i(\mathbf{r}) \phi_i(\mathbf{r}) d\mathbf{r} &= 1\\
+            \int (\frac{1}{\sqrt{N}} \phi_i(\mathbf{r}))
+            (\frac{1}{\sqrt{N}} \phi_i(\mathbf{r})) d\mathbf{r} &= 1\\
+
+        where :math:`\phi_i` is a contraction and :math:`N` is the norm of the contraction (without
+        normalization).
 
         Notes
         -----
@@ -374,6 +381,7 @@ class ContractedCartesianGaussians:
         from gbasis.overlap import Overlap  # pylint: disable=R0401
 
         self.norm_cont = np.einsum("ijij->ij", Overlap.construct_array_contraction(self, self))
+        self.norm_cont **= -0.5
 
 
 def make_contractions(basis_dict, atoms, coords, charges=None):

--- a/tests/test_moment_int.py
+++ b/tests/test_moment_int.py
@@ -416,7 +416,7 @@ def test_compute_multipole_moment_integrals_prim_moment_recursion():
 
 
 def test_compute_multipole_moment_integrals_contraction_norm():
-    """Test moment_int._compute_multipole_moment_integrals using the norm of contractions.
+    """Test moment_int._compute_multipole_moment_integrals using the normalized contractions.
 
     Note
     ----


### PR DESCRIPTION
norm_prim is a normalization constant where as norm_cont was the norm of the
contration. Since the normalization constants is the important quantity, the
normalization constant is used as the convention.

What:
1. Turn norm_cont into a normalization constant
2. Fix documentation