### PR TITLE
Simplify method in base classes

### DIFF
--- a/gbasis/base_one.py
+++ b/gbasis/base_one.py
@@ -131,10 +131,7 @@ class BaseOneIndex(BaseGaussianRelatedArray):
             # normalize contractions
             array *= contraction.norm_cont.reshape(*array.shape[:2], *[1 for i in array.shape[2:]])
             # ASSUME array always has shape (M, L, ...)
-            if array.shape[0] == 1:
-                matrices.append(np.squeeze(array, axis=0))
-            else:
-                matrices.append(np.concatenate(array, axis=0))
+            matrices.append(np.concatenate(array, axis=0))
         return np.concatenate(matrices, axis=0)
 
     def construct_array_spherical(self, **kwargs):
@@ -168,12 +165,8 @@ class BaseOneIndex(BaseGaussianRelatedArray):
             )
             # transform
             # ASSUME array always has shape (M, L, ...)
-            if matrix_contraction.shape[0] == 1:
-                matrix_contraction = np.squeeze(matrix_contraction, axis=0)
-                matrix_contraction = np.tensordot(transform, matrix_contraction, (1, 0))
-            else:
-                matrix_contraction = np.tensordot(transform, matrix_contraction, (1, 1))
-                matrix_contraction = np.concatenate(np.swapaxes(matrix_contraction, 0, 1), axis=0)
+            matrix_contraction = np.tensordot(transform, matrix_contraction, (1, 1))
+            matrix_contraction = np.concatenate(np.swapaxes(matrix_contraction, 0, 1), axis=0)
             # store
             matrices_spherical.append(matrix_contraction)
 

--- a/gbasis/base_two_asymm.py
+++ b/gbasis/base_two_asymm.py
@@ -179,17 +179,11 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
                     1, 1, *block.shape[2:4], *[1 for i in block.shape[4:]]
                 )
                 # assume array always has shape (M_1, L_1, M_2, L_2, ...)
-                if block.shape[0] == 1:
-                    block = np.squeeze(block, axis=0)
-                else:
-                    block = np.concatenate(block, axis=0)
+                block = np.concatenate(block, axis=0)
                 # array now has shape (M_1 L_1, M_2, L_2, ...)
-                if block.shape[1] == 1:
-                    block = np.squeeze(block, axis=1)
-                else:
-                    block = np.swapaxes(np.swapaxes(block, 0, 1), 1, 2)
-                    block = np.concatenate(block, axis=0)
-                    block = np.swapaxes(block, 0, 1)
+                block = np.swapaxes(np.swapaxes(block, 0, 1), 1, 2)
+                block = np.concatenate(block, axis=0)
+                block = np.swapaxes(block, 0, 1)
                 # array now has shape (M_1 L_1, M_2 L_2, ...)
                 matrices_cols.append(block)
             matrices.append(np.concatenate(matrices_cols, axis=1))
@@ -240,24 +234,13 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
                 )
                 # transform
                 # assume array always has shape (M_1, L_1, M_2, L_2, ...)
-                if matrix_contraction.shape[0] == 1:
-                    matrix_contraction = np.squeeze(matrix_contraction, axis=0)
-                    matrix_contraction = np.tensordot(transform_one, matrix_contraction, (1, 0))
-                else:
-                    matrix_contraction = np.tensordot(transform_one, matrix_contraction, (1, 1))
-                    matrix_contraction = np.concatenate(
-                        np.swapaxes(matrix_contraction, 0, 1), axis=0
-                    )
+                matrix_contraction = np.tensordot(transform_one, matrix_contraction, (1, 1))
+                matrix_contraction = np.concatenate(np.swapaxes(matrix_contraction, 0, 1), axis=0)
                 # array now has shape (M_1 L_1, M_2, L_2, ...)
-                if matrix_contraction.shape[1] == 1:
-                    matrix_contraction = np.squeeze(matrix_contraction, axis=1)
-                    matrix_contraction = np.tensordot(transform_two, matrix_contraction, (1, 1))
-                    matrix_contraction = np.swapaxes(matrix_contraction, 0, 1)
-                else:
-                    matrix_contraction = np.tensordot(transform_two, matrix_contraction, (1, 2))
-                    matrix_contraction = np.swapaxes(np.swapaxes(matrix_contraction, 0, 1), 0, 2)
-                    matrix_contraction = np.concatenate(matrix_contraction, axis=0)
-                    matrix_contraction = np.swapaxes(matrix_contraction, 0, 1)
+                matrix_contraction = np.tensordot(transform_two, matrix_contraction, (1, 2))
+                matrix_contraction = np.swapaxes(np.swapaxes(matrix_contraction, 0, 1), 0, 2)
+                matrix_contraction = np.concatenate(matrix_contraction, axis=0)
+                matrix_contraction = np.swapaxes(matrix_contraction, 0, 1)
                 # array now has shape (M_1 L_1, M_2 L_2, ...)
                 # store
                 matrices_spherical_cols.append(matrix_contraction)

--- a/gbasis/base_two_symm.py
+++ b/gbasis/base_two_symm.py
@@ -161,17 +161,11 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
                     1, 1, *block.shape[2:4], *[1 for i in block.shape[4:]]
                 )
                 # assume array always has shape (M_1, L_1, M_2, L_2, ...)
-                if block.shape[0] == 1:
-                    block = np.squeeze(block, axis=0)
-                else:
-                    block = np.concatenate(block, axis=0)
+                block = np.concatenate(block, axis=0)
                 # array now has shape (M_1 L_1, M_2, L_2, ...)
-                if block.shape[1] == 1:
-                    block = np.squeeze(block, axis=1)
-                else:
-                    block = np.swapaxes(np.swapaxes(block, 0, 1), 1, 2)
-                    block = np.concatenate(block, axis=0)
-                    block = np.swapaxes(block, 0, 1)
+                block = np.swapaxes(np.swapaxes(block, 0, 1), 1, 2)
+                block = np.concatenate(block, axis=0)
+                block = np.swapaxes(block, 0, 1)
                 # array now has shape (M_1 L_1, M_2 L_2, ...)
                 triu_blocks.append(block)
         # use numpy triu and tril indices to create blocks
@@ -234,22 +228,13 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
                 )
                 # assume array has shape (M_1, L_1, M_2, L_2, ...)
                 # transform
-                if block_sph.shape[0] == 1:
-                    block_sph = np.squeeze(block_sph, axis=0)
-                    block_sph = np.tensordot(transform_one, block_sph, (1, 0))
-                else:
-                    block_sph = np.tensordot(transform_one, block_sph, (1, 1))
-                    block_sph = np.concatenate(np.swapaxes(block_sph, 0, 1), axis=0)
+                block_sph = np.tensordot(transform_one, block_sph, (1, 1))
+                block_sph = np.concatenate(np.swapaxes(block_sph, 0, 1), axis=0)
                 # array now has shape (M_1 L_1, M_2, L_2, ...)
-                if block_sph.shape[1] == 1:
-                    block_sph = np.squeeze(block_sph, axis=1)
-                    block_sph = np.tensordot(transform_two, block_sph, (1, 1))
-                    block_sph = np.swapaxes(block_sph, 0, 1)
-                else:
-                    block_sph = np.tensordot(transform_two, block_sph, (1, 2))
-                    block_sph = np.swapaxes(np.swapaxes(block_sph, 0, 1), 0, 2)
-                    block_sph = np.concatenate(block_sph, axis=0)
-                    block_sph = np.swapaxes(block_sph, 0, 1)
+                block_sph = np.tensordot(transform_two, block_sph, (1, 2))
+                block_sph = np.swapaxes(np.swapaxes(block_sph, 0, 1), 0, 2)
+                block_sph = np.concatenate(block_sph, axis=0)
+                block_sph = np.swapaxes(block_sph, 0, 1)
                 # array now has shape (M_1 L_1, M_2 L_2, ...)
                 # store
                 triu_blocks.append(block_sph)


### PR DESCRIPTION
Since each matrix associated with the contracted Cartesian Gaussians is a two
dimensional matrix, we do not need to treat matrices differently regardless of
the number of rows. We can remove the if statement for matrices with one row
vector.

Removing this if statement might make it easier for numba (or some other jit's)
to optimize the code