### PR TITLE
Add convenient properties to ContractedCartesianGaussians

### DIFF
--- a/gbasis/contractions.py
+++ b/gbasis/contractions.py
@@ -45,8 +45,10 @@ class ContractedCartesianGaussians:
         The normalization constant for each Cartesian Gaussian primitive.
     norm_const : np.ndarray(M, L)
         Normalization constants of the contractions of each angular momentum.
-    num_contr : int
-        The number of Cartesian Gaussian primitives in the shell (L).
+    num_cart : int
+        The number of Cartesian contracted Gaussians in the shell of angular momentum, :math:`l`.
+    num_sph : int
+        The number of spherical contracted Gaussian in the shell of angular momentum, :math:`l`.
 
     Methods
     -------
@@ -347,16 +349,28 @@ class ContractedCartesianGaussians:
         )
 
     @property
-    def num_contr(self):
+    def num_cart(self):
         """Return the number of Cartesian contracted Gaussian functions of given angular momentum.
 
         Returns
         -------
-        num_contr : int
-            Number of contracted Cartesian Gaussian functions of angular momentum, :math:`angmom`.
+        num_cart : int
+            Number of contracted Cartesian Gaussian functions of angular momentum, `angmom`.
 
         """
         return (self.angmom + 1) * (self.angmom + 2) // 2
+
+    @property
+    def num_sph(self):
+        """Return the number of spherical contracted Gaussian functions of given angular momentum.
+
+        Returns
+        -------
+        num_sph : int
+            Number of spherical Cartesian Gaussian functions of angular momentum, `angmom`.
+
+        """
+        return 1 + 2 * self.angmom
 
     def assign_norm_cont(self):
         r"""Store the normalization constants of the contractions.

--- a/gbasis/contractions.py
+++ b/gbasis/contractions.py
@@ -372,6 +372,18 @@ class ContractedCartesianGaussians:
         """
         return 1 + 2 * self.angmom
 
+    @property
+    def num_seg_cont(self):
+        """Return the number of segmented contractions.
+
+        Returns
+        -------
+        num_seg_cont : int
+            Number of segmented contractions.
+
+        """
+        return self.coeffs.shape[1]
+
     def assign_norm_cont(self):
         r"""Store the normalization constants of the contractions.
 

--- a/gbasis/electrostatic_potential.py
+++ b/gbasis/electrostatic_potential.py
@@ -3,24 +3,19 @@ from gbasis.point_charge import point_charge_cartesian, point_charge_mix, point_
 import numpy as np
 
 
-# FIXME: check if density_matrix has the right shape. otherwise, hartree potential needs to be
-# obtained first, which is quite expensive
 def _electrostatic_potential_base(
-    base_func,
     basis,
     density_matrix,
     coords_points,
     nuclear_coords,
     nuclear_charges,
-    coord_types=None,
+    coord_type,
     threshold_dist=0.0,
 ):
     """Return the electrostatic potentials of the basis set in the Cartesian form.
 
     Parameters
     ----------
-    base_func : {point_charge_cartesian, point_charge_spherical}
-        Function.
     basis : list/tuple of ContractedCartesianGaussians
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     density_matrix : np.ndarray(K, K)
@@ -33,14 +28,17 @@ def _electrostatic_potential_base(
         Rows correspond to the atoms and columns correspond to the x, y, and z components.
     nuclear_charges : np.ndarray(N_nuc)
         Charges of each atom.
+    coord_type : {"cartesian", "spherical", list/tuple of "cartesian" or "spherical"}
+        Types of the coordinate system for the contractions.
+        If "cartesian", then all of the contractions are treated as Cartesian contractions.
+        If "spherical", then all of the contractions are treated as spherical contractions.
+        If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
+        coordinate type of each ContractedCartesianGaussians instance.
     threshold_dist : {float, 0.0}
         Threshold for rejecting nuclei whose distances to the points are less than the provided
         value. i.e. nuclei that are closer to the point than the threshold are discarded when
         computing the electrostatic potential of the point.
         Default value is 0.0, i.e. no nuclei are discarded.
-    coord_types : {list/tuple of str, None}
-        Types of the coordinate system for each ContractedCartesianGaussians.
-        Each entry must be one of "cartesian" or "spherical".
 
     Returns
     -------
@@ -71,6 +69,7 @@ def _electrostatic_potential_base(
     `gbasis.electrostatic_potential_electrostatic_potential_sphrical`.
 
     """
+    # pylint: disable=R0912
     if not (isinstance(density_matrix, np.ndarray) and density_matrix.ndim == 2):
         raise TypeError("`density_matrix_cart` must be given as a two-dimensional numpy array.")
     if not (
@@ -97,11 +96,44 @@ def _electrostatic_potential_base(
     if threshold_dist < 0:
         raise ValueError("`threshold_dist` must be greater than or equal to zero.")
 
-    if coord_types is None:
-        hartree_potential = base_func(basis, coords_points, -np.ones(coords_points.shape[0]))
+    if coord_type == "cartesian":
+        if sum(cont.num_cart * cont.num_seg_cont for cont in basis) != density_matrix.shape[0]:
+            raise ValueError(
+                "`density_matrix` does not have number of rows/columns that is equal to the total "
+                "number of Cartesian contractions (atomic orbitals)."
+            )
+        hartree_potential = point_charge_cartesian(
+            basis, coords_points, -np.ones(coords_points.shape[0])
+        )
+    elif coord_type == "spherical":
+        if sum(cont.num_sph * cont.num_seg_cont for cont in basis) != density_matrix.shape[0]:
+            raise ValueError(
+                "`density_matrix` does not have number of rows/columns that is equal to the total "
+                "number of spherical contractions (atomic orbitals)."
+            )
+        hartree_potential = point_charge_spherical(
+            basis, coords_points, -np.ones(coords_points.shape[0])
+        )
+    elif isinstance(coord_type, (list, tuple)):
+        if (
+            sum(
+                cont.num_sph * cont.num_seg_cont
+                if j == "spherical"
+                else cont.num_cart * cont.num_seg_cont
+                for cont, j in zip(basis, coord_type)
+            )
+            != density_matrix.shape[0]
+        ):
+            raise ValueError(
+                "`density_matrix` does not have number of rows/columns that is equal to the total "
+                "number of contractions in the given coordinate systems (atomic orbitals)."
+            )
+        hartree_potential = point_charge_mix(
+            basis, coords_points, -np.ones(coords_points.shape[0]), coord_types=coord_type
+        )
     else:
-        hartree_potential = base_func(
-            basis, coords_points, -np.ones(coords_points.shape[0]), coord_types=coord_types
+        raise TypeError(
+            "`coord_type` must be 'spherical', 'cartesian', or a list/tuple of these strings."
         )
     hartree_potential *= density_matrix[:, :, None]
     hartree_potential = np.sum(hartree_potential, axis=(0, 1))
@@ -176,12 +208,12 @@ def electrostatic_potential_cartesian(
 
     """
     return _electrostatic_potential_base(
-        point_charge_cartesian,
         basis,
         density_matrix_cart,
         coords_points,
         nuclear_coords,
         nuclear_charges,
+        "cartesian",
         threshold_dist=threshold_dist,
     )
 
@@ -240,12 +272,12 @@ def electrostatic_potential_spherical(
 
     """
     return _electrostatic_potential_base(
-        point_charge_spherical,
         basis,
         density_matrix_sph,
         coords_points,
         nuclear_coords,
         nuclear_charges,
+        "spherical",
         threshold_dist=threshold_dist,
     )
 
@@ -314,7 +346,6 @@ def electrostatic_potential_mix(
 
     """
     return _electrostatic_potential_base(
-        point_charge_mix,
         basis,
         density_matrix_mix,
         coords_points,

--- a/gbasis/electrostatic_potential.py
+++ b/gbasis/electrostatic_potential.py
@@ -123,7 +123,7 @@ def _electrostatic_potential_base(
 
 
 def electrostatic_potential_cartesian(
-    basis, density_matrix_cart, coords_points, nuclear_coords, nuclear_charges
+    basis, density_matrix_cart, coords_points, nuclear_coords, nuclear_charges, threshold_dist=0.0
 ):
     """Return the electrostatic potentials of the basis set in the Cartesian form.
 
@@ -141,6 +141,11 @@ def electrostatic_potential_cartesian(
         Rows correspond to the atoms and columns correspond to the x, y, and z components.
     nuclear_charges : np.ndarray(N_nuc)
         Charges of each atom.
+    threshold_dist : {float, 0.0}
+        Threshold for rejecting nuclei whose distances to the points are less than the provided
+        value. i.e. nuclei that are closer to the point than the threshold are discarded when
+        computing the electrostatic potential of the point.
+        Default value is 0.0, i.e. no nuclei are discarded.
 
     Returns
     -------
@@ -177,11 +182,12 @@ def electrostatic_potential_cartesian(
         coords_points,
         nuclear_coords,
         nuclear_charges,
+        threshold_dist=threshold_dist,
     )
 
 
 def electrostatic_potential_spherical(
-    basis, density_matrix_sph, coords_points, nuclear_coords, nuclear_charges
+    basis, density_matrix_sph, coords_points, nuclear_coords, nuclear_charges, threshold_dist=0.0
 ):
     """Return the electrostatic potentials of the basis set in the spherical form.
 
@@ -199,6 +205,11 @@ def electrostatic_potential_spherical(
         Rows correspond to the atoms and columns correspond to the x, y, and z components.
     nuclear_charges : np.ndarray(N_nuc)
         Charges of each atom.
+    threshold_dist : {float, 0.0}
+        Threshold for rejecting nuclei whose distances to the points are less than the provided
+        value. i.e. nuclei that are closer to the point than the threshold are discarded when
+        computing the electrostatic potential of the point.
+        Default value is 0.0, i.e. no nuclei are discarded.
 
     Returns
     -------
@@ -235,11 +246,18 @@ def electrostatic_potential_spherical(
         coords_points,
         nuclear_coords,
         nuclear_charges,
+        threshold_dist=threshold_dist,
     )
 
 
 def electrostatic_potential_mix(
-    basis, density_matrix_mix, coords_points, nuclear_coords, nuclear_charges, coord_types
+    basis,
+    density_matrix_mix,
+    coords_points,
+    nuclear_coords,
+    nuclear_charges,
+    coord_types,
+    threshold_dist=0.0,
 ):
     """Return the electrostatic potentials of the basis set in the given coordinate systems.
 
@@ -260,6 +278,11 @@ def electrostatic_potential_mix(
     coord_types : list/tuple of str
         Types of the coordinate system for each ContractedCartesianGaussians.
         Each entry must be one of "cartesian" or "spherical".
+    threshold_dist : {float, 0.0}
+        Threshold for rejecting nuclei whose distances to the points are less than the provided
+        value. i.e. nuclei that are closer to the point than the threshold are discarded when
+        computing the electrostatic potential of the point.
+        Default value is 0.0, i.e. no nuclei are discarded.
 
     Returns
     -------
@@ -298,4 +321,5 @@ def electrostatic_potential_mix(
         nuclear_coords,
         nuclear_charges,
         coord_types,
+        threshold_dist=threshold_dist,
     )

--- a/tests/test_base_two_symm.py
+++ b/tests/test_base_two_symm.py
@@ -73,15 +73,15 @@ def test_contruct_array_cartesian():
         BaseTwoIndexSymmetric,
         dict_overwrite={
             "construct_array_contraction": lambda self, cont_one, cont_two, a=2: (
-                np.arange(cont_one.num_contr * cont_two.num_contr, dtype=float).reshape(
-                    1, cont_one.num_contr, 1, cont_two.num_contr
+                np.arange(cont_one.num_cart * cont_two.num_cart, dtype=float).reshape(
+                    1, cont_one.num_cart, 1, cont_two.num_cart
                 )
                 * a
             )
         },
     )
-    cont_one.norm_cont = np.ones((1, cont_one.num_contr))
-    cont_two.norm_cont = np.ones((1, cont_two.num_contr))
+    cont_one.norm_cont = np.ones((1, cont_one.num_cart))
+    cont_two.norm_cont = np.ones((1, cont_two.num_cart))
     test = Test([cont_one, cont_two])
     assert np.allclose(
         test.construct_array_cartesian(),
@@ -106,8 +106,8 @@ def test_contruct_array_cartesian():
         BaseTwoIndexSymmetric,
         dict_overwrite={
             "construct_array_contraction": lambda self, cont_one, cont_two, a=2: (
-                np.arange(cont_one.num_contr * cont_two.num_contr * 2, dtype=float).reshape(
-                    1, cont_one.num_contr, 1, cont_two.num_contr, 2
+                np.arange(cont_one.num_cart * cont_two.num_cart * 2, dtype=float).reshape(
+                    1, cont_one.num_cart, 1, cont_two.num_cart, 2
                 )
                 * a
             )
@@ -162,22 +162,22 @@ def test_contruct_array_cartesian():
             # NOTE: assume that cont_one and cont_two will always be cont_one and cont_two defined
             # above
             "construct_array_contraction": lambda self, cont_one, cont_two, a=2: np.arange(
-                2 * cont_one.num_contr * 2 * cont_two.num_contr, dtype=float
-            ).reshape(2, cont_one.num_contr, 2, cont_two.num_contr)
+                2 * cont_one.num_cart * 2 * cont_two.num_cart, dtype=float
+            ).reshape(2, cont_one.num_cart, 2, cont_two.num_cart)
             * a
         },
     )
-    cont_one.norm_cont = np.ones((2, cont_one.num_contr))
-    cont_two.norm_cont = np.ones((2, cont_two.num_contr))
+    cont_one.norm_cont = np.ones((2, cont_one.num_cart))
+    cont_two.norm_cont = np.ones((2, cont_two.num_cart))
     test = Test([cont_one, cont_two])
-    matrix_11 = np.arange(2 * cont_one.num_contr * 2 * cont_one.num_contr).reshape(
-        2, cont_one.num_contr, 2, cont_one.num_contr
+    matrix_11 = np.arange(2 * cont_one.num_cart * 2 * cont_one.num_cart).reshape(
+        2, cont_one.num_cart, 2, cont_one.num_cart
     )
-    matrix_12 = np.arange(2 * cont_one.num_contr * 2 * cont_two.num_contr).reshape(
-        2, cont_one.num_contr, 2, cont_two.num_contr
+    matrix_12 = np.arange(2 * cont_one.num_cart * 2 * cont_two.num_cart).reshape(
+        2, cont_one.num_cart, 2, cont_two.num_cart
     )
-    matrix_22 = np.arange(2 * cont_two.num_contr * 2 * cont_two.num_contr).reshape(
-        2, cont_two.num_contr, 2, cont_two.num_contr
+    matrix_22 = np.arange(2 * cont_two.num_cart * 2 * cont_two.num_cart).reshape(
+        2, cont_two.num_cart, 2, cont_two.num_cart
     )
     assert np.allclose(
         test.construct_array_cartesian(),
@@ -263,15 +263,15 @@ def test_contruct_array_spherical():
         BaseTwoIndexSymmetric,
         dict_overwrite={
             "construct_array_contraction": lambda self, cont_one, cont_two, a=2: (
-                np.arange(cont_one.num_contr * cont_two.num_contr * 2, dtype=float).reshape(
-                    1, cont_one.num_contr, 1, cont_two.num_contr, 2
+                np.arange(cont_one.num_cart * cont_two.num_cart * 2, dtype=float).reshape(
+                    1, cont_one.num_cart, 1, cont_two.num_cart, 2
                 )
                 * a
             )
         },
     )
-    cont_one.norm_cont = np.ones((1, cont_one.num_contr))
-    cont_two.norm_cont = np.ones((1, cont_two.num_contr))
+    cont_one.norm_cont = np.ones((1, cont_one.num_cart))
+    cont_two.norm_cont = np.ones((1, cont_two.num_cart))
     test = Test([cont_one, cont_two])
     assert np.allclose(
         test.construct_array_spherical(a=4),
@@ -324,29 +324,29 @@ def test_contruct_array_spherical():
         BaseTwoIndexSymmetric,
         dict_overwrite={
             "construct_array_contraction": lambda self, cont_one, cont_two, a=2: (
-                np.arange(2 * cont_one.num_contr * 2 * cont_two.num_contr, dtype=float).reshape(
-                    2, cont_one.num_contr, 2, cont_two.num_contr
+                np.arange(2 * cont_one.num_cart * 2 * cont_two.num_cart, dtype=float).reshape(
+                    2, cont_one.num_cart, 2, cont_two.num_cart
                 )
                 * a
             )
         },
     )
-    cont_one.norm_cont = np.ones((2, cont_one.num_contr))
-    cont_two.norm_cont = np.ones((2, cont_two.num_contr))
+    cont_one.norm_cont = np.ones((2, cont_one.num_cart))
+    cont_two.norm_cont = np.ones((2, cont_two.num_cart))
     test = Test([cont_one, cont_two])
 
-    matrix_11 = np.arange(2 * cont_one.num_contr * 2 * cont_one.num_contr).reshape(
-        2, cont_one.num_contr, 2, cont_one.num_contr
+    matrix_11 = np.arange(2 * cont_one.num_cart * 2 * cont_one.num_cart).reshape(
+        2, cont_one.num_cart, 2, cont_one.num_cart
     )
     matrix_11 = np.swapaxes(np.tensordot(transform_one, matrix_11, (1, 1)), 0, 1)
     matrix_11 = np.moveaxis(np.tensordot(transform_one, matrix_11, (1, 3)), 0, 3)
-    matrix_12 = np.arange(2 * cont_one.num_contr * 2 * cont_two.num_contr).reshape(
-        2, cont_one.num_contr, 2, cont_two.num_contr
+    matrix_12 = np.arange(2 * cont_one.num_cart * 2 * cont_two.num_cart).reshape(
+        2, cont_one.num_cart, 2, cont_two.num_cart
     )
     matrix_12 = np.swapaxes(np.tensordot(transform_one, matrix_12, (1, 1)), 0, 1)
     matrix_12 = np.moveaxis(np.tensordot(transform_two, matrix_12, (1, 3)), 0, 3)
-    matrix_22 = np.arange(2 * cont_two.num_contr * 2 * cont_two.num_contr).reshape(
-        2, cont_two.num_contr, 2, cont_two.num_contr
+    matrix_22 = np.arange(2 * cont_two.num_cart * 2 * cont_two.num_cart).reshape(
+        2, cont_two.num_cart, 2, cont_two.num_cart
     )
     matrix_22 = np.swapaxes(np.tensordot(transform_two, matrix_22, (1, 1)), 0, 1)
     matrix_22 = np.moveaxis(np.tensordot(transform_two, matrix_22, (1, 3)), 0, 3)
@@ -422,8 +422,8 @@ def test_contruct_array_mix():
         BaseTwoIndexSymmetric,
         dict_overwrite={
             "construct_array_contraction": lambda self, cont_one, cont_two, a=2: (
-                np.arange(cont_one.num_contr * cont_two.num_contr * 2, dtype=float).reshape(
-                    1, cont_one.num_contr, 1, cont_two.num_contr, 2
+                np.arange(cont_one.num_cart * cont_two.num_cart * 2, dtype=float).reshape(
+                    1, cont_one.num_cart, 1, cont_two.num_cart, 2
                 )
                 * a
             )
@@ -447,15 +447,15 @@ def test_contruct_array_mix():
         BaseTwoIndexSymmetric,
         dict_overwrite={
             "construct_array_contraction": lambda self, cont_one, cont_two, a=2: (
-                np.arange(2 * cont_one.num_contr * 2 * cont_two.num_contr, dtype=float).reshape(
-                    2, cont_one.num_contr, 2, cont_two.num_contr
+                np.arange(2 * cont_one.num_cart * 2 * cont_two.num_cart, dtype=float).reshape(
+                    2, cont_one.num_cart, 2, cont_two.num_cart
                 )
                 * a
             )
         },
     )
-    cont_one.norm_cont = np.ones((2, cont_one.num_contr))
-    cont_two.norm_cont = np.ones((2, cont_two.num_contr))
+    cont_one.norm_cont = np.ones((2, cont_one.num_cart))
+    cont_two.norm_cont = np.ones((2, cont_two.num_cart))
     test = Test([cont_one, cont_two])
     assert np.allclose(
         test.construct_array_spherical(), test.construct_array_mix(["spherical"] * 2)
@@ -533,8 +533,8 @@ def test_contruct_array_lincomb():
         BaseTwoIndexSymmetric,
         dict_overwrite={
             "construct_array_contraction": lambda self, cont_one, cont_two, a=2: (
-                np.arange(cont_one.num_contr * cont_two.num_contr * 2, dtype=float).reshape(
-                    1, cont_one.num_contr, 1, cont_two.num_contr, 2
+                np.arange(cont_one.num_cart * cont_two.num_cart * 2, dtype=float).reshape(
+                    1, cont_one.num_cart, 1, cont_two.num_cart, 2
                 )
                 * a
             )
@@ -542,8 +542,8 @@ def test_contruct_array_lincomb():
     )
     cont_one = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     cont_two = ContractedCartesianGaussians(2, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
-    cont_one.norm_cont = np.ones((1, cont_one.num_contr))
-    cont_two.norm_cont = np.ones((1, cont_two.num_contr))
+    cont_one.norm_cont = np.ones((1, cont_one.num_cart))
+    cont_two.norm_cont = np.ones((1, cont_two.num_cart))
     test = Test([cont_one, cont_two])
     sph_transform_one = generate_transformation(1, cont_one.angmom_components, "left")
     sph_transform_two = generate_transformation(2, cont_two.angmom_components, "left")
@@ -689,8 +689,8 @@ def test_compare_two_asymm():
 
     def construct_array_contraction(self, cont_one, cont_two, a=2):
         """Temporary symmetric function for testing."""
-        one_size = cont_one.num_contr
-        two_size = cont_two.num_contr
+        one_size = cont_one.num_cart
+        two_size = cont_two.num_cart
         output = (
             np.arange(one_size)[None, :, None, None, None]
             + np.arange(two_size)[None, None, None, :, None]
@@ -706,8 +706,8 @@ def test_compare_two_asymm():
         BaseTwoIndexAsymmetric,
         dict_overwrite={"construct_array_contraction": construct_array_contraction},
     )
-    cont_one.norm_cont = np.ones((1, cont_one.num_contr))
-    cont_two.norm_cont = np.ones((1, cont_two.num_contr))
+    cont_one.norm_cont = np.ones((1, cont_one.num_cart))
+    cont_two.norm_cont = np.ones((1, cont_two.num_cart))
 
     test_symm = TestSymmetric([cont_one, cont_two])
     test_asymm = TestAsymmetric([cont_one, cont_two], [cont_one, cont_two])

--- a/tests/test_contractions.py
+++ b/tests/test_contractions.py
@@ -264,6 +264,13 @@ def test_num_sph():
         last_num_sph = test.num_sph + 2
 
 
+def test_num_seg_cont():
+    """Test ContractedCartesianGaussians.num_seg_cont."""
+    test = skip_init(ContractedCartesianGaussians)
+    test._coeffs = np.random.rand(10, 21)
+    assert test.num_seg_cont == 21
+
+
 def test_make_contractions():
     """Test gbasis.contractions.make_contractions."""
     with open(find_datafile("data_sto6g.nwchem"), "r") as f:

--- a/tests/test_contractions.py
+++ b/tests/test_contractions.py
@@ -244,14 +244,24 @@ def test_norm_prim():
     assert np.isclose(test.norm_prim[7], 0.6920252830162908851679097)
 
 
-def test_num_contr():
-    """Test ContractedCartesianGaussians.num_contr."""
+def test_num_cart():
+    """Test ContractedCartesianGaussians.num_cart."""
     test = skip_init(ContractedCartesianGaussians)
-    last_num_contr = 0
+    last_num_cart = 0
     for i in range(100):
         test._angmom = i
-        assert test.num_contr == last_num_contr + i + 1
-        last_num_contr = test.num_contr
+        assert test.num_cart == last_num_cart + i + 1
+        last_num_cart = test.num_cart
+
+
+def test_num_sph():
+    """Test ContractedCartesianGaussians.num_sph."""
+    test = skip_init(ContractedCartesianGaussians)
+    last_num_sph = 1
+    for i in range(100):
+        test._angmom = i
+        assert test.num_sph == last_num_sph
+        last_num_sph = test.num_sph + 2
 
 
 def test_make_contractions():

--- a/tests/test_electrostatic_potential.py
+++ b/tests/test_electrostatic_potential.py
@@ -7,7 +7,6 @@ from gbasis.electrostatic_potential import (
     electrostatic_potential_spherical,
 )
 from gbasis.parsers import parse_nwchem
-from gbasis.point_charge import point_charge_cartesian
 import numpy as np
 import pytest
 from utils import find_datafile, HortonContractions
@@ -29,101 +28,138 @@ def test_electrostatic_potential_base():
     # check density_matrix type
     with pytest.raises(TypeError):
         _electrostatic_potential_base(
-            point_charge_cartesian,
             basis,
             np.identity(103).tolist(),
             np.random.rand(10, 3),
             np.random.rand(2, 3),
             np.array([1, 2]),
+            "cartesian",
         )
     with pytest.raises(TypeError):
         _electrostatic_potential_base(
-            point_charge_cartesian,
             basis,
             np.identity(103).flatten(),
             np.random.rand(10, 3),
             np.random.rand(2, 3),
             np.array([1, 2]),
+            "cartesian",
         )
     # check nuclear_coords
     with pytest.raises(TypeError):
         _electrostatic_potential_base(
-            point_charge_cartesian,
             basis,
             np.identity(103),
             np.random.rand(10, 3),
             np.random.rand(2, 3).tolist(),
             np.array([1, 2]),
+            "cartesian",
         )
     with pytest.raises(TypeError):
         _electrostatic_potential_base(
-            point_charge_cartesian,
             basis,
             np.identity(103),
             np.random.rand(10, 3),
             np.random.rand(2, 4),
             np.array([1, 2]),
+            "cartesian",
         )
     # check nuclear charges
     with pytest.raises(TypeError):
         _electrostatic_potential_base(
-            point_charge_cartesian,
             basis,
             np.identity(103),
             np.random.rand(10, 3),
             np.random.rand(2, 3),
             np.array([1, 2]).reshape(1, 2),
+            "cartesian",
         )
     with pytest.raises(TypeError):
         _electrostatic_potential_base(
-            point_charge_cartesian,
             basis,
             np.identity(103),
             np.random.rand(10, 3),
             np.random.rand(2, 3),
             np.array([1, 2]).tolist(),
+            "cartesian",
         )
     # check density_matrix symmetry
     with pytest.raises(ValueError):
         _electrostatic_potential_base(
-            point_charge_cartesian,
             basis,
             np.eye(103, 102),
             np.random.rand(10, 3),
             np.random.rand(2, 3),
             np.array([1, 2]),
+            "cartesian",
         )
     # check nuclear_coords and nuclear_charges shapes
     with pytest.raises(ValueError):
         _electrostatic_potential_base(
-            point_charge_cartesian,
             basis,
             np.identity(103),
             np.random.rand(10, 3),
             np.random.rand(3, 3),
             np.array([1, 2]),
+            "cartesian",
         )
     # check threshold_dist types
     with pytest.raises(TypeError):
         _electrostatic_potential_base(
-            point_charge_cartesian,
             basis,
             np.identity(103),
             np.random.rand(10, 3),
             np.random.rand(2, 3),
             np.array([1, 2]),
+            "cartesian",
             threshold_dist=None,
         )
     # check threshold_dist value
     with pytest.raises(ValueError):
         _electrostatic_potential_base(
-            point_charge_cartesian,
             basis,
             np.identity(103),
             np.random.rand(10, 3),
             np.random.rand(2, 3),
             np.array([1, 2]),
+            "cartesian",
             threshold_dist=-0.1,
+        )
+    # check coord_types type
+    with pytest.raises(TypeError):
+        _electrostatic_potential_base(
+            basis,
+            np.identity(103),
+            np.random.rand(10, 3),
+            np.random.rand(2, 3),
+            np.array([1, 2]),
+            "bad",
+        )
+    with pytest.raises(ValueError):
+        _electrostatic_potential_base(
+            basis,
+            np.identity(88),
+            np.random.rand(10, 3),
+            np.random.rand(2, 3),
+            np.array([1, 2]),
+            "cartesian",
+        )
+    with pytest.raises(ValueError):
+        _electrostatic_potential_base(
+            basis,
+            np.identity(103),
+            np.random.rand(10, 3),
+            np.random.rand(2, 3),
+            np.array([1, 2]),
+            "spherical",
+        )
+    with pytest.raises(ValueError):
+        _electrostatic_potential_base(
+            basis,
+            np.identity(103),
+            np.random.rand(10, 3),
+            np.random.rand(2, 3),
+            np.array([1, 2]),
+            ["spherical"] * 9,
         )
 
 


### PR DESCRIPTION
1. Add `num_cart` for number of cartesian contractions
2. Add `num_sph` for number of spherical contractions
3. Add `num_seg_cont` for number of segmented contractions
4. Use these properties to check the shape of the density matrix when computing the electrostatic potential