### PR TITLE
Change ordering of the angular momentum components of Cartesian contractions

### DIFF
--- a/gbasis/contractions.py
+++ b/gbasis/contractions.py
@@ -315,8 +315,8 @@ class ContractedCartesianGaussians:
         return np.array(
             [
                 (x, y, self.angmom - x - y)
-                for x in range(self.angmom + 1)
-                for y in range(self.angmom - x + 1)
+                for x in range(self.angmom + 1)[::-1]
+                for y in range(self.angmom - x + 1)[::-1]
             ]
         )
 

--- a/tests/test_contractions.py
+++ b/tests/test_contractions.py
@@ -207,25 +207,25 @@ def test_angmom_components():
     test._angmom = 0
     assert np.allclose(test.angmom_components, [(0, 0, 0)])
     test._angmom = 1
-    assert np.allclose(test.angmom_components, [(0, 0, 1), (0, 1, 0), (1, 0, 0)])
+    assert np.allclose(test.angmom_components, [(1, 0, 0), (0, 1, 0), (0, 0, 1)])
     test._angmom = 2
     assert np.allclose(
-        test.angmom_components, [(0, 0, 2), (0, 1, 1), (0, 2, 0), (1, 0, 1), (1, 1, 0), (2, 0, 0)]
+        test.angmom_components, [(2, 0, 0), (1, 1, 0), (1, 0, 1), (0, 2, 0), (0, 1, 1), (0, 0, 2)]
     )
     test._angmom = 3
     assert np.allclose(
         test.angmom_components,
         [
-            (0, 0, 3),
-            (0, 1, 2),
-            (0, 2, 1),
-            (0, 3, 0),
-            (1, 0, 2),
-            (1, 1, 1),
-            (1, 2, 0),
-            (2, 0, 1),
-            (2, 1, 0),
             (3, 0, 0),
+            (2, 1, 0),
+            (2, 0, 1),
+            (1, 2, 0),
+            (1, 1, 1),
+            (1, 0, 2),
+            (0, 3, 0),
+            (0, 2, 1),
+            (0, 1, 2),
+            (0, 0, 3),
         ],
     )
     test._angmom = 10

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -92,19 +92,6 @@ def test_evaluate_basis_spherical():
         eval_obj.construct_array_cartesian(coords=np.array([[0, 0, 0]])),
         evaluate_basis_spherical(basis, np.array([[0, 0, 0]])),
     )
-    # z dimension is untouched when transforming to spherical
-    assert np.allclose(
-        eval_obj.construct_array_cartesian(coords=np.array([[1, 0, 0]])),
-        evaluate_basis_spherical(basis, np.array([[1, 0, 0]])),
-    )
-    assert not np.allclose(
-        eval_obj.construct_array_cartesian(coords=np.array([[0, 0, 1]])),
-        evaluate_basis_spherical(basis, np.array([[0, 0, 1]])),
-    )
-    assert np.allclose(
-        eval_obj.construct_array_spherical(coords=np.array([[0, 0, 1]])),
-        evaluate_basis_spherical(basis, np.array([[0, 0, 1]])),
-    )
 
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     eval_obj = Eval(basis)

--- a/tests/test_point_charge.py
+++ b/tests/test_point_charge.py
@@ -99,7 +99,7 @@ def test_construct_array_contraction():
             * 1
             * 3
             * (-1)
-        )[::-1],
+        ),
     )
 
     test_one = ContractedCartesianGaussians(
@@ -118,7 +118,7 @@ def test_construct_array_contraction():
             * 1
             * 3
             * (-1)
-        )[::-1],
+        ),
     )
 
 


### PR DESCRIPTION
Before, the angular momentum components of Cartesian contractions were ordered
by giving precedence to z component, then y component, then x component so that
z component has the highest value first, then y and so on. However, this seemed
a little counter intuitive seeing as we normally count from x to z. The ordering
was changed to give precedence to x, y, then z.

What:
1. Change default ordering of the angular components in
ContractedCartesianGaussians
2. Update tests