### PR TITLE
Polish up contractions data class

### DIFF
--- a/gbasis/_one_elec_int.py
+++ b/gbasis/_one_elec_int.py
@@ -64,7 +64,7 @@ def _compute_one_elec_integrals(
     Returns
     -------
     integrals : np.ndarray(L_a + 1, L_a + 1, L_a + 1, L_b + 1, L_b + 1, L_b + 1, M_a, M_b)
-        One electron integrals for the given `ContractedCartesianGaussian` instances.
+        One electron integrals for the given `GeneralizedContractionShell` instances.
         First, second, and third index correspond to the `x`, `y`, and `z` components of the
         angular momentum for contraction a.
         Fourth, fifth, and sixth index correspond to the `x`, `y`, and `z` components of the

--- a/gbasis/base.py
+++ b/gbasis/base.py
@@ -1,7 +1,7 @@
 """Base class for arrays that depend on one or more contracted Gaussians."""
 import abc
 
-from gbasis.contractions import ContractedCartesianGaussians
+from gbasis.contractions import GeneralizedContractionShell
 
 
 class BaseGaussianRelatedArray(abc.ABC):
@@ -9,16 +9,16 @@ class BaseGaussianRelatedArray(abc.ABC):
 
     Attributes
     ----------
-    _axes_contractions : tuple of tuple of ContractedCartesianGaussians
+    _axes_contractions : tuple of tuple of GeneralizedContractionShell
         Contractions that are associated with each index of the array.
-        Each tuple of ContractedCartesianGaussians corresponds to an index of the array.
+        Each tuple of GeneralizedContractionShell corresponds to an index of the array.
 
     Methods
     -------
     __init__(self, *axes_contractions)
         Initialize.
     construct_array_contraction(self, *contraction, **kwargs) : np.ndarray
-        Return the array associated with a `ContractedCartesianGaussians` instance.
+        Return the array associated with a `GeneralizedContractionShell` instance.
     construct_array_cartesian(self, **kwargs) : np.ndarray
         Return the array associated with Cartesian Gaussians.
     construct_array_spherical(self, **kwargs) : np.ndarray
@@ -34,14 +34,14 @@ class BaseGaussianRelatedArray(abc.ABC):
 
         Parameters
         ----------
-        contractions : list/tuple of ContractedCartesianGaussians
+        contractions : list/tuple of GeneralizedContractionShell
             Contractions that are associated with each index of the array.
             First contractions is associated with the first index, etc.
 
         Raises
         ------
         TypeError
-            If `axes_contractions` is not given as a list or tuple of ContractedCartesianGaussians.
+            If `axes_contractions` is not given as a list or tuple of GeneralizedContractionShell.
         ValueError
             If `axes_contractions` is an empty list or tuple.
 
@@ -49,15 +49,15 @@ class BaseGaussianRelatedArray(abc.ABC):
         for each_contractions in contractions:
             if not isinstance(each_contractions, (list, tuple)):
                 raise TypeError(
-                    "Contractions must be given as a list or tuple of ContractedCartesianGaussians "
+                    "Contractions must be given as a list or tuple of GeneralizedContractionShell "
                     "instance"
                 )
             if not each_contractions:
-                raise ValueError("At least one `ContractedCartesianGaussians` must be given.")
+                raise ValueError("At least one `GeneralizedContractionShell` must be given.")
             for contraction in each_contractions:
-                if not isinstance(contraction, ContractedCartesianGaussians):
+                if not isinstance(contraction, GeneralizedContractionShell):
                     raise TypeError(
-                        "Given contractions must be instances of the ContractedCartesianGaussians "
+                        "Given contractions must be instances of the GeneralizedContractionShell "
                         "class."
                     )
         self._axes_contractions = tuple(
@@ -70,7 +70,7 @@ class BaseGaussianRelatedArray(abc.ABC):
 
         Parameters
         ----------
-        contractions : ContractedCartesianGaussians
+        contractions : GeneralizedContractionShell
             Contracted Cartesian Gaussians (of the same shell) that will be used to construct an
             array.
             Note that multiple instances may be needed to construct the array.
@@ -80,12 +80,12 @@ class BaseGaussianRelatedArray(abc.ABC):
         Returns
         -------
         array_contraction : np.ndarray
-            Array associated with the given instance(s) of ContractedCartesianGaussians.
+            Array associated with the given instance(s) of GeneralizedContractionShell.
 
         Notes
         -----
         The next level of classes will be divided by number of indices associated with
-        ContractedCartesianGaussians. Then this method's parameters will likely be different from
+        GeneralizedContractionShell. Then this method's parameters will likely be different from
         it's children. This means that using this method's API blindly (by simply copying and
         pasting) will not be suitable for all its children. Here, we allow arbitrary number of
         `contractions` to indicate that its children may have different number of `contractions` in
@@ -134,7 +134,7 @@ class BaseGaussianRelatedArray(abc.ABC):
         Parameters
         ----------
         coord_types : list/tuple of str
-            Types of the coordinate system for each ContractedCartesianGaussians.
+            Types of the coordinate system for each GeneralizedContractionShell.
             Each entry must be one of "cartesian" or "spherical".
         kwargs : dict
             Other keyword arguments that will be used to construct the array.
@@ -162,7 +162,7 @@ class BaseGaussianRelatedArray(abc.ABC):
             If "cartesian", then all of the contractions are treated as Cartesian contractions.
             If "spherical", then all of the contractions are treated as spherical contractions.
             If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-            coordinate type of each ContractedCartesianGaussians instance.
+            coordinate type of each GeneralizedContractionShell instance.
         kwargs : dict
             Other keyword arguments that will be used to construct the array.
 
@@ -175,7 +175,7 @@ class BaseGaussianRelatedArray(abc.ABC):
         Notes
         -----
         The next level of classes will be divided by number of indices associated with
-        ContractedCartesianGaussians. Then this method's parameters will likely be different from
+        GeneralizedContractionShell. Then this method's parameters will likely be different from
         it's children. This means that using this method's API blindly (by simply copying and
         pasting) will not be suitable for all its children. Here, we allow arbitrary number of
         `transform` to indicate that its children may have different number of `transform` in

--- a/gbasis/base_one.py
+++ b/gbasis/base_one.py
@@ -160,7 +160,7 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         for cont in self.contractions:
             # get transformation from cartesian to spherical (applied to left)
             transform = generate_transformation(
-                cont.angmom, cont.angmom_components, cont.spherical_order, "left"
+                cont.angmom, cont.angmom_components_cart, cont.angmom_components_sph, "left"
             )
             # evaluate the function at the given points
             matrix_contraction = self.construct_array_contraction(cont, **kwargs)
@@ -223,7 +223,7 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         for cont, coord_type in zip(self.contractions, coord_types):
             # get transformation from cartesian to spherical (applied to left)
             transform = generate_transformation(
-                cont.angmom, cont.angmom_components, cont.spherical_order, "left"
+                cont.angmom, cont.angmom_components_cart, cont.angmom_components_sph, "left"
             )
             # evaluate the function at the given points
             matrix_contraction = self.construct_array_contraction(cont, **kwargs)

--- a/gbasis/base_one.py
+++ b/gbasis/base_one.py
@@ -15,13 +15,13 @@ class BaseOneIndex(BaseGaussianRelatedArray):
 
     Attributes
     ----------
-    _axes_contractions : tuple of tuple of ContractedCartesianGaussians
+    _axes_contractions : tuple of tuple of GeneralizedContractionShell
         Contractions that are associated with each index of the array.
-        Each tuple of ContractedCartesianGaussians corresponds to an index of the array.
+        Each tuple of GeneralizedContractionShell corresponds to an index of the array.
 
     Properties
     ----------
-    contractions : tuple of ContractedCartesianGaussians
+    contractions : tuple of GeneralizedContractionShell
         Contractions that are associated with the first index of the array.
 
     Methods
@@ -29,7 +29,7 @@ class BaseOneIndex(BaseGaussianRelatedArray):
     __init__(self, contractions)
         Initialize.
     construct_array_contraction(self, contraction) : np.ndarray(M, L_cart, ...)
-        Return the array associated with a `ContractedCartesianGaussians` instance.
+        Return the array associated with a `GeneralizedContractionShell` instance.
         `M` is the number of segmented contractions with the same exponents (and angular momentum).
         `L_cart` is the number of Cartesian contractions for the given angular momentum.
     construct_array_cartesian(self) : np.ndarray(K_cart, ...)
@@ -53,7 +53,7 @@ class BaseOneIndex(BaseGaussianRelatedArray):
 
         Parameters
         ----------
-        contractions : list/tuple of ContractedCartesianGaussians
+        contractions : list/tuple of GeneralizedContractionShell
             Contractions that are associated with the first index of the array.
 
         """
@@ -65,7 +65,7 @@ class BaseOneIndex(BaseGaussianRelatedArray):
 
         Returns
         -------
-        contractions : tuple of ContractedCartesianGaussians
+        contractions : tuple of GeneralizedContractionShell
             Contractions that are associated with the first index of the array.
 
         """
@@ -77,7 +77,7 @@ class BaseOneIndex(BaseGaussianRelatedArray):
 
         Parameters
         ----------
-        contractions : ContractedCartesianGaussians
+        contractions : GeneralizedContractionShell
             Contracted Cartesian Gaussians (of the same shell) that will be used to construct an
             array.
         kwargs : dict
@@ -86,7 +86,7 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         Returns
         -------
         array_contraction : np.ndarray(M, L_cart, ...)
-            Array associated with the given instance(s) of ContractedCartesianGaussians.
+            Array associated with the given instance(s) of GeneralizedContractionShell.
             First index corresponds to segmented contractions within the given generalized
             contraction (same exponents and angular momentum, but different coefficients). `M` is
             the number of segmented contractions with the same exponents (and angular momentum).
@@ -183,7 +183,7 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         Parameters
         ----------
         coord_types : list/tuple of str
-            Types of the coordinate system for each ContractedCartesianGaussians.
+            Types of the coordinate system for each GeneralizedContractionShell.
             Each entry must be one of "cartesian" or "spherical".
         kwargs : dict
             Other keyword arguments that will be used to construct the array.
@@ -204,7 +204,7 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         ValueError
             If `coord_types` has an entry that is not "cartesian" or "spherical".
             If `coord_types` has different number of entries as the number of
-            ContractedCartesianGaussians (`contractions`) in instance.
+            GeneralizedContractionShell (`contractions`) in instance.
 
         """
         if not isinstance(coord_types, (list, tuple)):
@@ -216,7 +216,7 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         if len(coord_types) != len(self.contractions):
             raise ValueError(
                 "`coord_types` must have the same number of entries as the number of "
-                "ContractedCartesianGaussians in the instance."
+                "GeneralizedContractionShell in the instance."
             )
 
         matrices = []
@@ -263,7 +263,7 @@ class BaseOneIndex(BaseGaussianRelatedArray):
             If "cartesian", then all of the contractions are treated as Cartesian contractions.
             If "spherical", then all of the contractions are treated as spherical contractions.
             If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-            coordinate type of each ContractedCartesianGaussians instance.
+            coordinate type of each GeneralizedContractionShell instance.
         kwargs : dict
             Other keyword arguments that will be used to construct the array.
             These keyword arguments are passed directly to `construct_array_spherical`, which will

--- a/gbasis/base_one.py
+++ b/gbasis/base_one.py
@@ -159,7 +159,9 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         matrices_spherical = []
         for cont in self.contractions:
             # get transformation from cartesian to spherical (applied to left)
-            transform = generate_transformation(cont.angmom, cont.angmom_components, "left")
+            transform = generate_transformation(
+                cont.angmom, cont.angmom_components, cont.spherical_order, "left"
+            )
             # evaluate the function at the given points
             matrix_contraction = self.construct_array_contraction(cont, **kwargs)
             # normalize contractions
@@ -220,7 +222,9 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         matrices = []
         for cont, coord_type in zip(self.contractions, coord_types):
             # get transformation from cartesian to spherical (applied to left)
-            transform = generate_transformation(cont.angmom, cont.angmom_components, "left")
+            transform = generate_transformation(
+                cont.angmom, cont.angmom_components, cont.spherical_order, "left"
+            )
             # evaluate the function at the given points
             matrix_contraction = self.construct_array_contraction(cont, **kwargs)
             # normalize contractions

--- a/gbasis/base_two_asymm.py
+++ b/gbasis/base_two_asymm.py
@@ -16,14 +16,14 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
 
     Attributes
     ----------
-    _axes_contractions : tuple of tuple of ContractedCartesianGaussians
+    _axes_contractions : tuple of tuple of GeneralizedContractionShell
         Sets of contractions associated with each axis of the array.
 
     Properties
     ----------
-    contractions_one : tuple of ContractedCartesianGaussians
+    contractions_one : tuple of GeneralizedContractionShell
         Contractions that are associated with the first index of the array.
-    contractions_two : tuple of ContractedCartesianGaussians
+    contractions_two : tuple of GeneralizedContractionShell
         Contractions that are associated with the second index of the array.
 
     Methods
@@ -32,7 +32,7 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
         Initialize.
     construct_array_contraction(self, contractions_one, contractions_two, **kwargs) :
     np.ndarray(M_1, L_cart_1, M_2, L_cart_2, ...)
-        Return the array associated with a `ContractedCartesianGaussians` instance.
+        Return the array associated with a `GeneralizedContractionShell` instance.
         `M_1` is the number of segmented contractions with the same exponents (and angular momentum)
         associated with the first index.
         `L_cart_1` is the number of Cartesian contractions for the given angular momentum associated
@@ -65,9 +65,9 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
 
         Parameters
         ----------
-        contractions_one : list/tuple of ContractedCartesianGaussians
+        contractions_one : list/tuple of GeneralizedContractionShell
             Contractions that are associated with the first index of the array.
-        contractions_two : list/tuple of ContractedCartesianGaussians
+        contractions_two : list/tuple of GeneralizedContractionShell
             Contractions that are associated with the second index of the array.
 
         """
@@ -79,7 +79,7 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
 
         Returns
         -------
-        contractions_one : tuple of ContractedCartesianGaussians
+        contractions_one : tuple of GeneralizedContractionShell
             Contractions that are associated with the first index of the array.
 
         """
@@ -91,7 +91,7 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
 
         Returns
         -------
-        contractions_two : tuple of ContractedCartesianGaussians
+        contractions_two : tuple of GeneralizedContractionShell
             Contractions that are associated with the second index of the array.
 
         """
@@ -103,10 +103,10 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
 
         Parameters
         ----------
-        contractions_one : ContractedCartesianGaussians
+        contractions_one : GeneralizedContractionShell
             Contracted Cartesian Gaussians (of the same shell) associated with the first index of
             the array.
-        contractions_two : ContractedCartesianGaussians
+        contractions_two : GeneralizedContractionShell
             Contracted Cartesian Gaussians (of the same shell) associated with the second index of
             the array.
         kwargs : dict
@@ -115,7 +115,7 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
         Returns
         -------
         array_contraction : np.ndarray(M_1, L_cart_1, M_2, L_cart_2, ...)
-            Array associated with the given instance(s) of ContractedCartesianGaussians.
+            Array associated with the given instance(s) of GeneralizedContractionShell.
             First axis corresponds to the segmented contraction within `contractions_one`. `M_1` is
             the number of segmented contractions with the same exponents (and angular momentum)
             associated with the first index.
@@ -253,11 +253,11 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
         Parameters
         ----------
         coord_types_one : list/tuple of str
-            Types of the coordinate system for ContractedCartesianGaussians associated with the
+            Types of the coordinate system for GeneralizedContractionShell associated with the
             first index of the array.
             Each entry must be one of "cartesian" or "spherical".
         coord_types_two : list/tuple of str
-            Types of the coordinate system for ContractedCartesianGaussians associated with the
+            Types of the coordinate system for GeneralizedContractionShell associated with the
             second index of the array.
             Each entry must be one of "cartesian" or "spherical".
         kwargs : dict
@@ -279,10 +279,10 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
         ValueError
             If `coord_types_one` has an entry that is not "cartesian" or "spherical".
             If `coord_types_one` has different number of entries as the number of
-            ContractedCartesianGaussians (`contractions`) in instance.
+            GeneralizedContractionShell (`contractions`) in instance.
             If `coord_types_two` has an entry that is not "cartesian" or "spherical".
             If `coord_types_two` has different number of entries as the number of
-            ContractedCartesianGaussians (`contractions`) in instance.
+            GeneralizedContractionShell (`contractions`) in instance.
 
         """
         if not isinstance(coord_types_one, (list, tuple)):
@@ -300,12 +300,12 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
         if len(coord_types_one) != len(self.contractions_one):
             raise ValueError(
                 "`coord_types_one` must have the same number of entries as the number of "
-                "ContractedCartesianGaussians in the instance."
+                "GeneralizedContractionShell in the instance."
             )
         if len(coord_types_two) != len(self.contractions_two):
             raise ValueError(
                 "`coord_types_two` must have the same number of entries as the number of "
-                "ContractedCartesianGaussians in the instance."
+                "GeneralizedContractionShell in the instance."
             )
 
         matrices_spherical = []
@@ -371,13 +371,13 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
             If "cartesian", then all of the contractions are treated as Cartesian contractions.
             If "spherical", then all of the contractions are treated as spherical contractions.
             If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-            coordinate type of each ContractedCartesianGaussians instance.
+            coordinate type of each GeneralizedContractionShell instance.
         coord_type_two : {"cartesian", "spherical", list/tuple of "cartesian" or "spherical}
             Types of the coordinate system for the contractions associated with the second index.
             If "cartesian", then all of the contractions are treated as Cartesian contractions.
             If "spherical", then all of the contractions are treated as spherical contractions.
             If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-            coordinate type of each ContractedCartesianGaussians instance.
+            coordinate type of each GeneralizedContractionShell instance.
         kwargs : dict
             Other keyword arguments that will be used to construct the array.
             These keyword arguments are passed directly to `construct_array_spherical`, which will

--- a/gbasis/base_two_asymm.py
+++ b/gbasis/base_two_asymm.py
@@ -214,14 +214,20 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
         for cont_one in self.contractions_one:
             # get transformation from cartesian to spherical for the first index (applied to left)
             transform_one = generate_transformation(
-                cont_one.angmom, cont_one.angmom_components, cont_one.spherical_order, "left"
+                cont_one.angmom,
+                cont_one.angmom_components_cart,
+                cont_one.angmom_components_sph,
+                "left",
             )
             matrices_spherical_cols = []
             for cont_two in self.contractions_two:
                 # get transformation from cartesian to spherical for the first index (applied to
                 # left)
                 transform_two = generate_transformation(
-                    cont_two.angmom, cont_two.angmom_components, cont_two.spherical_order, "left"
+                    cont_two.angmom,
+                    cont_two.angmom_components_cart,
+                    cont_two.angmom_components_sph,
+                    "left",
                 )
                 # evaluate
                 matrix_contraction = self.construct_array_contraction(cont_one, cont_two, **kwargs)
@@ -312,14 +318,20 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
         for cont_one, type_one in zip(self.contractions_one, coord_types_one):
             # get transformation from cartesian to spherical for the first index (applied to left)
             transform_one = generate_transformation(
-                cont_one.angmom, cont_one.angmom_components, cont_one.spherical_order, "left"
+                cont_one.angmom,
+                cont_one.angmom_components_cart,
+                cont_one.angmom_components_sph,
+                "left",
             )
             matrices_spherical_cols = []
             for cont_two, type_two in zip(self.contractions_two, coord_types_two):
                 # get transformation from cartesian to spherical for the first index (applied to
                 # left)
                 transform_two = generate_transformation(
-                    cont_two.angmom, cont_two.angmom_components, cont_two.spherical_order, "left"
+                    cont_two.angmom,
+                    cont_two.angmom_components_cart,
+                    cont_two.angmom_components_sph,
+                    "left",
                 )
                 # evaluate
                 block = self.construct_array_contraction(cont_one, cont_two, **kwargs)

--- a/gbasis/base_two_asymm.py
+++ b/gbasis/base_two_asymm.py
@@ -214,14 +214,14 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
         for cont_one in self.contractions_one:
             # get transformation from cartesian to spherical for the first index (applied to left)
             transform_one = generate_transformation(
-                cont_one.angmom, cont_one.angmom_components, "left"
+                cont_one.angmom, cont_one.angmom_components, cont_one.spherical_order, "left"
             )
             matrices_spherical_cols = []
             for cont_two in self.contractions_two:
                 # get transformation from cartesian to spherical for the first index (applied to
                 # left)
                 transform_two = generate_transformation(
-                    cont_two.angmom, cont_two.angmom_components, "left"
+                    cont_two.angmom, cont_two.angmom_components, cont_two.spherical_order, "left"
                 )
                 # evaluate
                 matrix_contraction = self.construct_array_contraction(cont_one, cont_two, **kwargs)
@@ -312,14 +312,14 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
         for cont_one, type_one in zip(self.contractions_one, coord_types_one):
             # get transformation from cartesian to spherical for the first index (applied to left)
             transform_one = generate_transformation(
-                cont_one.angmom, cont_one.angmom_components, "left"
+                cont_one.angmom, cont_one.angmom_components, cont_one.spherical_order, "left"
             )
             matrices_spherical_cols = []
             for cont_two, type_two in zip(self.contractions_two, coord_types_two):
                 # get transformation from cartesian to spherical for the first index (applied to
                 # left)
                 transform_two = generate_transformation(
-                    cont_two.angmom, cont_two.angmom_components, "left"
+                    cont_two.angmom, cont_two.angmom_components, cont_two.spherical_order, "left"
                 )
                 # evaluate
                 block = self.construct_array_contraction(cont_one, cont_two, **kwargs)

--- a/gbasis/base_two_symm.py
+++ b/gbasis/base_two_symm.py
@@ -15,12 +15,12 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
 
     Attributes
     ----------
-    _axes_contractions : tuple of tuple of ContractedCartesianGaussians
+    _axes_contractions : tuple of tuple of GeneralizedContractionShell
         Sets of contractions associated with each axis of the array.
 
     Properties
     ----------
-    contractions : tuple of ContractedCartesianGaussians
+    contractions : tuple of GeneralizedContractionShell
         Contractions that are associated with the first and second indices of the array.
 
     Methods
@@ -29,7 +29,7 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
         Initialize.
     construct_array_contraction(self, contraction, **kwargs) :
     np.ndarray(M_1, L_cart_1, M_2, L_cart_2, ...)
-        Return the array associated with a `ContractedCartesianGaussians` instance.
+        Return the array associated with a `GeneralizedContractionShell` instance.
         `M_1` is the number of segmented contractions with the same exponents (and angular momentum)
         associated with the first index.
         `L_cart_1` is the number of Cartesian contractions for the given angular momentum associated
@@ -56,7 +56,7 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
 
         Parameters
         ----------
-        contractions : list/tuple of ContractedCartesianGaussians
+        contractions : list/tuple of GeneralizedContractionShell
             Contractions that are associated with the first and second indices of the array.
 
         """
@@ -68,7 +68,7 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
 
         Returns
         -------
-        contractions : tuple of ContractedCartesianGaussians
+        contractions : tuple of GeneralizedContractionShell
             Contractions that are associated with the first index of the array.
 
         """
@@ -81,10 +81,10 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
 
         Parameters
         ----------
-        contractions_one : ContractedCartesianGaussians
+        contractions_one : GeneralizedContractionShell
             Contracted Cartesian Gaussians (of the same shell) associated with the first index of
             the array.
-        contractions_two : ContractedCartesianGaussians
+        contractions_two : GeneralizedContractionShell
             Contracted Cartesian Gaussians (of the same shell) associated with the second index of
             the array.
         kwargs : dict
@@ -93,7 +93,7 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
         Returns
         -------
         array_contraction : np.ndarray(M_1, L_cart_1, M_2, L_cart_2, ...)
-            Array associated with the given instances of ContractedCartesianGaussians.
+            Array associated with the given instances of GeneralizedContractionShell.
             First axis corresponds to the segmented contraction within `contractions_one`. `M_1` is
             the number of segmented contractions with the same exponents (and angular momentum)
             associated with the first index.
@@ -256,7 +256,7 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
         Parameters
         ----------
         coord_types : list/tuple of str
-            Types of the coordinate system for each ContractedCartesianGaussians.
+            Types of the coordinate system for each GeneralizedContractionShell.
             Each entry must be one of "cartesian" or "spherical".
         kwargs : dict
             Other keyword arguments that will be used to construct the array.
@@ -276,7 +276,7 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
         ValueError
             If `coord_types` has an entry that is not "cartesian" or "spherical".
             If `coord_types` has different number of entries as the number of
-            ContractedCartesianGaussians (`contractions`) in instance.
+            GeneralizedContractionShell (`contractions`) in instance.
 
         """
         if not isinstance(coord_types, (list, tuple)):
@@ -288,7 +288,7 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
         if len(coord_types) != len(self.contractions):
             raise ValueError(
                 "`coord_types` must have the same number of entries as the number of "
-                "ContractedCartesianGaussians in the instance."
+                "GeneralizedContractionShell in the instance."
             )
 
         triu_blocks = []
@@ -357,7 +357,7 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
             If "cartesian", then all of the contractions are treated as Cartesian contractions.
             If "spherical", then all of the contractions are treated as spherical contractions.
             If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-            coordinate type of each ContractedCartesianGaussians instance.
+            coordinate type of each GeneralizedContractionShell instance.
         kwargs : dict
             Other keyword arguments that will be used to construct the array.
             These keyword arguments are passed directly to `construct_array_spherical`, which will

--- a/gbasis/base_two_symm.py
+++ b/gbasis/base_two_symm.py
@@ -211,11 +211,17 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
         for i, cont_one in enumerate(self.contractions):
             # get transformation from cartesian to spherical (applied to left)
             transform_one = generate_transformation(
-                cont_one.angmom, cont_one.angmom_components, cont_one.spherical_order, "left"
+                cont_one.angmom,
+                cont_one.angmom_components_cart,
+                cont_one.angmom_components_sph,
+                "left",
             )
             for cont_two in self.contractions[i:]:
                 transform_two = generate_transformation(
-                    cont_two.angmom, cont_two.angmom_components, cont_two.spherical_order, "left"
+                    cont_two.angmom,
+                    cont_two.angmom_components_cart,
+                    cont_two.angmom_components_sph,
+                    "left",
                 )
                 # evaluate
                 block_sph = self.construct_array_contraction(cont_one, cont_two, **kwargs)
@@ -295,11 +301,17 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
         for i, (cont_one, type_one) in enumerate(zip(self.contractions, coord_types)):
             # get transformation from cartesian to spherical (applied to left)
             transform_one = generate_transformation(
-                cont_one.angmom, cont_one.angmom_components, cont_one.spherical_order, "left"
+                cont_one.angmom,
+                cont_one.angmom_components_cart,
+                cont_one.angmom_components_sph,
+                "left",
             )
             for cont_two, type_two in zip(self.contractions[i:], coord_types[i:]):
                 transform_two = generate_transformation(
-                    cont_two.angmom, cont_two.angmom_components, cont_two.spherical_order, "left"
+                    cont_two.angmom,
+                    cont_two.angmom_components_cart,
+                    cont_two.angmom_components_sph,
+                    "left",
                 )
                 # evaluate
                 block = self.construct_array_contraction(cont_one, cont_two, **kwargs)

--- a/gbasis/base_two_symm.py
+++ b/gbasis/base_two_symm.py
@@ -211,11 +211,11 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
         for i, cont_one in enumerate(self.contractions):
             # get transformation from cartesian to spherical (applied to left)
             transform_one = generate_transformation(
-                cont_one.angmom, cont_one.angmom_components, "left"
+                cont_one.angmom, cont_one.angmom_components, cont_one.spherical_order, "left"
             )
             for cont_two in self.contractions[i:]:
                 transform_two = generate_transformation(
-                    cont_two.angmom, cont_two.angmom_components, "left"
+                    cont_two.angmom, cont_two.angmom_components, cont_two.spherical_order, "left"
                 )
                 # evaluate
                 block_sph = self.construct_array_contraction(cont_one, cont_two, **kwargs)
@@ -295,11 +295,11 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
         for i, (cont_one, type_one) in enumerate(zip(self.contractions, coord_types)):
             # get transformation from cartesian to spherical (applied to left)
             transform_one = generate_transformation(
-                cont_one.angmom, cont_one.angmom_components, "left"
+                cont_one.angmom, cont_one.angmom_components, cont_one.spherical_order, "left"
             )
             for cont_two, type_two in zip(self.contractions[i:], coord_types[i:]):
                 transform_two = generate_transformation(
-                    cont_two.angmom, cont_two.angmom_components, "left"
+                    cont_two.angmom, cont_two.angmom_components, cont_two.spherical_order, "left"
                 )
                 # evaluate
                 block = self.construct_array_contraction(cont_one, cont_two, **kwargs)

--- a/gbasis/contractions.py
+++ b/gbasis/contractions.py
@@ -97,7 +97,7 @@ class GeneralizedContractionShell:
     angmom_components_sph : tuple of int
         Tuple of magnetic quantum numbers of the contractions that specifies the ordering after
         transforming the contractions from the Cartesian to spherical coordinate system.
-    norm_prim : np.ndarray(L, K)
+    norm_prim_cart : np.ndarray(L, K)
         The normalization constants of the Cartesian Gaussian primitives.
         :math:`L` is the number of contracted Cartesian Gaussian functions for the given angular
         momentum, i.e. :math:`(angmom + 1) * (angmom + 2) / 2`
@@ -354,7 +354,7 @@ class GeneralizedContractionShell:
         return tuple(range(-self.angmom, self.angmom + 1))
 
     @property
-    def norm_prim(self):
+    def norm_prim_cart(self):
         r"""Return the normalization constants of the Cartesian Gaussian primitives.
 
             .. math::
@@ -365,7 +365,7 @@ class GeneralizedContractionShell:
 
         Returns
         -------
-        norm_prim : np.ndarray(L, K)
+        norm_prim_cart : np.ndarray(L, K)
             The normalization constants of the Cartesian Gaussian primitives.
             :math:`L` is the number of contracted Cartesian Gaussian functions for the given angular
             momentum, i.e. :math:`(angmom + 1) * (angmom + 2) / 2`

--- a/gbasis/contractions.py
+++ b/gbasis/contractions.py
@@ -104,7 +104,7 @@ class GeneralizedContractionShell:
 
     """
 
-    def __init__(self, angmom, coord, charge, coeffs, exps):
+    def __init__(self, angmom, coord, coeffs, exps):
         r"""Initialize a GeneralizedContractionShell instance.
 
         Attributes
@@ -117,8 +117,6 @@ class GeneralizedContractionShell:
 
         coord : np.ndarray(3,)
             Coordinate of the center of the Gaussian primitives.
-        charge : float
-            Charge at the center of the Gaussian primitives.
         coeffs : {np.ndarray(K,), np.ndarray(K, M)}
             Contraction coefficients, :math:`\{d_i\}`, of the primitives.
             If a two-dimensional array is given, the first axis corresponds to the primitive and the
@@ -131,43 +129,9 @@ class GeneralizedContractionShell:
         """
         self.angmom = angmom
         self.coord = coord
-        self.charge = charge
         self.coeffs = coeffs
         self.exps = exps
         self.assign_norm_cont()
-
-    @property
-    def charge(self):
-        """Charge at the center of the Gaussian primitives.
-
-        Returns
-        -------
-        charge : float
-            Point charge at the center of the Gaussian primitive.
-
-        """
-        return self._charge
-
-    @charge.setter
-    def charge(self, charge):
-        """Set the charge at the center of the Gaussian primitives.
-
-        Parameters
-        ----------
-        charge : {float, int}
-            Point charge at the center of the Gaussian primitive.
-
-        Raises
-        ------
-        TypeError
-            If charge is not given as an integer or a float.
-
-        """
-        if isinstance(charge, int):
-            charge = float(charge)
-        if not isinstance(charge, float):
-            raise TypeError("Charge must be given as an integer or a float.")
-        self._charge = charge
 
     @property
     def coord(self):
@@ -466,7 +430,7 @@ class GeneralizedContractionShell:
         self.norm_cont **= -0.5
 
 
-def make_contractions(basis_dict, atoms, coords, charges=None):
+def make_contractions(basis_dict, atoms, coords):
     """Return the contractions that correspond to the given atoms for the given basis.
 
     Parameters
@@ -477,9 +441,6 @@ def make_contractions(basis_dict, atoms, coords, charges=None):
         Atoms at which the contractions are centered.
     coords : np.ndarray(N, 3)
         Coordinates of each atom.
-    charges : np.ndarray(N,)
-        Charges of each atom.
-        Default is 0 for each atom (neutral).
 
     Returns
     -------
@@ -492,10 +453,8 @@ def make_contractions(basis_dict, atoms, coords, charges=None):
     TypeError
         If atoms is not a list or tuple of strings.
         If coords is not a two-dimensional numpy array with 3 columns.
-        If charges is not a one-dimensional numpy array.
     ValueError
         If the length of atoms is not equal to the number of rows of coords.
-        If the length of charges is not equal to the length of atoms.
 
     """
     if not (isinstance(atoms, (list, tuple)) and all(isinstance(i, str) for i in atoms)):
@@ -507,15 +466,8 @@ def make_contractions(basis_dict, atoms, coords, charges=None):
     if len(atoms) != coords.shape[0]:
         raise ValueError("Number of atoms must be equal to the number of rows in the coordinates.")
 
-    if charges is None:
-        charges = np.zeros(len(atoms))
-    elif not (isinstance(charges, np.ndarray) and charges.ndim == 1):
-        raise TypeError("Charges must be given as a one-dimensional numpy array.")
-    if charges.size != len(atoms):
-        raise ValueError("Number of charges must be equal to the number of atoms.")
-
     basis = []
-    for atom, coord, charge in zip(atoms, coords, charges):
+    for atom, coord in zip(atoms, coords):
         for angmom, exps, coeffs in basis_dict[atom]:
-            basis.append(GeneralizedContractionShell(angmom, coord, charge, coeffs, exps))
+            basis.append(GeneralizedContractionShell(angmom, coord, coeffs, exps))
     return tuple(basis)

--- a/gbasis/contractions.py
+++ b/gbasis/contractions.py
@@ -1,4 +1,4 @@
-"""Data classes for contracted Gaussians."""
+"""Data class for contractions of Gaussian-type primitives."""
 import numpy as np
 from scipy.special import factorial2
 
@@ -441,46 +441,3 @@ class GeneralizedContractionShell:
 
         self.norm_cont = np.einsum("ijij->ij", Overlap.construct_array_contraction(self, self))
         self.norm_cont **= -0.5
-
-
-def make_contractions(basis_dict, atoms, coords):
-    """Return the contractions that correspond to the given atoms for the given basis.
-
-    Parameters
-    ----------
-    basis_dict : dict of str to list of 3-tuple of (int, np.ndarray, np.ndarray)
-        Output of the parsers from gbasis.parsers.
-    atoms : N-list/tuple of str
-        Atoms at which the contractions are centered.
-    coords : np.ndarray(N, 3)
-        Coordinates of each atom.
-
-    Returns
-    -------
-    basis : tuple of GeneralizedContractionShell
-        Contractions for each atom.
-        Contractions are ordered in the same order as in the values of `basis_dict`.
-
-    Raises
-    ------
-    TypeError
-        If atoms is not a list or tuple of strings.
-        If coords is not a two-dimensional numpy array with 3 columns.
-    ValueError
-        If the length of atoms is not equal to the number of rows of coords.
-
-    """
-    if not (isinstance(atoms, (list, tuple)) and all(isinstance(i, str) for i in atoms)):
-        raise TypeError("Atoms must be provided as a list or tuple.")
-    if not (isinstance(coords, np.ndarray) and coords.ndim == 2 and coords.shape[1] == 3):
-        raise TypeError(
-            "Coordinates must be provided as a two-dimensional numpy array with three columns."
-        )
-    if len(atoms) != coords.shape[0]:
-        raise ValueError("Number of atoms must be equal to the number of rows in the coordinates.")
-
-    basis = []
-    for atom, coord in zip(atoms, coords):
-        for angmom, exps, coeffs in basis_dict[atom]:
-            basis.append(GeneralizedContractionShell(angmom, coord, coeffs, exps))
-    return tuple(basis)

--- a/gbasis/contractions.py
+++ b/gbasis/contractions.py
@@ -71,7 +71,7 @@ class GeneralizedContractionShell:
 
             l = \sum_i \vec{a} = a_x + a_y + a_z
 
-    angmom_components : np.ndarray(L, 3)
+    angmom_components_cart : np.ndarray(L, 3)
         Components of the angular momentum.
     coord : np.ndarray(3,)
         Coordinate of the center of the Gaussian primitives.
@@ -91,7 +91,7 @@ class GeneralizedContractionShell:
         The number of Cartesian contracted Gaussians in the shell of angular momentum, :math:`l`.
     num_sph : int
         The number of spherical contracted Gaussian in the shell of angular momentum, :math:`l`.
-    spherical_order : tuple of int
+    angmom_components_sph : tuple of int
         Ordering of the spherical primitives/contractions.
 
     Methods
@@ -308,16 +308,16 @@ class GeneralizedContractionShell:
             self._coeffs = coeffs
 
     @property
-    def angmom_components(self):
-        r"""Components of the angular momentum.
+    def angmom_components_cart(self):
+        r"""Return the components of the angular momentum vectors for the given angular momentum.
 
         Returns
         -------
-        angmom_components : np.ndarray(L, 3)
-            The x, y, and z components of the angular momentum (:math:`\vec{a} = (a_x, a_y, a_z)`
-            where :math:`a_x + a_y + a_z = l`).
-            :math:`L` is the number of Cartesian contracted Gaussian functions for the given angular
-            momentum, i.e. :math:`(angmom + 1) * (angmom + 2) / 2`
+        angmom_components_cart : np.ndarray(L, 3)
+            The x, y, and z components of the angular momentum vectors (
+            :math:`\vec{a} = (a_x, a_y, a_z)` where :math:`a_x + a_y + a_z = \ell`).
+            :math:`L` is the number of Cartesian contracted Gaussian functions for the given
+            angular momentum, i.e. :math:`(angmom + 1) * (angmom + 2) / 2`
 
         """
         return np.array(
@@ -329,13 +329,14 @@ class GeneralizedContractionShell:
         )
 
     @property
-    def spherical_order(self):
-        """Return the ordering of the spherical primitives/contractions.
+    def angmom_components_sph(self):
+        """Return the ordering of the magnetic quantum numbers for the given angular momentum.
 
         Returns
         -------
-        spherical_order : tuple of int
-            Order of the spherical primitives.
+        angmom_components_sph : tuple of int
+            Tuple of magnetic quantum numbers of the contractions that specifies the ordering after
+            transforming the contractions from the Cartesian to spherical coordinate system.
 
         """
         return tuple(range(-self.angmom, self.angmom + 1))
@@ -360,12 +361,12 @@ class GeneralizedContractionShell:
 
         """
         exponents = self.exps[np.newaxis, :]
-        angmom_components = self.angmom_components[:, :, np.newaxis]
+        angmom_components_cart = self.angmom_components_cart[:, :, np.newaxis]
 
         return (
             (2 * exponents / np.pi) ** (3 / 4)
             * ((4 * exponents) ** (self.angmom / 2))
-            / np.sqrt(np.prod(factorial2(2 * angmom_components - 1), axis=1))
+            / np.sqrt(np.prod(factorial2(2 * angmom_components_cart - 1), axis=1))
         )
 
     @property

--- a/gbasis/contractions.py
+++ b/gbasis/contractions.py
@@ -49,6 +49,8 @@ class ContractedCartesianGaussians:
         The number of Cartesian contracted Gaussians in the shell of angular momentum, :math:`l`.
     num_sph : int
         The number of spherical contracted Gaussian in the shell of angular momentum, :math:`l`.
+    spherical_order : tuple of int
+        Ordering of the spherical primitives/contractions.
 
     Methods
     -------
@@ -319,6 +321,18 @@ class ContractedCartesianGaussians:
                 for y in range(self.angmom - x + 1)[::-1]
             ]
         )
+
+    @property
+    def spherical_order(self):
+        """Return the ordering of the spherical primitives/contractions.
+
+        Returns
+        -------
+        spherical_order : tuple of int
+            Order of the spherical primitives.
+
+        """
+        return tuple(range(-self.angmom, self.angmom + 1))
 
     @property
     def norm_prim(self):

--- a/gbasis/contractions.py
+++ b/gbasis/contractions.py
@@ -3,23 +3,65 @@ import numpy as np
 from scipy.special import factorial2
 
 
-class ContractedCartesianGaussians:
-    r"""Data class for contracted Cartesian Gaussians of the same angular momentum.
+class GeneralizedContractionShell:
+    r"""Data class for generalized contractions.
+
+    Generalized contractions are defined to be a set of contractions that have the same angular
+    momentum, center, and the same set of exponents. To avoid confusion with the term
+    "contraction", we add "shell" to indicate that this instance refers to a collection of
+    contractions.
+
+    A Cartesian **primitive**, :math:`g_i`, is
 
     .. math::
 
-        \phi_{\vec{a}, A} (\mathbf{r}) &=
-        \sum_i d_i (x - X_A)^{a_x} (y - Y_A)^{a_y} (z - Z_A)^{a_z}
-        \exp{-\alpha_i |\vec{r} - \vec{R}_A|^2}\\
-        &= \sum_i d_i g_{i} (\vec{r} | \vec{a}, \vec{R}_A)
+        g_i (\mathbf{r} | \vec{a}, \vec{R}_A) =
+        N_g (\alpha, \vec{a})
+        (x - X_A)^{a_x} (y - Y_A)^{a_y} (z - Z_A)^{a_z}
+        \exp{-\alpha_i |\vec{r} - \vec{R}_A|^2}
 
-    where :math:`\vec{r} = (x, y, z)`, :math:`\vec{R}_A = (X_A, Y_A, Z_A)`,
-    :math:`\vec{a} = (a_x, a_y, a_z)`, and :math:`g_i` is a Gaussian primitive.
+    where :math:`\vec{a} = (a_x, a_y, az)` is the angular momentum components in the Cartesian
+    coordinate, :math:`\vec{R}_A` is the coordinate of the center :math:`A`, :math:`N_g` is the
+    normalization constant of the primitive, and :math:`\alpha_i` is the exponent of the primitive.
 
-    Since the integrals involving these contractions are computed using recursive relations that
-    modify the :math:`\vec{a}`, we group the primitives that share the same properties (i.e.
-    :math:`\vec{R}_A` and :math:`\alpha_i`) except for the :math:`\vec{a}` in the hopes of
-    vectorizing and storing repeating elements.
+    A **Cartesian contraction** is a linear combination of Cartesian primitives:
+
+    .. math::
+
+        \phi_{\vec{a}, \vec{R}_A} (\mathbf{r}) =
+        N_{\phi} (\vec{a}, \vec{R}_A) \sum_i d_i g_i (\vec{r} | \vec{a}, \vec{R}_A)
+
+    where :math:`d_i` is the contraction coefficient of the primitive and :math:`N_{\phi}` is the
+    normalization constant of the contraction.
+
+    Note that the Cartesian contraction depends on the angular momentum components in the Cartesian
+    coordinate, :math:`\vec{a}`. At a given angular momentum, :math:`\ell`, we have
+    :math:`\frac{(\ell + 1) (\ell + 2)}{2}` different components. We can linearly transform these
+    contractions to obtain the :math:`2 \ell + 1` **spherical contractions**. Since we can convert
+    the contractions in one coordinate system to another, we use the term **contraction** to
+    describe both cases, unless otherwise stated.
+
+    In order to obtain the spherical contractions, we need the contractions at different angular
+    momentum components. We will denote the collection of these contractions as
+    **segmented contraction shell**. Note that contractions within segmented contraction shell all
+    have the same angular momentum, center, and the same set of exponents and contraction
+    coefficients.
+
+    Now, some basis sets, e.g. ANO-RCC, group together multiple segmented contractions that only
+    differ by the contraction coefficients and angular momentums. Here, we denote a collection of
+    contractions with the same angular momentum, center, and the same set of exponents as
+    **generalized contraction shell**. Note that **we do not support generalized contraction with
+    different angular momentum**.
+
+    We can think of generalized contraction shell as a union of segmented contraction shells with
+    the same angular momentum, center, and the same set of exponents. Now, the contraction
+    coefficients depend on the specific segmented contraction shell, :math:`j`, to which the
+    contraction belongs:
+
+    .. math::
+
+        \phi_{j, \vec{a}, \vec{R}_A} (\mathbf{r}) =
+        N_{\phi} (\vec{a}, \vec{R}_A) \sum_i d_{ij} g_i (\vec{r} | \vec{a}, \vec{R}_A)
 
     Attributes
     ----------
@@ -63,7 +105,7 @@ class ContractedCartesianGaussians:
     """
 
     def __init__(self, angmom, coord, charge, coeffs, exps):
-        r"""Initialize a ContractedCartesianGaussians instance.
+        r"""Initialize a GeneralizedContractionShell instance.
 
         Attributes
         ----------
@@ -441,7 +483,7 @@ def make_contractions(basis_dict, atoms, coords, charges=None):
 
     Returns
     -------
-    basis : tuple of ContractedCartesianGaussians
+    basis : tuple of GeneralizedContractionShell
         Contractions for each atom.
         Contractions are ordered in the same order as in the values of `basis_dict`.
 
@@ -475,5 +517,5 @@ def make_contractions(basis_dict, atoms, coords, charges=None):
     basis = []
     for atom, coord, charge in zip(atoms, coords, charges):
         for angmom, exps, coeffs in basis_dict[atom]:
-            basis.append(ContractedCartesianGaussians(angmom, coord, charge, coeffs, exps))
+            basis.append(GeneralizedContractionShell(angmom, coord, charge, coeffs, exps))
     return tuple(basis)

--- a/gbasis/density.py
+++ b/gbasis/density.py
@@ -68,7 +68,7 @@ def eval_density(one_density_matrix, basis, coords, transform, coord_type="spher
     ----------
     one_density_matrix : np.ndarray(K_orb, K_orb)
         One-electron density matrix.
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     coords : np.ndarray(N, 3)
         Points in space where the contractions are evaluated.
@@ -83,7 +83,7 @@ def eval_density(one_density_matrix, basis, coords, transform, coord_type="spher
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each ContractedCartesianGaussians instance.
+        coordinate type of each GeneralizedContractionShell instance.
         Default value is "spherical".
 
     Returns
@@ -107,7 +107,7 @@ def eval_deriv_density(
         Orders of the derivative.
     one_density_matrix : np.ndarray(K_orb, K_orb)
         One-electron density matrix.
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     coords : np.ndarray(N, 3)
         Points in space where the contractions are evaluated.
@@ -122,7 +122,7 @@ def eval_deriv_density(
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each ContractedCartesianGaussians instance.
+        coordinate type of each GeneralizedContractionShell instance.
         Default value is "spherical".
 
     Returns
@@ -169,7 +169,7 @@ def eval_density_gradient(one_density_matrix, basis, coords, transform, coord_ty
     ----------
     one_density_matrix : np.ndarray(K_orb, K_orb)
         One-electron density matrix.
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     coords : np.ndarray(N, 3)
         Points in space where the contractions are evaluated.
@@ -184,7 +184,7 @@ def eval_density_gradient(one_density_matrix, basis, coords, transform, coord_ty
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each ContractedCartesianGaussians instance.
+        coordinate type of each GeneralizedContractionShell instance.
         Default value is "spherical".
 
     Returns
@@ -230,7 +230,7 @@ def eval_density_laplacian(one_density_matrix, basis, coords, transform, coord_t
     ----------
     one_density_matrix : np.ndarray(K_orb, K_orb)
         One-electron density matrix.
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     coords : np.ndarray(N, 3)
         Points in space where the contractions are evaluated.
@@ -245,7 +245,7 @@ def eval_density_laplacian(one_density_matrix, basis, coords, transform, coord_t
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each ContractedCartesianGaussians instance.
+        coordinate type of each GeneralizedContractionShell instance.
         Default value is "spherical".
 
     Returns
@@ -273,7 +273,7 @@ def eval_density_hessian(one_density_matrix, basis, coords, transform, coord_typ
     ----------
     one_density_matrix : np.ndarray(K_orb, K_orb)
         One-electron density matrix.
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     coords : np.ndarray(N, 3)
         Points in space where the contractions are evaluated.
@@ -288,7 +288,7 @@ def eval_density_hessian(one_density_matrix, basis, coords, transform, coord_typ
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each ContractedCartesianGaussians instance.
+        coordinate type of each GeneralizedContractionShell instance.
         Default value is "spherical".
 
     Returns
@@ -326,7 +326,7 @@ def eval_posdef_kinetic_energy_density(
     ----------
     one_density_matrix : np.ndarray(K_orb, K_orb)
         One-electron density matrix.
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     coords : np.ndarray(N, 3)
         Points in space where the contractions are evaluated.
@@ -341,7 +341,7 @@ def eval_posdef_kinetic_energy_density(
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each ContractedCartesianGaussians instance.
+        coordinate type of each GeneralizedContractionShell instance.
         Default value is "spherical".
 
     Returns

--- a/gbasis/electrostatic_potential.py
+++ b/gbasis/electrostatic_potential.py
@@ -16,7 +16,7 @@ def _electrostatic_potential_base(
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     density_matrix : np.ndarray(K, K)
         Density matrix constructed using the given basis set.
@@ -33,7 +33,7 @@ def _electrostatic_potential_base(
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each ContractedCartesianGaussians instance.
+        coordinate type of each GeneralizedContractionShell instance.
     threshold_dist : {float, 0.0}
         Threshold for rejecting nuclei whose distances to the points are less than the provided
         value. i.e. nuclei that are closer to the point than the threshold are discarded when
@@ -161,7 +161,7 @@ def electrostatic_potential_cartesian(
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     density_matrix_cart : np.ndarray(K_cart, K_cart)
         Density matrix constructed using the Cartesian forms of the given basis set.
@@ -225,7 +225,7 @@ def electrostatic_potential_spherical(
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     density_matrix_sph : np.ndarray(K_sph, K_sph)
         Density matrix constructed using the Cartesian forms of the given basis set.
@@ -295,7 +295,7 @@ def electrostatic_potential_mix(
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     density_matrix_mix : np.ndarray(K_cont, K_cont)
         Density matrix constructed using the Cartesian forms of the given basis set.
@@ -308,7 +308,7 @@ def electrostatic_potential_mix(
     nuclear_charges : np.ndarray(N_nuc)
         Charges of each atom.
     coord_types : list/tuple of str
-        Types of the coordinate system for each ContractedCartesianGaussians.
+        Types of the coordinate system for each GeneralizedContractionShell.
         Each entry must be one of "cartesian" or "spherical".
     threshold_dist : {float, 0.0}
         Threshold for rejecting nuclei whose distances to the points are less than the provided

--- a/gbasis/eval.py
+++ b/gbasis/eval.py
@@ -100,7 +100,7 @@ class Eval(BaseOneIndex):
 
         alphas = contractions.exps
         prim_coeffs = contractions.coeffs
-        angmom_comps = contractions.angmom_components
+        angmom_comps = contractions.angmom_components_cart
         center = contractions.coord
         norm_prim = contractions.norm_prim
         output = _eval_deriv_contractions(

--- a/gbasis/eval.py
+++ b/gbasis/eval.py
@@ -1,7 +1,7 @@
 """Functions for evaluating Gaussian contractions."""
 from gbasis._deriv import _eval_deriv_contractions
 from gbasis.base_one import BaseOneIndex
-from gbasis.contractions import ContractedCartesianGaussians
+from gbasis.contractions import GeneralizedContractionShell
 import numpy as np
 
 
@@ -13,13 +13,13 @@ class Eval(BaseOneIndex):
 
     Attributes
     ----------
-    _axes_contractions : tuple of tuple of ContractedCartesianGaussians
+    _axes_contractions : tuple of tuple of GeneralizedContractionShell
         Contractions that are associated with each index of the array.
-        Each tuple of ContractedCartesianGaussians corresponds to an index of the array.
+        Each tuple of GeneralizedContractionShell corresponds to an index of the array.
 
     Properties
     ----------
-    contractions : tuple of ContractedCartesianGaussians
+    contractions : tuple of GeneralizedContractionShell
         Contractions that are associated with the first index of the array.
 
     Methods
@@ -59,7 +59,7 @@ class Eval(BaseOneIndex):
 
         Parameters
         ----------
-        contractions : ContractedCartesianGaussians
+        contractions : GeneralizedContractionShell
             Contracted Cartesian Gaussians (of the same shell) that will be used to construct an
             array.
         coords : np.ndarray(N, 3)
@@ -80,7 +80,7 @@ class Eval(BaseOneIndex):
         Raises
         ------
         TypeError
-            If contractions is not a ContractedCartesianGaussians instance.
+            If contractions is not a GeneralizedContractionShell instance.
             If coords is not a two-dimensional numpy array with 3 columns.
 
         Note
@@ -91,8 +91,8 @@ class Eval(BaseOneIndex):
         `coords` and `orders`.
 
         """
-        if not isinstance(contractions, ContractedCartesianGaussians):
-            raise TypeError("`contractions` must be a ContractedCartesianGaussians instance.")
+        if not isinstance(contractions, GeneralizedContractionShell):
+            raise TypeError("`contractions` must be a GeneralizedContractionShell instance.")
         if not (isinstance(coords, np.ndarray) and coords.ndim == 2 and coords.shape[1] == 3):
             raise TypeError(
                 "`coords` must be given as a two-dimensional numpy array with 3 columnms."
@@ -114,7 +114,7 @@ def evaluate_basis_cartesian(basis, coords):
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     coords : np.ndarray(N, 3)
         Points in space where the contractions are evaluated.
@@ -135,7 +135,7 @@ def evaluate_basis_spherical(basis, coords):
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     coords : np.ndarray(N, 3)
         Points in space where the contractions are evaluated.
@@ -156,12 +156,12 @@ def evaluate_basis_mix(basis, coords, coord_types):
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     coords : np.ndarray(N, 3)
         Points in space where the contractions are evaluated.
     coord_types : list/tuple of str
-        Types of the coordinate system for each ContractedCartesianGaussians.
+        Types of the coordinate system for each GeneralizedContractionShell.
         Each entry must be one of "cartesian" or "spherical".
 
     Returns
@@ -180,7 +180,7 @@ def evaluate_basis_lincomb(basis, coords, transform, coord_type="spherical"):
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     coords : np.ndarray(N, 3)
         Points in space where the contractions are evaluated.
@@ -195,7 +195,7 @@ def evaluate_basis_lincomb(basis, coords, transform, coord_type="spherical"):
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each ContractedCartesianGaussians instance.
+        coordinate type of each GeneralizedContractionShell instance.
         Default value is "spherical".
 
     Returns

--- a/gbasis/eval.py
+++ b/gbasis/eval.py
@@ -102,9 +102,9 @@ class Eval(BaseOneIndex):
         prim_coeffs = contractions.coeffs
         angmom_comps = contractions.angmom_components_cart
         center = contractions.coord
-        norm_prim = contractions.norm_prim
+        norm_prim_cart = contractions.norm_prim_cart
         output = _eval_deriv_contractions(
-            coords, np.zeros(3), center, angmom_comps, alphas, prim_coeffs, norm_prim
+            coords, np.zeros(3), center, angmom_comps, alphas, prim_coeffs, norm_prim_cart
         )
         return output
 

--- a/gbasis/eval_deriv.py
+++ b/gbasis/eval_deriv.py
@@ -116,9 +116,9 @@ class EvalDeriv(BaseOneIndex):
         prim_coeffs = contractions.coeffs
         angmom_comps = contractions.angmom_components_cart
         center = contractions.coord
-        norm_prim = contractions.norm_prim
+        norm_prim_cart = contractions.norm_prim_cart
         output = _eval_deriv_contractions(
-            coords, orders, center, angmom_comps, alphas, prim_coeffs, norm_prim
+            coords, orders, center, angmom_comps, alphas, prim_coeffs, norm_prim_cart
         )
         return output
 

--- a/gbasis/eval_deriv.py
+++ b/gbasis/eval_deriv.py
@@ -1,7 +1,7 @@
 """Functions for evaluating Gaussian primitives."""
 from gbasis._deriv import _eval_deriv_contractions
 from gbasis.base_one import BaseOneIndex
-from gbasis.contractions import ContractedCartesianGaussians
+from gbasis.contractions import GeneralizedContractionShell
 import numpy as np
 
 
@@ -13,13 +13,13 @@ class EvalDeriv(BaseOneIndex):
 
     Attributes
     ----------
-    _axes_contractions : tuple of tuple of ContractedCartesianGaussians
+    _axes_contractions : tuple of tuple of GeneralizedContractionShell
         Contractions that are associated with each index of the array.
-        Each tuple of ContractedCartesianGaussians corresponds to an index of the array.
+        Each tuple of GeneralizedContractionShell corresponds to an index of the array.
 
     Properties
     ----------
-    contractions : tuple of ContractedCartesianGaussians
+    contractions : tuple of GeneralizedContractionShell
         Contractions that are associated with the first index of the array.
 
     Methods
@@ -59,7 +59,7 @@ class EvalDeriv(BaseOneIndex):
 
         Parameters
         ----------
-        contractions : ContractedCartesianGaussians
+        contractions : GeneralizedContractionShell
             Contracted Cartesian Gaussians (of the same shell) that will be used to construct an
             array.
         coords : np.ndarray(N, 3)
@@ -70,7 +70,7 @@ class EvalDeriv(BaseOneIndex):
         Returns
         -------
         array_contraction : np.ndarray(M, L_cart, N)
-            Array associated with the given instance(s) of ContractedCartesianGaussians.
+            Array associated with the given instance(s) of GeneralizedContractionShell.
             First index corresponds to segmented contractions within the given generalized
             contraction (same exponents and angular momentum, but different coefficients). `M` is
             the number of segmented contractions with the same exponents (and angular momentum).
@@ -82,7 +82,7 @@ class EvalDeriv(BaseOneIndex):
         Raises
         ------
         TypeError
-            If contractions is not a ContractedCartesianGaussians instance.
+            If contractions is not a GeneralizedContractionShell instance.
             If coords is not a two-dimensional numpy array with 3 columns.
             If orders is not a one-dimensional numpy array with 3 elements.
         ValueError
@@ -97,8 +97,8 @@ class EvalDeriv(BaseOneIndex):
         `coords` and `orders`.
 
         """
-        if not isinstance(contractions, ContractedCartesianGaussians):
-            raise TypeError("`contractions` must be a ContractedCartesianGaussians instance.")
+        if not isinstance(contractions, GeneralizedContractionShell):
+            raise TypeError("`contractions` must be a GeneralizedContractionShell instance.")
         if not (isinstance(coords, np.ndarray) and coords.ndim == 2 and coords.shape[1] == 3):
             raise TypeError(
                 "`coords` must be given as a two-dimensional numpy array with 3 columnms."
@@ -128,7 +128,7 @@ def evaluate_deriv_basis_cartesian(basis, coords, orders):
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     coords : np.ndarray(N, 3)
         Points in space where the contractions are evaluated.
@@ -152,7 +152,7 @@ def evaluate_deriv_basis_spherical(basis, coords, orders):
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     coords : np.ndarray(N, 3)
         Points in space where the contractions are evaluated.
@@ -176,14 +176,14 @@ def evaluate_deriv_basis_mix(basis, coords, orders, coord_types):
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     coords : np.ndarray(N, 3)
         Points in space where the contractions are evaluated.
     orders : np.ndarray(3,)
         Orders of the derivative.
     coord_types : list/tuple of str
-        Types of the coordinate system for each ContractedCartesianGaussians.
+        Types of the coordinate system for each GeneralizedContractionShell.
         Each entry must be one of "cartesian" or "spherical".
 
     Returns
@@ -203,7 +203,7 @@ def evaluate_deriv_basis_lincomb(basis, coords, orders, transform, coord_type="s
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     coords : np.ndarray(N, 3)
         Points in space where the contractions are evaluated.
@@ -220,7 +220,7 @@ def evaluate_deriv_basis_lincomb(basis, coords, orders, transform, coord_type="s
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each ContractedCartesianGaussians instance.
+        coordinate type of each GeneralizedContractionShell instance.
         Default value is "spherical".
 
     Returns

--- a/gbasis/eval_deriv.py
+++ b/gbasis/eval_deriv.py
@@ -114,7 +114,7 @@ class EvalDeriv(BaseOneIndex):
 
         alphas = contractions.exps
         prim_coeffs = contractions.coeffs
-        angmom_comps = contractions.angmom_components
+        angmom_comps = contractions.angmom_components_cart
         center = contractions.coord
         norm_prim = contractions.norm_prim
         output = _eval_deriv_contractions(

--- a/gbasis/kinetic_energy.py
+++ b/gbasis/kinetic_energy.py
@@ -98,12 +98,12 @@ class KineticEnergyIntegral(BaseTwoIndexSymmetric):
         angmoms_a = contractions_one.angmom_components_cart
         alphas_a = contractions_one.exps
         coeffs_a = contractions_one.coeffs
-        norm_a_prim = contractions_one.norm_prim
+        norm_a_prim = contractions_one.norm_prim_cart
         coord_b = contractions_two.coord
         angmoms_b = contractions_two.angmom_components_cart
         alphas_b = contractions_two.exps
         coeffs_b = contractions_two.coeffs
-        norm_b_prim = contractions_two.norm_prim
+        norm_b_prim = contractions_two.norm_prim_cart
         output = _compute_differential_operator_integrals(
             np.array([[2, 0, 0], [0, 2, 0], [0, 0, 2]]),
             coord_a,

--- a/gbasis/kinetic_energy.py
+++ b/gbasis/kinetic_energy.py
@@ -1,7 +1,7 @@
 """Module for evaluating the kinetic energy integral."""
 from gbasis._diff_operator_int import _compute_differential_operator_integrals
 from gbasis.base_two_symm import BaseTwoIndexSymmetric
-from gbasis.contractions import ContractedCartesianGaussians
+from gbasis.contractions import GeneralizedContractionShell
 import numpy as np
 
 
@@ -10,12 +10,12 @@ class KineticEnergyIntegral(BaseTwoIndexSymmetric):
 
     Attributes
     ----------
-    _axes_contractions : tuple of tuple of ContractedCartesianGaussians
+    _axes_contractions : tuple of tuple of GeneralizedContractionShell
         Sets of contractions associated with each axis of the array.
 
     Properties
     ----------
-    contractions : tuple of ContractedCartesianGaussians
+    contractions : tuple of GeneralizedContractionShell
         Contractions that are associated with the first and second indices of the array.
 
     Methods
@@ -24,7 +24,7 @@ class KineticEnergyIntegral(BaseTwoIndexSymmetric):
         Initialize.
     construct_array_contraction(contractions_one, contractions_two) :
     np.ndarray(M_1, L_cart_1, M_2, L_cart_2)
-        Return the kinetic energy integral associated with a `ContractedCartesianGaussians`
+        Return the kinetic energy integral associated with a `GeneralizedContractionShell`
         instance.
         `M_1` is the number of segmented contractions with the same exponents (and angular momentum)
         associated with the first index.
@@ -57,10 +57,10 @@ class KineticEnergyIntegral(BaseTwoIndexSymmetric):
 
         Parameters
         ----------
-        contractions_one : ContractedCartesianGaussians
+        contractions_one : GeneralizedContractionShell
             Contracted Cartesian Gaussians (of the same shell) associated with the first index of
             the kinetic energy integral.
-        contractions_two : ContractedCartesianGaussians
+        contractions_two : GeneralizedContractionShell
             Contracted Cartesian Gaussians (of the same shell) associated with the second index of
             the kinetic energy integral.
 
@@ -68,7 +68,7 @@ class KineticEnergyIntegral(BaseTwoIndexSymmetric):
         -------
         array_contraction : np.ndarray(M_1, L_cart_1, M_2, L_cart_2)
             Kinetic energy integral associated with the given instances of
-            ContractedCartesianGaussians.
+            GeneralizedContractionShell.
             First axis corresponds to the segmented contraction within `contractions_one`. `M_1` is
             the number of segmented contractions with the same exponents (and angular momentum)
             associated with the first index.
@@ -85,14 +85,14 @@ class KineticEnergyIntegral(BaseTwoIndexSymmetric):
         Raises
         ------
         TypeError
-            If contractions_one is not a ContractedCartesianGaussians instance.
-            If contractions_two is not a ContractedCartesianGaussians instance.
+            If contractions_one is not a GeneralizedContractionShell instance.
+            If contractions_two is not a GeneralizedContractionShell instance.
 
         """
-        if not isinstance(contractions_one, ContractedCartesianGaussians):
-            raise TypeError("`contractions_one` must be a ContractedCartesianGaussians instance.")
-        if not isinstance(contractions_two, ContractedCartesianGaussians):
-            raise TypeError("`contractions_two` must be a ContractedCartesianGaussians instance.")
+        if not isinstance(contractions_one, GeneralizedContractionShell):
+            raise TypeError("`contractions_one` must be a GeneralizedContractionShell instance.")
+        if not isinstance(contractions_two, GeneralizedContractionShell):
+            raise TypeError("`contractions_two` must be a GeneralizedContractionShell instance.")
 
         coord_a = contractions_one.coord
         angmoms_a = contractions_one.angmom_components
@@ -125,7 +125,7 @@ def kinetic_energy_integral_cartesian(basis):
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
 
     Returns
@@ -144,7 +144,7 @@ def kinetic_energy_integral_spherical(basis):
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
 
     Returns
@@ -164,10 +164,10 @@ def kinetic_energy_integral_mix(basis, coord_types):
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     coord_types : list/tuple of str
-        Types of the coordinate system for each ContractedCartesianGaussians.
+        Types of the coordinate system for each GeneralizedContractionShell.
         Each entry must be one of "cartesian" or "spherical".
 
     Returns
@@ -186,7 +186,7 @@ def kinetic_energy_integral_lincomb(basis, transform, coord_type="spherical"):
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     transform : np.ndarray(K_orbs, K_sph)
         Array associated with the linear combinations of spherical Gaussians (LCAO's).
@@ -197,7 +197,7 @@ def kinetic_energy_integral_lincomb(basis, transform, coord_type="spherical"):
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each ContractedCartesianGaussians instance.
+        coordinate type of each GeneralizedContractionShell instance.
         Default value is "spherical".
 
     Returns

--- a/gbasis/kinetic_energy.py
+++ b/gbasis/kinetic_energy.py
@@ -95,12 +95,12 @@ class KineticEnergyIntegral(BaseTwoIndexSymmetric):
             raise TypeError("`contractions_two` must be a GeneralizedContractionShell instance.")
 
         coord_a = contractions_one.coord
-        angmoms_a = contractions_one.angmom_components
+        angmoms_a = contractions_one.angmom_components_cart
         alphas_a = contractions_one.exps
         coeffs_a = contractions_one.coeffs
         norm_a_prim = contractions_one.norm_prim
         coord_b = contractions_two.coord
-        angmoms_b = contractions_two.angmom_components
+        angmoms_b = contractions_two.angmom_components_cart
         alphas_b = contractions_two.exps
         coeffs_b = contractions_two.coeffs
         norm_b_prim = contractions_two.norm_prim

--- a/gbasis/moment.py
+++ b/gbasis/moment.py
@@ -130,12 +130,12 @@ class Moment(BaseTwoIndexSymmetric):
             )
 
         coord_a = contractions_one.coord
-        angmoms_a = contractions_one.angmom_components
+        angmoms_a = contractions_one.angmom_components_cart
         exps_a = contractions_one.exps
         coeffs_a = contractions_one.coeffs
         norm_a_prim = contractions_one.norm_prim
         coord_b = contractions_two.coord
-        angmoms_b = contractions_two.angmom_components
+        angmoms_b = contractions_two.angmom_components_cart
         exps_b = contractions_two.exps
         coeffs_b = contractions_two.coeffs
         norm_b_prim = contractions_two.norm_prim

--- a/gbasis/moment.py
+++ b/gbasis/moment.py
@@ -133,12 +133,12 @@ class Moment(BaseTwoIndexSymmetric):
         angmoms_a = contractions_one.angmom_components_cart
         exps_a = contractions_one.exps
         coeffs_a = contractions_one.coeffs
-        norm_a_prim = contractions_one.norm_prim
+        norm_a_prim = contractions_one.norm_prim_cart
         coord_b = contractions_two.coord
         angmoms_b = contractions_two.angmom_components_cart
         exps_b = contractions_two.exps
         coeffs_b = contractions_two.coeffs
-        norm_b_prim = contractions_two.norm_prim
+        norm_b_prim = contractions_two.norm_prim_cart
         output = _compute_multipole_moment_integrals(
             moment_coord,
             moment_orders,

--- a/gbasis/moment.py
+++ b/gbasis/moment.py
@@ -1,7 +1,7 @@
 """Module for computing the moments of a basis set."""
 from gbasis._moment_int import _compute_multipole_moment_integrals
 from gbasis.base_two_symm import BaseTwoIndexSymmetric
-from gbasis.contractions import ContractedCartesianGaussians
+from gbasis.contractions import GeneralizedContractionShell
 import numpy as np
 
 
@@ -10,12 +10,12 @@ class Moment(BaseTwoIndexSymmetric):
 
     Attributes
     ----------
-    _axes_contractions : tuple of tuple of ContractedCartesianGaussians
+    _axes_contractions : tuple of tuple of GeneralizedContractionShell
         Sets of contractions associated with each axis of the moment.
 
     Properties
     ----------
-    contractions : tuple of ContractedCartesianGaussians
+    contractions : tuple of GeneralizedContractionShell
         Contractions that are associated with the first and second indices of the array.
 
     Methods
@@ -23,7 +23,7 @@ class Moment(BaseTwoIndexSymmetric):
     __init__(self, contractions)
         Initialize.
     construct_array_contraction(self, contraction) : np.ndarray(M_1, L_cart_1, M_2, L_cart_2)
-        Return the moment associated with a `ContractedCartesianGaussians` instance.
+        Return the moment associated with a `GeneralizedContractionShell` instance.
         `M_1` is the number of segmented contractions with the same exponents (and angular momentum)
         associated with the first index.
         `L_cart_1` is the number of Cartesian contractions for the given angular momentum associated
@@ -57,10 +57,10 @@ class Moment(BaseTwoIndexSymmetric):
 
         Parameters
         ----------
-        contractions_one : ContractedCartesianGaussians
+        contractions_one : GeneralizedContractionShell
             Contracted Cartesian Gaussians (of the same shell) associated with the first index of
             the array.
-        contractions_two : ContractedCartesianGaussians
+        contractions_two : GeneralizedContractionShell
             Contracted Cartesian Gaussians (of the same shell) associated with the second index of
             the array.
         moment_coord : np.ndarray(3,)
@@ -73,7 +73,7 @@ class Moment(BaseTwoIndexSymmetric):
         Returns
         -------
         array_contraction : np.ndarray(M_1, L_cart_1, M_2, L_cart_2, D)
-            Moment associated with the given instances of ContractedCartesianGaussians.
+            Moment associated with the given instances of GeneralizedContractionShell.
             First axis corresponds to the segmented contraction within `contractions_one`. `M_1` is
             the number of segmented contractions with the same exponents (and angular momentum)
             associated with the first index.
@@ -92,8 +92,8 @@ class Moment(BaseTwoIndexSymmetric):
         Raises
         ------
         TypeError
-            If contractions_one is not a ContractedCartesianGaussians instance.
-            If contractions_two is not a ContractedCartesianGaussians instance.
+            If contractions_one is not a GeneralizedContractionShell instance.
+            If contractions_two is not a GeneralizedContractionShell instance.
             If moment_coord is not a one-dimensional numpy array with 3 elements.
             If moment_orders is not a two-dimensional numpy array with 3 columns and dtype int.
 
@@ -109,10 +109,10 @@ class Moment(BaseTwoIndexSymmetric):
 
         """
         # pylint: disable=R0914
-        if not isinstance(contractions_one, ContractedCartesianGaussians):
-            raise TypeError("`contractions_one` must be a ContractedCartesianGaussians instance.")
-        if not isinstance(contractions_two, ContractedCartesianGaussians):
-            raise TypeError("`contractions_two` must be a ContractedCartesianGaussians instance.")
+        if not isinstance(contractions_one, GeneralizedContractionShell):
+            raise TypeError("`contractions_one` must be a GeneralizedContractionShell instance.")
+        if not isinstance(contractions_two, GeneralizedContractionShell):
+            raise TypeError("`contractions_two` must be a GeneralizedContractionShell instance.")
         if not (
             isinstance(moment_coord, np.ndarray)
             and moment_coord.ndim == 1
@@ -161,7 +161,7 @@ def moment_cartesian(basis, moment_coord, moment_orders):
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     moment_coord : np.ndarray(3,)
         Center of the moment.
@@ -195,7 +195,7 @@ def moment_spherical(basis, moment_coord, moment_orders):
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     moment_coord : np.ndarray(3,)
         Center of the moment.
@@ -230,7 +230,7 @@ def moment_mix(basis, moment_coord, moment_orders, coord_types):
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     moment_coord : np.ndarray(3,)
         Center of the moment.
@@ -239,7 +239,7 @@ def moment_mix(basis, moment_coord, moment_orders, coord_types):
         Note that a two dimensional array must be given, even if there is only one set of orders
         of the moment.
     coord_types : list/tuple of str
-        Types of the coordinate system for each ContractedCartesianGaussians.
+        Types of the coordinate system for each GeneralizedContractionShell.
         Each entry must be one of "cartesian" or "spherical".
 
     Returns
@@ -267,7 +267,7 @@ def moment_lincomb(basis, transform, moment_coord, moment_orders, coord_type="sp
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     transform : np.ndarray(K_orbs, K_sph)
         Array associated with the linear combinations of spherical Gaussians (LCAO's).
@@ -284,7 +284,7 @@ def moment_lincomb(basis, transform, moment_coord, moment_orders, coord_type="sp
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each ContractedCartesianGaussians instance.
+        coordinate type of each GeneralizedContractionShell instance.
         Default value is "spherical".
 
     Returns

--- a/gbasis/nuclear_electron_attraction.py
+++ b/gbasis/nuclear_electron_attraction.py
@@ -13,7 +13,7 @@ def nuclear_electron_attraction_cartesian(basis, nuclear_coords, nuclear_charges
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     nuclear_coords : np.ndarray(N_nuc, 3)
         Coordinates of each atom.
@@ -36,7 +36,7 @@ def nuclear_electron_attraction_spherical(basis, nuclear_coords, nuclear_charges
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     nuclear_coords : np.ndarray(N_nuc, 3)
         Coordinates of each atom.
@@ -60,14 +60,14 @@ def nuclear_electron_attraction_mix(basis, nuclear_coords, nuclear_charges, coor
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     nuclear_coords : np.ndarray(N_nuc, 3)
         Coordinates of each atom.
     nuclear_charges : np.ndarray(N_nuc)
         Charges of each atom.
     coord_types : list/tuple of str
-        Types of the coordinate system for each ContractedCartesianGaussians.
+        Types of the coordinate system for each GeneralizedContractionShell.
         Each entry must be one of "cartesian" or "spherical".
 
     Returns
@@ -88,7 +88,7 @@ def nuclear_electron_attraction_lincomb(
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     transform : np.ndarray(K_orbs, K_sph)
         Array associated with the linear combinations of spherical Gaussians (LCAO's).
@@ -103,7 +103,7 @@ def nuclear_electron_attraction_lincomb(
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each ContractedCartesianGaussians instance.
+        coordinate type of each GeneralizedContractionShell instance.
         Default value is "spherical".
 
     Returns

--- a/gbasis/overlap.py
+++ b/gbasis/overlap.py
@@ -95,12 +95,12 @@ class Overlap(BaseTwoIndexSymmetric):
         angmoms_a = contractions_one.angmom_components_cart
         alphas_a = contractions_one.exps
         coeffs_a = contractions_one.coeffs
-        norm_a_prim = contractions_one.norm_prim
+        norm_a_prim = contractions_one.norm_prim_cart
         coord_b = contractions_two.coord
         angmoms_b = contractions_two.angmom_components_cart
         alphas_b = contractions_two.exps
         coeffs_b = contractions_two.coeffs
-        norm_b_prim = contractions_two.norm_prim
+        norm_b_prim = contractions_two.norm_prim_cart
         return _compute_multipole_moment_integrals(
             np.zeros(3),
             np.zeros((1, 3), dtype=int),

--- a/gbasis/overlap.py
+++ b/gbasis/overlap.py
@@ -92,12 +92,12 @@ class Overlap(BaseTwoIndexSymmetric):
             raise TypeError("`contractions_two` must be a GeneralizedContractionShell instance.")
 
         coord_a = contractions_one.coord
-        angmoms_a = contractions_one.angmom_components
+        angmoms_a = contractions_one.angmom_components_cart
         alphas_a = contractions_one.exps
         coeffs_a = contractions_one.coeffs
         norm_a_prim = contractions_one.norm_prim
         coord_b = contractions_two.coord
-        angmoms_b = contractions_two.angmom_components
+        angmoms_b = contractions_two.angmom_components_cart
         alphas_b = contractions_two.exps
         coeffs_b = contractions_two.coeffs
         norm_b_prim = contractions_two.norm_prim

--- a/gbasis/overlap.py
+++ b/gbasis/overlap.py
@@ -1,7 +1,7 @@
 """Functions for computing overlap of a basis set."""
 from gbasis._moment_int import _compute_multipole_moment_integrals
 from gbasis.base_two_symm import BaseTwoIndexSymmetric
-from gbasis.contractions import ContractedCartesianGaussians
+from gbasis.contractions import GeneralizedContractionShell
 import numpy as np
 
 
@@ -10,12 +10,12 @@ class Overlap(BaseTwoIndexSymmetric):
 
     Attributes
     ----------
-    _axes_contractions : tuple of tuple of ContractedCartesianGaussians
+    _axes_contractions : tuple of tuple of GeneralizedContractionShell
         Sets of contractions associated with each axis of the array.
 
     Properties
     ----------
-    contractions : tuple of ContractedCartesianGaussians
+    contractions : tuple of GeneralizedContractionShell
         Contractions that are associated with the first and second indices of the array.
 
     Methods
@@ -24,7 +24,7 @@ class Overlap(BaseTwoIndexSymmetric):
         Initialize.
     construct_array_contraction(contractions_one, contractions_two) :
     np.ndarray(M_1, L_cart_1, M_2, L_cart_2)
-        Return the overlap associated with a `ContractedCartesianGaussians` instance.
+        Return the overlap associated with a `GeneralizedContractionShell` instance.
         `M_1` is the number of segmented contractions with the same exponents (and angular momentum)
         associated with the first index.
         `L_cart_1` is the number of Cartesian contractions for the given angular momentum associated
@@ -55,17 +55,17 @@ class Overlap(BaseTwoIndexSymmetric):
 
         Parameters
         ----------
-        contractions_one : ContractedCartesianGaussians
+        contractions_one : GeneralizedContractionShell
             Contracted Cartesian Gaussians (of the same shell) associated with the first index of
             the overlap.
-        contractions_two : ContractedCartesianGaussians
+        contractions_two : GeneralizedContractionShell
             Contracted Cartesian Gaussians (of the same shell) associated with the second index of
             the overlap.
 
         Returns
         -------
         array_contraction : np.ndarray(M_1, L_cart_1, M_2, L_cart_2)
-            Overlap associated with the given instances of ContractedCartesianGaussians.
+            Overlap associated with the given instances of GeneralizedContractionShell.
             First axis corresponds to the segmented contraction within `contractions_one`. `M_1` is
             the number of segmented contractions with the same exponents (and angular momentum)
             associated with the first index.
@@ -82,14 +82,14 @@ class Overlap(BaseTwoIndexSymmetric):
         Raises
         ------
         TypeError
-            If contractions_one is not a ContractedCartesianGaussians instance.
-            If contractions_two is not a ContractedCartesianGaussians instance.
+            If contractions_one is not a GeneralizedContractionShell instance.
+            If contractions_two is not a GeneralizedContractionShell instance.
 
         """
-        if not isinstance(contractions_one, ContractedCartesianGaussians):
-            raise TypeError("`contractions_one` must be a ContractedCartesianGaussians instance.")
-        if not isinstance(contractions_two, ContractedCartesianGaussians):
-            raise TypeError("`contractions_two` must be a ContractedCartesianGaussians instance.")
+        if not isinstance(contractions_one, GeneralizedContractionShell):
+            raise TypeError("`contractions_one` must be a GeneralizedContractionShell instance.")
+        if not isinstance(contractions_two, GeneralizedContractionShell):
+            raise TypeError("`contractions_two` must be a GeneralizedContractionShell instance.")
 
         coord_a = contractions_one.coord
         angmoms_a = contractions_one.angmom_components
@@ -122,7 +122,7 @@ def overlap_cartesian(basis):
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
 
     Returns
@@ -141,7 +141,7 @@ def overlap_spherical(basis):
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
 
     Returns
@@ -162,10 +162,10 @@ def overlap_mix(basis, coord_types):
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     coord_types : list/tuple of str
-        Types of the coordinate system for each ContractedCartesianGaussians.
+        Types of the coordinate system for each GeneralizedContractionShell.
         Each entry must be one of "cartesian" or "spherical".
 
     Returns
@@ -184,7 +184,7 @@ def overlap_lincomb(basis, transform, coord_type="spherical"):
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     transform : np.ndarray(K_orbs, K_sph)
         Array associated with the linear combinations of spherical Gaussians (LCAO's).
@@ -195,7 +195,7 @@ def overlap_lincomb(basis, transform, coord_type="spherical"):
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each ContractedCartesianGaussians instance.
+        coordinate type of each GeneralizedContractionShell instance.
         Default value is "spherical".
 
     Returns

--- a/gbasis/parsers.py
+++ b/gbasis/parsers.py
@@ -1,6 +1,7 @@
 """Parsers for reading basis set files."""
 import re
 
+from gbasis.contractions import GeneralizedContractionShell
 import numpy as np
 
 
@@ -65,3 +66,46 @@ def parse_nwchem(nwchem_basis):
                 output[atom].append((angmom, exps, coeffs_gen[:, i]))
 
     return output
+
+
+def make_contractions(basis_dict, atoms, coords):
+    """Return the contractions that correspond to the given atoms for the given basis.
+
+    Parameters
+    ----------
+    basis_dict : dict of str to list of 3-tuple of (int, np.ndarray, np.ndarray)
+        Output of the parsers from gbasis.parsers.
+    atoms : N-list/tuple of str
+        Atoms at which the contractions are centered.
+    coords : np.ndarray(N, 3)
+        Coordinates of each atom.
+
+    Returns
+    -------
+    basis : tuple of GeneralizedContractionShell
+        Contractions for each atom.
+        Contractions are ordered in the same order as in the values of `basis_dict`.
+
+    Raises
+    ------
+    TypeError
+        If atoms is not a list or tuple of strings.
+        If coords is not a two-dimensional numpy array with 3 columns.
+    ValueError
+        If the length of atoms is not equal to the number of rows of coords.
+
+    """
+    if not (isinstance(atoms, (list, tuple)) and all(isinstance(i, str) for i in atoms)):
+        raise TypeError("Atoms must be provided as a list or tuple.")
+    if not (isinstance(coords, np.ndarray) and coords.ndim == 2 and coords.shape[1] == 3):
+        raise TypeError(
+            "Coordinates must be provided as a two-dimensional numpy array with three columns."
+        )
+    if len(atoms) != coords.shape[0]:
+        raise ValueError("Number of atoms must be equal to the number of rows in the coordinates.")
+
+    basis = []
+    for atom, coord in zip(atoms, coords):
+        for angmom, exps, coeffs in basis_dict[atom]:
+            basis.append(GeneralizedContractionShell(angmom, coord, coeffs, exps))
+    return tuple(basis)

--- a/gbasis/point_charge.py
+++ b/gbasis/point_charge.py
@@ -201,12 +201,12 @@ class PointChargeIntegral(BaseTwoIndexSymmetric):
 
         coord_a = contractions_one.coord
         angmom_a = contractions_one.angmom
-        angmoms_a = contractions_one.angmom_components
+        angmoms_a = contractions_one.angmom_components_cart
         exps_a = contractions_one.exps
         coeffs_a = contractions_one.coeffs
         coord_b = contractions_two.coord
         angmom_b = contractions_two.angmom
-        angmoms_b = contractions_two.angmom_components
+        angmoms_b = contractions_two.angmom_components_cart
         exps_b = contractions_two.exps
         coeffs_b = contractions_two.coeffs
 

--- a/gbasis/point_charge.py
+++ b/gbasis/point_charge.py
@@ -1,7 +1,7 @@
 """Module for computing point charge integrals."""
 from gbasis._one_elec_int import _compute_one_elec_integrals
 from gbasis.base_two_symm import BaseTwoIndexSymmetric
-from gbasis.contractions import ContractedCartesianGaussians
+from gbasis.contractions import GeneralizedContractionShell
 import numpy as np
 from scipy.special import hyp1f1  # pylint: disable=E0611
 
@@ -22,12 +22,12 @@ class PointChargeIntegral(BaseTwoIndexSymmetric):
 
     Attributes
     ----------
-    _axes_contractions : tuple of tuple of ContractedCartesianGaussians
+    _axes_contractions : tuple of tuple of GeneralizedContractionShell
         Sets of contractions associated with each axis of the array.
 
     Properties
     ----------
-    contractions : tuple of ContractedCartesianGaussians
+    contractions : tuple of GeneralizedContractionShell
         Contractions that are associated with the first and second indices of the array.
 
     Methods
@@ -40,7 +40,7 @@ class PointChargeIntegral(BaseTwoIndexSymmetric):
         primitives on the left and right side, respectively.
     construct_array_contraction(self, contractions_one, contractions_two, coords_points,
                                 charges_points)
-        Return the point charge integrals for the given `ContractedCartesianGaussians` instances.
+        Return the point charge integrals for the given `GeneralizedContractionShell` instances.
         `M_1` is the number of segmented contractions with the same exponents (and angular momentum)
         associated with the first index.
         `L_cart_1` is the number of Cartesian contractions for the given angular momentum associated
@@ -122,10 +122,10 @@ class PointChargeIntegral(BaseTwoIndexSymmetric):
 
         Parameters
         ----------
-        contractions_one : ContractedCartesianGaussians
+        contractions_one : GeneralizedContractionShell
             Contracted Cartesian Gaussians (of the same shell) associated with the first index of
             the array.
-        contractions_two : ContractedCartesianGaussians
+        contractions_two : GeneralizedContractionShell
             Contracted Cartesian Gaussians (of the same shell) associated with the second index of
             the array.
         coords_points : np.ndarray(N, 3)
@@ -139,7 +139,7 @@ class PointChargeIntegral(BaseTwoIndexSymmetric):
         -------
         array_contraction : np.ndarray(M_1, L_cart_1, M_2, L_cart_2, N)
             Point charge integral associated with the given instances of
-            ContractedCartesianGaussians.
+            GeneralizedContractionShell.
             First axis corresponds to the segmented contraction within `contractions_one`. `M_1` is
             the number of segmented contractions with the same exponents (and angular momentum)
             associated with the first index.
@@ -157,8 +157,8 @@ class PointChargeIntegral(BaseTwoIndexSymmetric):
         Raises
         ------
         TypeError
-            If `contractions_one` is not a ContractedCartesianGaussians instance.
-            If `contractions_two` is not a ContractedCartesianGaussians instance.
+            If `contractions_one` is not a GeneralizedContractionShell instance.
+            If `contractions_two` is not a GeneralizedContractionShell instance.
             If `coords_points` is not a two-dimensional numpy array of dtype int/float with 3
             columns.
             If `charges_points` is not a one-dimensional numpy array of int/float.
@@ -169,10 +169,10 @@ class PointChargeIntegral(BaseTwoIndexSymmetric):
         """
         # pylint: disable=R0914
 
-        if not isinstance(contractions_one, ContractedCartesianGaussians):
-            raise TypeError("`contractions_one` must be a ContractedCartesianGaussians instance.")
-        if not isinstance(contractions_two, ContractedCartesianGaussians):
-            raise TypeError("`contractions_two` must be a ContractedCartesianGaussians instance.")
+        if not isinstance(contractions_one, GeneralizedContractionShell):
+            raise TypeError("`contractions_one` must be a GeneralizedContractionShell instance.")
+        if not isinstance(contractions_two, GeneralizedContractionShell):
+            raise TypeError("`contractions_two` must be a GeneralizedContractionShell instance.")
         if not (
             isinstance(coords_points, np.ndarray)
             and coords_points.ndim == 2
@@ -270,7 +270,7 @@ def point_charge_cartesian(basis, coords_points, charges_points):
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     coords_points : np.ndarray(N, 3)
         Coordinates of the point charges.
@@ -297,7 +297,7 @@ def point_charge_spherical(basis, coords_points, charges_points):
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     coords_points : np.ndarray(3,)
         Coordinate of the point charge.
@@ -326,7 +326,7 @@ def point_charge_mix(basis, coords_points, charges_points, coord_types):
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     coords_points : np.ndarray(3,)
         Coordinate of the point charge.
@@ -335,7 +335,7 @@ def point_charge_mix(basis, coords_points, charges_points, coord_types):
     charges_points : float
         Charge of the point charge.
     coord_types : list/tuple of str
-        Types of the coordinate system for each ContractedCartesianGaussians.
+        Types of the coordinate system for each GeneralizedContractionShell.
         Each entry must be one of "cartesian" or "spherical".
 
     Returns
@@ -357,7 +357,7 @@ def point_charge_lincomb(basis, transform, coords_points, charges_points, coord_
 
     Parameters
     ----------
-    basis : list/tuple of ContractedCartesianGaussians
+    basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
     transform : np.ndarray(K_orbs, K_sph)
         Array associated with the linear combinations of spherical Gaussians (LCAO's).
@@ -374,7 +374,7 @@ def point_charge_lincomb(basis, transform, coords_points, charges_points, coord_
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each ContractedCartesianGaussians instance.
+        coordinate type of each GeneralizedContractionShell instance.
         Default value is "spherical".
 
     Returns

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,6 +1,6 @@
 """Test gbasis.base.BaseGuassianRelatedArray."""
 from gbasis.base import BaseGaussianRelatedArray
-from gbasis.contractions import ContractedCartesianGaussians
+from gbasis.contractions import GeneralizedContractionShell
 import numpy as np
 import pytest
 from utils import disable_abstract, skip_init
@@ -10,7 +10,7 @@ def test_init():
     """Test base.BaseGaussianRelatedArray."""
     Test = disable_abstract(BaseGaussianRelatedArray)  # noqa: N806
     test = skip_init(Test)
-    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     assert not hasattr(test, "_axes_contractions")
     with pytest.raises(TypeError):
         Test.__init__(test, set([contractions]))
@@ -38,7 +38,7 @@ def test_contruct_array_contraction():
             "construct_array_contraction": BaseGaussianRelatedArray.construct_array_contraction
         },
     )
-    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     with pytest.raises(TypeError):
         Test([contractions])
 
@@ -52,7 +52,7 @@ def test_contruct_array_cartesian():
             "construct_array_cartesian": BaseGaussianRelatedArray.construct_array_cartesian
         },
     )
-    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     with pytest.raises(TypeError):
         Test([contractions])
 
@@ -66,7 +66,7 @@ def test_contruct_array_spherical():
             "construct_array_spherical": BaseGaussianRelatedArray.construct_array_spherical
         },
     )
-    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     with pytest.raises(TypeError):
         Test([contractions])
 
@@ -80,6 +80,6 @@ def test_contruct_array_lincomb():
             "construct_array_lincomb": BaseGaussianRelatedArray.construct_array_lincomb
         },
     )
-    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     with pytest.raises(TypeError):
         Test([contractions])

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -10,7 +10,7 @@ def test_init():
     """Test base.BaseGaussianRelatedArray."""
     Test = disable_abstract(BaseGaussianRelatedArray)  # noqa: N806
     test = skip_init(Test)
-    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     assert not hasattr(test, "_axes_contractions")
     with pytest.raises(TypeError):
         Test.__init__(test, set([contractions]))
@@ -38,7 +38,7 @@ def test_contruct_array_contraction():
             "construct_array_contraction": BaseGaussianRelatedArray.construct_array_contraction
         },
     )
-    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     with pytest.raises(TypeError):
         Test([contractions])
 
@@ -52,7 +52,7 @@ def test_contruct_array_cartesian():
             "construct_array_cartesian": BaseGaussianRelatedArray.construct_array_cartesian
         },
     )
-    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     with pytest.raises(TypeError):
         Test([contractions])
 
@@ -66,7 +66,7 @@ def test_contruct_array_spherical():
             "construct_array_spherical": BaseGaussianRelatedArray.construct_array_spherical
         },
     )
-    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     with pytest.raises(TypeError):
         Test([contractions])
 
@@ -80,6 +80,6 @@ def test_contruct_array_lincomb():
             "construct_array_lincomb": BaseGaussianRelatedArray.construct_array_lincomb
         },
     )
-    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     with pytest.raises(TypeError):
         Test([contractions])

--- a/tests/test_base_one.py
+++ b/tests/test_base_one.py
@@ -11,7 +11,7 @@ def test_init():
     """Test BaseOneIndex.__init__."""
     Test = disable_abstract(BaseOneIndex)  # noqa: N806
     test = skip_init(Test)
-    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     Test.__init__(test, [contractions])
     assert test._axes_contractions == ((contractions,),)
     with pytest.raises(TypeError):
@@ -21,7 +21,7 @@ def test_init():
 def test_contractions():
     """Test BaseOneIndex.constractions."""
     Test = disable_abstract(BaseOneIndex)  # noqa: N806
-    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     test = Test([contractions])
     assert test.contractions[0] == contractions
 
@@ -33,14 +33,14 @@ def test_contruct_array_contraction():
         BaseOneIndex,
         dict_overwrite={"construct_array_contraction": BaseOneIndex.construct_array_contraction},
     )
-    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     with pytest.raises(TypeError):
         Test([contractions])
 
 
 def test_contruct_array_cartesian():
     """Test BaseOneIndex.construct_array_cartesian."""
-    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     contractions.norm_cont = np.ones((1, 5))
     Test = disable_abstract(  # noqa: N806
         BaseOneIndex,
@@ -78,7 +78,7 @@ def test_contruct_array_cartesian():
 
 def test_contruct_array_spherical():
     """Test BaseOneIndex.construct_array_spherical."""
-    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     transform = generate_transformation(
         1, contractions.angmom_components, contractions.spherical_order, "left"
     )
@@ -108,9 +108,7 @@ def test_contruct_array_spherical():
         np.vstack([transform.dot(np.arange(9).reshape(3, 3)) * 2] * 2),
     )
 
-    contractions = GeneralizedContractionShell(
-        1, np.array([1, 2, 3]), 0, np.ones((1, 2)), np.ones(1)
-    )
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones((1, 2)), np.ones(1))
     Test = disable_abstract(  # noqa: N806
         BaseOneIndex,
         dict_overwrite={
@@ -157,7 +155,7 @@ def test_contruct_array_spherical():
 
 def test_contruct_array_mix():
     """Test BaseOneIndex.construct_array_mix."""
-    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
 
     Test = disable_abstract(  # noqa: N806
         BaseOneIndex,
@@ -192,9 +190,7 @@ def test_contruct_array_mix():
         test.construct_array_cartesian(a=3), test.construct_array_mix(["cartesian"] * 2, a=3)
     )
 
-    contractions = GeneralizedContractionShell(
-        1, np.array([1, 2, 3]), 0, np.ones((1, 2)), np.ones(1)
-    )
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones((1, 2)), np.ones(1))
     Test = disable_abstract(  # noqa: N806
         BaseOneIndex,
         dict_overwrite={
@@ -240,7 +236,7 @@ def test_contruct_array_mix():
 
 def test_contruct_array_lincomb():
     """Test BaseOneIndex.construct_array_lincomb."""
-    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     sph_transform = generate_transformation(
         1, contractions.angmom_components, contractions.spherical_order, "left"
     )

--- a/tests/test_base_one.py
+++ b/tests/test_base_one.py
@@ -80,7 +80,7 @@ def test_contruct_array_spherical():
     """Test BaseOneIndex.construct_array_spherical."""
     contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     transform = generate_transformation(
-        1, contractions.angmom_components, contractions.spherical_order, "left"
+        1, contractions.angmom_components_cart, contractions.angmom_components_sph, "left"
     )
 
     Test = disable_abstract(  # noqa: N806
@@ -238,7 +238,7 @@ def test_contruct_array_lincomb():
     """Test BaseOneIndex.construct_array_lincomb."""
     contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     sph_transform = generate_transformation(
-        1, contractions.angmom_components, contractions.spherical_order, "left"
+        1, contractions.angmom_components_cart, contractions.angmom_components_sph, "left"
     )
     orb_transform = np.random.rand(3, 3)
 

--- a/tests/test_base_one.py
+++ b/tests/test_base_one.py
@@ -1,6 +1,6 @@
 """Test gbasis.base_one."""
 from gbasis.base_one import BaseOneIndex
-from gbasis.contractions import ContractedCartesianGaussians
+from gbasis.contractions import GeneralizedContractionShell
 from gbasis.spherical import generate_transformation
 import numpy as np
 import pytest
@@ -11,7 +11,7 @@ def test_init():
     """Test BaseOneIndex.__init__."""
     Test = disable_abstract(BaseOneIndex)  # noqa: N806
     test = skip_init(Test)
-    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     Test.__init__(test, [contractions])
     assert test._axes_contractions == ((contractions,),)
     with pytest.raises(TypeError):
@@ -21,7 +21,7 @@ def test_init():
 def test_contractions():
     """Test BaseOneIndex.constractions."""
     Test = disable_abstract(BaseOneIndex)  # noqa: N806
-    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     test = Test([contractions])
     assert test.contractions[0] == contractions
 
@@ -33,14 +33,14 @@ def test_contruct_array_contraction():
         BaseOneIndex,
         dict_overwrite={"construct_array_contraction": BaseOneIndex.construct_array_contraction},
     )
-    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     with pytest.raises(TypeError):
         Test([contractions])
 
 
 def test_contruct_array_cartesian():
     """Test BaseOneIndex.construct_array_cartesian."""
-    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     contractions.norm_cont = np.ones((1, 5))
     Test = disable_abstract(  # noqa: N806
         BaseOneIndex,
@@ -78,7 +78,7 @@ def test_contruct_array_cartesian():
 
 def test_contruct_array_spherical():
     """Test BaseOneIndex.construct_array_spherical."""
-    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     transform = generate_transformation(
         1, contractions.angmom_components, contractions.spherical_order, "left"
     )
@@ -108,7 +108,7 @@ def test_contruct_array_spherical():
         np.vstack([transform.dot(np.arange(9).reshape(3, 3)) * 2] * 2),
     )
 
-    contractions = ContractedCartesianGaussians(
+    contractions = GeneralizedContractionShell(
         1, np.array([1, 2, 3]), 0, np.ones((1, 2)), np.ones(1)
     )
     Test = disable_abstract(  # noqa: N806
@@ -157,7 +157,7 @@ def test_contruct_array_spherical():
 
 def test_contruct_array_mix():
     """Test BaseOneIndex.construct_array_mix."""
-    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
 
     Test = disable_abstract(  # noqa: N806
         BaseOneIndex,
@@ -192,7 +192,7 @@ def test_contruct_array_mix():
         test.construct_array_cartesian(a=3), test.construct_array_mix(["cartesian"] * 2, a=3)
     )
 
-    contractions = ContractedCartesianGaussians(
+    contractions = GeneralizedContractionShell(
         1, np.array([1, 2, 3]), 0, np.ones((1, 2)), np.ones(1)
     )
     Test = disable_abstract(  # noqa: N806
@@ -240,7 +240,7 @@ def test_contruct_array_mix():
 
 def test_contruct_array_lincomb():
     """Test BaseOneIndex.construct_array_lincomb."""
-    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     sph_transform = generate_transformation(
         1, contractions.angmom_components, contractions.spherical_order, "left"
     )

--- a/tests/test_base_one.py
+++ b/tests/test_base_one.py
@@ -79,7 +79,9 @@ def test_contruct_array_cartesian():
 def test_contruct_array_spherical():
     """Test BaseOneIndex.construct_array_spherical."""
     contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
-    transform = generate_transformation(1, contractions.angmom_components, "left")
+    transform = generate_transformation(
+        1, contractions.angmom_components, contractions.spherical_order, "left"
+    )
 
     Test = disable_abstract(  # noqa: N806
         BaseOneIndex,
@@ -239,7 +241,9 @@ def test_contruct_array_mix():
 def test_contruct_array_lincomb():
     """Test BaseOneIndex.construct_array_lincomb."""
     contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
-    sph_transform = generate_transformation(1, contractions.angmom_components, "left")
+    sph_transform = generate_transformation(
+        1, contractions.angmom_components, contractions.spherical_order, "left"
+    )
     orb_transform = np.random.rand(3, 3)
 
     Test = disable_abstract(  # noqa: N806

--- a/tests/test_base_two_asymm.py
+++ b/tests/test_base_two_asymm.py
@@ -11,7 +11,7 @@ def test_init():
     """Test BaseTwoIndexAsymmetric.__init__."""
     Test = disable_abstract(BaseTwoIndexAsymmetric)  # noqa: N806
     test = skip_init(Test)
-    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     Test.__init__(test, [contractions], [contractions])
     assert test._axes_contractions == ((contractions,), (contractions,))
     with pytest.raises(TypeError):
@@ -23,8 +23,8 @@ def test_init():
 def test_contractions_one():
     """Test BaseTwoIndexAsymmetric.constractions_one."""
     Test = disable_abstract(BaseTwoIndexAsymmetric)  # noqa: N806
-    cont_one = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
-    cont_two = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_one = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
+    cont_two = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     test = Test([cont_one], [cont_two])
     assert test.contractions_one[0] == cont_one
 
@@ -32,8 +32,8 @@ def test_contractions_one():
 def test_contractions_two():
     """Test BaseTwoIndexAsymmetric.constractions_two."""
     Test = disable_abstract(BaseTwoIndexAsymmetric)  # noqa: N806
-    cont_one = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
-    cont_two = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_one = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
+    cont_two = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     test = Test([cont_one], [cont_two])
     assert test.contractions_two[0] == cont_two
 
@@ -47,14 +47,14 @@ def test_contruct_array_contraction():
             "construct_array_contraction": BaseTwoIndexAsymmetric.construct_array_contraction
         },
     )
-    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     with pytest.raises(TypeError):
         Test([contractions])
 
 
 def test_contruct_array_cartesian():
     """Test BaseTwoIndexAsymmetric.construct_array_cartesian."""
-    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     Test = disable_abstract(  # noqa: N806
         BaseTwoIndexAsymmetric,
         dict_overwrite={
@@ -80,8 +80,8 @@ def test_contruct_array_cartesian():
             )
         },
     )
-    cont_one = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
-    cont_two = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_one = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
+    cont_two = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     cont_one.norm_cont = np.ones((1, 2))
     cont_two.norm_cont = np.ones((1, 5))
     test = Test([cont_one, cont_one], [cont_two])
@@ -105,7 +105,7 @@ def test_contruct_array_cartesian():
 
 def test_contruct_array_spherical():
     """Test BaseTwoIndexAsymmetric.construct_array_spherical."""
-    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     transform = generate_transformation(
         1, contractions.angmom_components, contractions.spherical_order, "left"
     )
@@ -194,7 +194,7 @@ def test_contruct_array_spherical():
 
 def test_contruct_array_mix():
     """Test BaseTwoIndexAsymmetric.construct_array_mix."""
-    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
 
     Test = disable_abstract(  # noqa: N806
         BaseTwoIndexAsymmetric,
@@ -299,7 +299,7 @@ def test_contruct_array_mix():
 
 def test_contruct_array_lincomb():
     """Test BaseTwoIndexAsymmetric.construct_array_lincomb."""
-    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     sph_transform = generate_transformation(
         1, contractions.angmom_components, contractions.spherical_order, "left"
     )

--- a/tests/test_base_two_asymm.py
+++ b/tests/test_base_two_asymm.py
@@ -107,7 +107,7 @@ def test_contruct_array_spherical():
     """Test BaseTwoIndexAsymmetric.construct_array_spherical."""
     contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     transform = generate_transformation(
-        1, contractions.angmom_components, contractions.spherical_order, "left"
+        1, contractions.angmom_components_cart, contractions.angmom_components_sph, "left"
     )
 
     Test = disable_abstract(  # noqa: N806
@@ -301,7 +301,7 @@ def test_contruct_array_lincomb():
     """Test BaseTwoIndexAsymmetric.construct_array_lincomb."""
     contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     sph_transform = generate_transformation(
-        1, contractions.angmom_components, contractions.spherical_order, "left"
+        1, contractions.angmom_components_cart, contractions.angmom_components_sph, "left"
     )
     orb_transform_one = np.random.rand(3, 3)
     orb_transform_two = np.random.rand(3, 3)

--- a/tests/test_base_two_asymm.py
+++ b/tests/test_base_two_asymm.py
@@ -106,7 +106,9 @@ def test_contruct_array_cartesian():
 def test_contruct_array_spherical():
     """Test BaseTwoIndexAsymmetric.construct_array_spherical."""
     contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
-    transform = generate_transformation(1, contractions.angmom_components, "left")
+    transform = generate_transformation(
+        1, contractions.angmom_components, contractions.spherical_order, "left"
+    )
 
     Test = disable_abstract(  # noqa: N806
         BaseTwoIndexAsymmetric,
@@ -298,7 +300,9 @@ def test_contruct_array_mix():
 def test_contruct_array_lincomb():
     """Test BaseTwoIndexAsymmetric.construct_array_lincomb."""
     contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
-    sph_transform = generate_transformation(1, contractions.angmom_components, "left")
+    sph_transform = generate_transformation(
+        1, contractions.angmom_components, contractions.spherical_order, "left"
+    )
     orb_transform_one = np.random.rand(3, 3)
     orb_transform_two = np.random.rand(3, 3)
 

--- a/tests/test_base_two_asymm.py
+++ b/tests/test_base_two_asymm.py
@@ -1,6 +1,6 @@
 """Test gbasis.base_two_asymm."""
 from gbasis.base_two_asymm import BaseTwoIndexAsymmetric
-from gbasis.contractions import ContractedCartesianGaussians
+from gbasis.contractions import GeneralizedContractionShell
 from gbasis.spherical import generate_transformation
 import numpy as np
 import pytest
@@ -11,7 +11,7 @@ def test_init():
     """Test BaseTwoIndexAsymmetric.__init__."""
     Test = disable_abstract(BaseTwoIndexAsymmetric)  # noqa: N806
     test = skip_init(Test)
-    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     Test.__init__(test, [contractions], [contractions])
     assert test._axes_contractions == ((contractions,), (contractions,))
     with pytest.raises(TypeError):
@@ -23,8 +23,8 @@ def test_init():
 def test_contractions_one():
     """Test BaseTwoIndexAsymmetric.constractions_one."""
     Test = disable_abstract(BaseTwoIndexAsymmetric)  # noqa: N806
-    cont_one = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
-    cont_two = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_one = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_two = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     test = Test([cont_one], [cont_two])
     assert test.contractions_one[0] == cont_one
 
@@ -32,8 +32,8 @@ def test_contractions_one():
 def test_contractions_two():
     """Test BaseTwoIndexAsymmetric.constractions_two."""
     Test = disable_abstract(BaseTwoIndexAsymmetric)  # noqa: N806
-    cont_one = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
-    cont_two = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_one = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_two = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     test = Test([cont_one], [cont_two])
     assert test.contractions_two[0] == cont_two
 
@@ -47,14 +47,14 @@ def test_contruct_array_contraction():
             "construct_array_contraction": BaseTwoIndexAsymmetric.construct_array_contraction
         },
     )
-    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     with pytest.raises(TypeError):
         Test([contractions])
 
 
 def test_contruct_array_cartesian():
     """Test BaseTwoIndexAsymmetric.construct_array_cartesian."""
-    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     Test = disable_abstract(  # noqa: N806
         BaseTwoIndexAsymmetric,
         dict_overwrite={
@@ -80,8 +80,8 @@ def test_contruct_array_cartesian():
             )
         },
     )
-    cont_one = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
-    cont_two = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_one = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_two = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     cont_one.norm_cont = np.ones((1, 2))
     cont_two.norm_cont = np.ones((1, 5))
     test = Test([cont_one, cont_one], [cont_two])
@@ -105,7 +105,7 @@ def test_contruct_array_cartesian():
 
 def test_contruct_array_spherical():
     """Test BaseTwoIndexAsymmetric.construct_array_spherical."""
-    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     transform = generate_transformation(
         1, contractions.angmom_components, contractions.spherical_order, "left"
     )
@@ -194,7 +194,7 @@ def test_contruct_array_spherical():
 
 def test_contruct_array_mix():
     """Test BaseTwoIndexAsymmetric.construct_array_mix."""
-    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
 
     Test = disable_abstract(  # noqa: N806
         BaseTwoIndexAsymmetric,
@@ -299,7 +299,7 @@ def test_contruct_array_mix():
 
 def test_contruct_array_lincomb():
     """Test BaseTwoIndexAsymmetric.construct_array_lincomb."""
-    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     sph_transform = generate_transformation(
         1, contractions.angmom_components, contractions.spherical_order, "left"
     )

--- a/tests/test_base_two_symm.py
+++ b/tests/test_base_two_symm.py
@@ -1,7 +1,7 @@
 """Test gbasis.base_two_symm."""
 from gbasis.base_two_asymm import BaseTwoIndexAsymmetric
 from gbasis.base_two_symm import BaseTwoIndexSymmetric
-from gbasis.contractions import ContractedCartesianGaussians
+from gbasis.contractions import GeneralizedContractionShell
 from gbasis.spherical import generate_transformation
 import numpy as np
 import pytest
@@ -12,7 +12,7 @@ def test_init():
     """Test BaseTwoIndexSymmetric.__init__."""
     Test = disable_abstract(BaseTwoIndexSymmetric)  # noqa: N806
     test = skip_init(Test)
-    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     Test.__init__(test, [contractions])
     assert test._axes_contractions[0][0] == contractions
     with pytest.raises(TypeError):
@@ -22,7 +22,7 @@ def test_init():
 def test_contractions():
     """Test BaseTwoIndexSymmetric.constractions."""
     Test = disable_abstract(BaseTwoIndexSymmetric)  # noqa: N806
-    cont = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     test = Test([cont])
     assert test.contractions[0] == cont
 
@@ -36,7 +36,7 @@ def test_contruct_array_contraction():
             "construct_array_contraction": BaseTwoIndexSymmetric.construct_array_contraction
         },
     )
-    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     with pytest.raises(TypeError):
         Test([contractions])
 
@@ -49,7 +49,7 @@ def test_contruct_array_contraction():
 # to the tril blocks because the ordering is different.
 def test_contruct_array_cartesian():
     """Test BaseTwoIndexSymmetric.construct_array_cartesian."""
-    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     Test = disable_abstract(  # noqa: N806
         BaseTwoIndexSymmetric,
         dict_overwrite={
@@ -67,8 +67,8 @@ def test_contruct_array_cartesian():
     assert np.allclose(test.construct_array_cartesian(), np.ones((4, 4)) * 2)
     assert np.allclose(test.construct_array_cartesian(a=3), np.ones((4, 4)) * 3)
 
-    cont_one = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
-    cont_two = ContractedCartesianGaussians(2, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_one = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_two = GeneralizedContractionShell(2, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     Test = disable_abstract(  # noqa: N806
         BaseTwoIndexSymmetric,
         dict_overwrite={
@@ -229,7 +229,7 @@ def test_contruct_array_cartesian():
 # to the tril blocks because the ordering is different.
 def test_contruct_array_spherical():
     """Test BaseTwoIndexSymmetric.construct_array_spherical."""
-    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     transform = generate_transformation(
         1, contractions.angmom_components, contractions.spherical_order, "left"
     )
@@ -256,8 +256,8 @@ def test_contruct_array_spherical():
     with pytest.raises(TypeError):
         test.construct_array_spherical(bad_keyword=3)
 
-    cont_one = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
-    cont_two = ContractedCartesianGaussians(2, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_one = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_two = GeneralizedContractionShell(2, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     transform_one = generate_transformation(
         1, cont_one.angmom_components, cont_one.spherical_order, "left"
     )
@@ -400,7 +400,7 @@ def test_contruct_array_spherical():
 
 def test_contruct_array_mix():
     """Test BaseTwoIndex.construct_array_mix."""
-    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
 
     Test = disable_abstract(  # noqa: N806
         BaseTwoIndexSymmetric,
@@ -421,8 +421,8 @@ def test_contruct_array_mix():
         test.construct_array_cartesian(a=3), test.construct_array_mix(["cartesian"], a=3)
     )
 
-    cont_one = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
-    cont_two = ContractedCartesianGaussians(2, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_one = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_two = GeneralizedContractionShell(2, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
 
     Test = disable_abstract(  # noqa: N806
         BaseTwoIndexSymmetric,
@@ -489,7 +489,7 @@ def test_contruct_array_mix():
 
 def test_contruct_array_lincomb():
     """Test BaseTwoIndexSymmetric.construct_array_lincomb."""
-    contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     sph_transform = generate_transformation(
         1, contractions.angmom_components, contractions.spherical_order, "left"
     )
@@ -548,8 +548,8 @@ def test_contruct_array_lincomb():
             )
         },
     )
-    cont_one = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
-    cont_two = ContractedCartesianGaussians(2, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_one = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_two = GeneralizedContractionShell(2, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     cont_one.norm_cont = np.ones((1, cont_one.num_cart))
     cont_two.norm_cont = np.ones((1, cont_two.num_cart))
     test = Test([cont_one, cont_two])
@@ -694,8 +694,8 @@ def test_contruct_array_lincomb():
 
 def test_compare_two_asymm():
     """Test BaseTwoIndexSymmetric by comparing it against BaseTwoIndexAsymmetric."""
-    cont_one = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
-    cont_two = ContractedCartesianGaussians(2, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_one = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_two = GeneralizedContractionShell(2, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     sph_orb_transform = np.random.rand(8, 8)
     cart_orb_transform = np.random.rand(9, 9)
 

--- a/tests/test_base_two_symm.py
+++ b/tests/test_base_two_symm.py
@@ -231,7 +231,7 @@ def test_contruct_array_spherical():
     """Test BaseTwoIndexSymmetric.construct_array_spherical."""
     contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     transform = generate_transformation(
-        1, contractions.angmom_components, contractions.spherical_order, "left"
+        1, contractions.angmom_components_cart, contractions.angmom_components_sph, "left"
     )
 
     Test = disable_abstract(  # noqa: N806
@@ -259,10 +259,10 @@ def test_contruct_array_spherical():
     cont_one = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     cont_two = GeneralizedContractionShell(2, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     transform_one = generate_transformation(
-        1, cont_one.angmom_components, cont_one.spherical_order, "left"
+        1, cont_one.angmom_components_cart, cont_one.angmom_components_sph, "left"
     )
     transform_two = generate_transformation(
-        2, cont_two.angmom_components, cont_two.spherical_order, "left"
+        2, cont_two.angmom_components_cart, cont_two.angmom_components_sph, "left"
     )
 
     Test = disable_abstract(  # noqa: N806
@@ -491,7 +491,7 @@ def test_contruct_array_lincomb():
     """Test BaseTwoIndexSymmetric.construct_array_lincomb."""
     contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     sph_transform = generate_transformation(
-        1, contractions.angmom_components, contractions.spherical_order, "left"
+        1, contractions.angmom_components_cart, contractions.angmom_components_sph, "left"
     )
     orb_transform = np.random.rand(3, 3)
 
@@ -554,10 +554,10 @@ def test_contruct_array_lincomb():
     cont_two.norm_cont = np.ones((1, cont_two.num_cart))
     test = Test([cont_one, cont_two])
     sph_transform_one = generate_transformation(
-        1, cont_one.angmom_components, cont_one.spherical_order, "left"
+        1, cont_one.angmom_components_cart, cont_one.angmom_components_sph, "left"
     )
     sph_transform_two = generate_transformation(
-        2, cont_two.angmom_components, cont_two.spherical_order, "left"
+        2, cont_two.angmom_components_cart, cont_two.angmom_components_sph, "left"
     )
     orb_transform = np.random.rand(8, 8)
     assert np.allclose(

--- a/tests/test_base_two_symm.py
+++ b/tests/test_base_two_symm.py
@@ -12,7 +12,7 @@ def test_init():
     """Test BaseTwoIndexSymmetric.__init__."""
     Test = disable_abstract(BaseTwoIndexSymmetric)  # noqa: N806
     test = skip_init(Test)
-    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     Test.__init__(test, [contractions])
     assert test._axes_contractions[0][0] == contractions
     with pytest.raises(TypeError):
@@ -22,7 +22,7 @@ def test_init():
 def test_contractions():
     """Test BaseTwoIndexSymmetric.constractions."""
     Test = disable_abstract(BaseTwoIndexSymmetric)  # noqa: N806
-    cont = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     test = Test([cont])
     assert test.contractions[0] == cont
 
@@ -36,7 +36,7 @@ def test_contruct_array_contraction():
             "construct_array_contraction": BaseTwoIndexSymmetric.construct_array_contraction
         },
     )
-    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     with pytest.raises(TypeError):
         Test([contractions])
 
@@ -49,7 +49,7 @@ def test_contruct_array_contraction():
 # to the tril blocks because the ordering is different.
 def test_contruct_array_cartesian():
     """Test BaseTwoIndexSymmetric.construct_array_cartesian."""
-    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     Test = disable_abstract(  # noqa: N806
         BaseTwoIndexSymmetric,
         dict_overwrite={
@@ -67,8 +67,8 @@ def test_contruct_array_cartesian():
     assert np.allclose(test.construct_array_cartesian(), np.ones((4, 4)) * 2)
     assert np.allclose(test.construct_array_cartesian(a=3), np.ones((4, 4)) * 3)
 
-    cont_one = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
-    cont_two = GeneralizedContractionShell(2, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_one = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
+    cont_two = GeneralizedContractionShell(2, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     Test = disable_abstract(  # noqa: N806
         BaseTwoIndexSymmetric,
         dict_overwrite={
@@ -229,7 +229,7 @@ def test_contruct_array_cartesian():
 # to the tril blocks because the ordering is different.
 def test_contruct_array_spherical():
     """Test BaseTwoIndexSymmetric.construct_array_spherical."""
-    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     transform = generate_transformation(
         1, contractions.angmom_components, contractions.spherical_order, "left"
     )
@@ -256,8 +256,8 @@ def test_contruct_array_spherical():
     with pytest.raises(TypeError):
         test.construct_array_spherical(bad_keyword=3)
 
-    cont_one = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
-    cont_two = GeneralizedContractionShell(2, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_one = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
+    cont_two = GeneralizedContractionShell(2, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     transform_one = generate_transformation(
         1, cont_one.angmom_components, cont_one.spherical_order, "left"
     )
@@ -400,7 +400,7 @@ def test_contruct_array_spherical():
 
 def test_contruct_array_mix():
     """Test BaseTwoIndex.construct_array_mix."""
-    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
 
     Test = disable_abstract(  # noqa: N806
         BaseTwoIndexSymmetric,
@@ -421,8 +421,8 @@ def test_contruct_array_mix():
         test.construct_array_cartesian(a=3), test.construct_array_mix(["cartesian"], a=3)
     )
 
-    cont_one = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
-    cont_two = GeneralizedContractionShell(2, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_one = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
+    cont_two = GeneralizedContractionShell(2, np.array([1, 2, 3]), np.ones(1), np.ones(1))
 
     Test = disable_abstract(  # noqa: N806
         BaseTwoIndexSymmetric,
@@ -489,7 +489,7 @@ def test_contruct_array_mix():
 
 def test_contruct_array_lincomb():
     """Test BaseTwoIndexSymmetric.construct_array_lincomb."""
-    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     sph_transform = generate_transformation(
         1, contractions.angmom_components, contractions.spherical_order, "left"
     )
@@ -548,8 +548,8 @@ def test_contruct_array_lincomb():
             )
         },
     )
-    cont_one = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
-    cont_two = GeneralizedContractionShell(2, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_one = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
+    cont_two = GeneralizedContractionShell(2, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     cont_one.norm_cont = np.ones((1, cont_one.num_cart))
     cont_two.norm_cont = np.ones((1, cont_two.num_cart))
     test = Test([cont_one, cont_two])
@@ -694,8 +694,8 @@ def test_contruct_array_lincomb():
 
 def test_compare_two_asymm():
     """Test BaseTwoIndexSymmetric by comparing it against BaseTwoIndexAsymmetric."""
-    cont_one = GeneralizedContractionShell(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
-    cont_two = GeneralizedContractionShell(2, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
+    cont_one = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
+    cont_two = GeneralizedContractionShell(2, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     sph_orb_transform = np.random.rand(8, 8)
     cart_orb_transform = np.random.rand(9, 9)
 

--- a/tests/test_base_two_symm.py
+++ b/tests/test_base_two_symm.py
@@ -230,7 +230,9 @@ def test_contruct_array_cartesian():
 def test_contruct_array_spherical():
     """Test BaseTwoIndexSymmetric.construct_array_spherical."""
     contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
-    transform = generate_transformation(1, contractions.angmom_components, "left")
+    transform = generate_transformation(
+        1, contractions.angmom_components, contractions.spherical_order, "left"
+    )
 
     Test = disable_abstract(  # noqa: N806
         BaseTwoIndexSymmetric,
@@ -256,8 +258,12 @@ def test_contruct_array_spherical():
 
     cont_one = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
     cont_two = ContractedCartesianGaussians(2, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
-    transform_one = generate_transformation(1, cont_one.angmom_components, "left")
-    transform_two = generate_transformation(2, cont_two.angmom_components, "left")
+    transform_one = generate_transformation(
+        1, cont_one.angmom_components, cont_one.spherical_order, "left"
+    )
+    transform_two = generate_transformation(
+        2, cont_two.angmom_components, cont_two.spherical_order, "left"
+    )
 
     Test = disable_abstract(  # noqa: N806
         BaseTwoIndexSymmetric,
@@ -484,7 +490,9 @@ def test_contruct_array_mix():
 def test_contruct_array_lincomb():
     """Test BaseTwoIndexSymmetric.construct_array_lincomb."""
     contractions = ContractedCartesianGaussians(1, np.array([1, 2, 3]), 0, np.ones(1), np.ones(1))
-    sph_transform = generate_transformation(1, contractions.angmom_components, "left")
+    sph_transform = generate_transformation(
+        1, contractions.angmom_components, contractions.spherical_order, "left"
+    )
     orb_transform = np.random.rand(3, 3)
 
     Test = disable_abstract(  # noqa: N806
@@ -545,8 +553,12 @@ def test_contruct_array_lincomb():
     cont_one.norm_cont = np.ones((1, cont_one.num_cart))
     cont_two.norm_cont = np.ones((1, cont_two.num_cart))
     test = Test([cont_one, cont_two])
-    sph_transform_one = generate_transformation(1, cont_one.angmom_components, "left")
-    sph_transform_two = generate_transformation(2, cont_two.angmom_components, "left")
+    sph_transform_one = generate_transformation(
+        1, cont_one.angmom_components, cont_one.spherical_order, "left"
+    )
+    sph_transform_two = generate_transformation(
+        2, cont_two.angmom_components, cont_two.spherical_order, "left"
+    )
     orb_transform = np.random.rand(8, 8)
     assert np.allclose(
         test.construct_array_lincomb(orb_transform, "spherical", a=4),

--- a/tests/test_contractions.py
+++ b/tests/test_contractions.py
@@ -6,28 +6,6 @@ import pytest
 from utils import find_datafile, skip_init
 
 
-def test_charge_setter():
-    """Test setter for GeneralizedContractionShell.charge."""
-    test = skip_init(GeneralizedContractionShell)
-    test.charge = 2
-    assert isinstance(test._charge, float) and test._charge == 2
-    test.charge = -2
-    assert isinstance(test._charge, float) and test._charge == -2
-    test.charge = 2.5
-    assert isinstance(test._charge, float) and test._charge == 2.5
-    with pytest.raises(TypeError):
-        test.charge = "0"
-    with pytest.raises(TypeError):
-        test.charge = None
-
-
-def test_charge_getter():
-    """Test getter for GeneralizedContractionShell.charge."""
-    test = skip_init(GeneralizedContractionShell)
-    test._charge = 2
-    assert test.charge == 2
-
-
 def test_coord_setter():
     """Test setter for GeneralizedContractionShell.coord."""
     test = skip_init(GeneralizedContractionShell)
@@ -190,13 +168,11 @@ def tests_init():
     test = GeneralizedContractionShell(
         1,
         np.array([0, 1, 2]),
-        0,
         np.array([1, 2, 3, 4], dtype=float),
         np.array([5, 6, 7, 8], dtype=float),
     )
     assert test._angmom == 1
     assert np.allclose(test._coord, np.array([0, 1, 2]))
-    assert test._charge == 0
     assert np.allclose(test._coeffs, np.array([[1], [2], [3], [4]]))
     assert np.allclose(test._exps, np.array([5, 6, 7, 8]))
 
@@ -249,9 +225,9 @@ def test_spherical_order():
 # TODO: add more tests
 def test_norm_prim():
     """Test GeneralizedContractionShell.norm_prim."""
-    test = GeneralizedContractionShell(0, np.array([0, 0, 0]), 0, np.array([1.0]), np.array([0.25]))
+    test = GeneralizedContractionShell(0, np.array([0, 0, 0]), np.array([1.0]), np.array([0.25]))
     assert np.isclose(test.norm_prim, 0.2519794355383807303479140)
-    test = GeneralizedContractionShell(3, np.array([0, 0, 0]), 0, np.array([1.0]), np.array([0.5]))
+    test = GeneralizedContractionShell(3, np.array([0, 0, 0]), np.array([1.0]), np.array([0.5]))
     assert np.isclose(test.norm_prim[7], 0.6920252830162908851679097)
 
 
@@ -304,22 +280,12 @@ def test_make_contractions():
 
     with pytest.raises(TypeError):
         make_contractions(basis_dict, ["H", "H"], np.array([[0, 0, 0], [1, 1, 1]]), [0, 0])
-    with pytest.raises(TypeError):
-        make_contractions(
-            basis_dict, ["H", "H"], np.array([[0, 0, 0], [1, 1, 1]]), np.array([[0, 0]])
-        )
-
-    with pytest.raises(ValueError):
-        make_contractions(
-            basis_dict, ["H", "H"], np.array([[0, 0, 0], [1, 1, 1]]), np.array([0, 0, 0])
-        )
 
     test = make_contractions(basis_dict, ["H", "H"], np.array([[0, 0, 0], [1, 1, 1]]))
     assert isinstance(test, tuple)
     assert len(test) == 2
     assert test[0].angmom == 0
     assert np.allclose(test[0].coord, np.array([0, 0, 0]))
-    assert test[0].charge == 0
     assert np.allclose(
         test[0].coeffs,
         np.array(
@@ -339,7 +305,6 @@ def test_make_contractions():
     )
     assert test[1].angmom == 0
     assert np.allclose(test[1].coord, np.array([1, 1, 1]))
-    assert test[1].charge == 0
     assert np.allclose(
         test[1].coeffs,
         np.array(
@@ -361,14 +326,14 @@ def test_make_contractions():
 
 def test_assign_norm_cont():
     """Test GeneralizedContractionShell.assign_norm_cont."""
-    test = GeneralizedContractionShell(0, np.array([0, 0, 0]), 0, np.array([1.0]), np.array([0.25]))
+    test = GeneralizedContractionShell(0, np.array([0, 0, 0]), np.array([1.0]), np.array([0.25]))
     test.assign_norm_cont()
     assert np.allclose(test.norm_cont, 1)
 
-    test = GeneralizedContractionShell(1, np.array([0, 0, 0]), 0, np.array([1.0]), np.array([0.25]))
+    test = GeneralizedContractionShell(1, np.array([0, 0, 0]), np.array([1.0]), np.array([0.25]))
     test.assign_norm_cont()
     assert np.allclose(test.norm_cont, 1)
 
-    test = GeneralizedContractionShell(2, np.array([0, 0, 0]), 0, np.array([1.0]), np.array([0.25]))
+    test = GeneralizedContractionShell(2, np.array([0, 0, 0]), np.array([1.0]), np.array([0.25]))
     test.assign_norm_cont()
     assert np.allclose(test.norm_cont, 1)

--- a/tests/test_contractions.py
+++ b/tests/test_contractions.py
@@ -1,6 +1,6 @@
 """Test gbasis.contractions."""
-from gbasis.contractions import GeneralizedContractionShell, make_contractions
-from gbasis.parsers import parse_nwchem
+from gbasis.contractions import GeneralizedContractionShell
+from gbasis.parsers import make_contractions, parse_nwchem
 import numpy as np
 import pytest
 from utils import find_datafile, skip_init

--- a/tests/test_contractions.py
+++ b/tests/test_contractions.py
@@ -177,20 +177,21 @@ def tests_init():
     assert np.allclose(test._exps, np.array([5, 6, 7, 8]))
 
 
-def test_angmom_components():
-    """Test GeneralizedContractionShell.angmom_components."""
+def test_angmom_components_cart():
+    """Test GeneralizedContractionShell.angmom_components_cart."""
     test = skip_init(GeneralizedContractionShell)
     test._angmom = 0
-    assert np.allclose(test.angmom_components, [(0, 0, 0)])
+    assert np.allclose(test.angmom_components_cart, [(0, 0, 0)])
     test._angmom = 1
-    assert np.allclose(test.angmom_components, [(1, 0, 0), (0, 1, 0), (0, 0, 1)])
+    assert np.allclose(test.angmom_components_cart, [(1, 0, 0), (0, 1, 0), (0, 0, 1)])
     test._angmom = 2
     assert np.allclose(
-        test.angmom_components, [(2, 0, 0), (1, 1, 0), (1, 0, 1), (0, 2, 0), (0, 1, 1), (0, 0, 2)]
+        test.angmom_components_cart,
+        [(2, 0, 0), (1, 1, 0), (1, 0, 1), (0, 2, 0), (0, 1, 1), (0, 0, 2)],
     )
     test._angmom = 3
     assert np.allclose(
-        test.angmom_components,
+        test.angmom_components_cart,
         [
             (3, 0, 0),
             (2, 1, 0),
@@ -205,20 +206,20 @@ def test_angmom_components():
         ],
     )
     test._angmom = 10
-    assert len(test.angmom_components) == 11 * 12 / 2
+    assert len(test.angmom_components_cart) == 11 * 12 / 2
 
 
-def test_spherical_order():
-    """Test GeneralizedContractionShell.spherical_order."""
+def test_angmom_components_sph():
+    """Test GeneralizedContractionShell.angmom_components_sph."""
     test = skip_init(GeneralizedContractionShell)
     test._angmom = 0
-    assert np.allclose(test.spherical_order, (0,))
+    assert np.allclose(test.angmom_components_sph, (0,))
     test._angmom = 1
-    assert np.allclose(test.spherical_order, (-1, 0, 1))
+    assert np.allclose(test.angmom_components_sph, (-1, 0, 1))
     test._angmom = 2
-    assert np.allclose(test.spherical_order, (-2, -1, 0, 1, 2))
+    assert np.allclose(test.angmom_components_sph, (-2, -1, 0, 1, 2))
     test._angmom = 3
-    assert np.allclose(test.spherical_order, (-3, -2, -1, 0, 1, 2, 3))
+    assert np.allclose(test.angmom_components_sph, (-3, -2, -1, 0, 1, 2, 3))
 
 
 # TODO: Test norm using actual integrals

--- a/tests/test_contractions.py
+++ b/tests/test_contractions.py
@@ -232,6 +232,19 @@ def test_angmom_components():
     assert len(test.angmom_components) == 11 * 12 / 2
 
 
+def test_spherical_order():
+    """Test ContractedCartesianGaussians.spherical_order."""
+    test = skip_init(ContractedCartesianGaussians)
+    test._angmom = 0
+    assert np.allclose(test.spherical_order, (0, ))
+    test._angmom = 1
+    assert np.allclose(test.spherical_order, (-1, 0, 1))
+    test._angmom = 2
+    assert np.allclose(test.spherical_order, (-2, -1, 0, 1, 2))
+    test._angmom = 3
+    assert np.allclose(test.spherical_order, (-3, -2, -1, 0, 1, 2, 3))
+
+
 # TODO: Test norm using actual integrals
 # TODO: add more tests
 def test_norm_prim():

--- a/tests/test_contractions.py
+++ b/tests/test_contractions.py
@@ -224,12 +224,12 @@ def test_angmom_components_sph():
 
 # TODO: Test norm using actual integrals
 # TODO: add more tests
-def test_norm_prim():
-    """Test GeneralizedContractionShell.norm_prim."""
+def test_norm_prim_cart():
+    """Test GeneralizedContractionShell.norm_prim_cart."""
     test = GeneralizedContractionShell(0, np.array([0, 0, 0]), np.array([1.0]), np.array([0.25]))
-    assert np.isclose(test.norm_prim, 0.2519794355383807303479140)
+    assert np.isclose(test.norm_prim_cart, 0.2519794355383807303479140)
     test = GeneralizedContractionShell(3, np.array([0, 0, 0]), np.array([1.0]), np.array([0.5]))
-    assert np.isclose(test.norm_prim[7], 0.6920252830162908851679097)
+    assert np.isclose(test.norm_prim_cart[7], 0.6920252830162908851679097)
 
 
 def test_num_cart():

--- a/tests/test_contractions.py
+++ b/tests/test_contractions.py
@@ -1,5 +1,5 @@
 """Test gbasis.contractions."""
-from gbasis.contractions import ContractedCartesianGaussians, make_contractions
+from gbasis.contractions import GeneralizedContractionShell, make_contractions
 from gbasis.parsers import parse_nwchem
 import numpy as np
 import pytest
@@ -7,8 +7,8 @@ from utils import find_datafile, skip_init
 
 
 def test_charge_setter():
-    """Test setter for ContractedCartesianGaussians.charge."""
-    test = skip_init(ContractedCartesianGaussians)
+    """Test setter for GeneralizedContractionShell.charge."""
+    test = skip_init(GeneralizedContractionShell)
     test.charge = 2
     assert isinstance(test._charge, float) and test._charge == 2
     test.charge = -2
@@ -22,15 +22,15 @@ def test_charge_setter():
 
 
 def test_charge_getter():
-    """Test getter for ContractedCartesianGaussians.charge."""
-    test = skip_init(ContractedCartesianGaussians)
+    """Test getter for GeneralizedContractionShell.charge."""
+    test = skip_init(GeneralizedContractionShell)
     test._charge = 2
     assert test.charge == 2
 
 
 def test_coord_setter():
-    """Test setter for ContractedCartesianGaussians.coord."""
-    test = skip_init(ContractedCartesianGaussians)
+    """Test setter for GeneralizedContractionShell.coord."""
+    test = skip_init(GeneralizedContractionShell)
     test.coord = np.array([1.0, 2.0, 3.0])
     assert (
         isinstance(test._coord, np.ndarray)
@@ -53,15 +53,15 @@ def test_coord_setter():
 
 
 def test_coord_getter():
-    """Test getter for ContractedCartesianGaussians.coord."""
-    test = skip_init(ContractedCartesianGaussians)
+    """Test getter for GeneralizedContractionShell.coord."""
+    test = skip_init(GeneralizedContractionShell)
     test._coord = 2
     assert test.coord == 2
 
 
 def test_angmom_setter():
-    """Test setter for ContractedCartesianGaussians.angmom."""
-    test = skip_init(ContractedCartesianGaussians)
+    """Test setter for GeneralizedContractionShell.angmom."""
+    test = skip_init(GeneralizedContractionShell)
     test.angmom = 1
     assert isinstance(test._angmom, int) and test._angmom == 1
     test.angmom = 0
@@ -77,15 +77,15 @@ def test_angmom_setter():
 
 
 def test_angmom_getter():
-    """Test getter for ContractedCartesianGaussians.angmom."""
-    test = skip_init(ContractedCartesianGaussians)
+    """Test getter for GeneralizedContractionShell.angmom."""
+    test = skip_init(GeneralizedContractionShell)
     test._angmom = 1
     assert test.angmom == 1
 
 
 def test_exps_setter():
-    """Test setter for ContractedCartesianGaussians.exps."""
-    test = skip_init(ContractedCartesianGaussians)
+    """Test setter for GeneralizedContractionShell.exps."""
+    test = skip_init(GeneralizedContractionShell)
     test.exps = np.array([1.0, 2.0, 3.0])
     assert (
         isinstance(test._exps, np.ndarray)
@@ -93,7 +93,7 @@ def test_exps_setter():
         and np.allclose(test._exps, np.array([1, 2, 3]))
     )
 
-    test = skip_init(ContractedCartesianGaussians)
+    test = skip_init(GeneralizedContractionShell)
     test.coeffs = np.array([1.0, 2.0, 3.0])
     test.exps = np.array([1.0, 2.0, 3.0])
     assert (
@@ -102,7 +102,7 @@ def test_exps_setter():
         and np.allclose(test._exps, np.array([1, 2, 3]))
     )
 
-    test = skip_init(ContractedCartesianGaussians)
+    test = skip_init(GeneralizedContractionShell)
     with pytest.raises(TypeError):
         test.exps = [1, 2, 3]
     with pytest.raises(TypeError):
@@ -116,15 +116,15 @@ def test_exps_setter():
 
 
 def test_exps_getter():
-    """Test getter for ContractedCartesianGaussians.exps."""
-    test = skip_init(ContractedCartesianGaussians)
+    """Test getter for GeneralizedContractionShell.exps."""
+    test = skip_init(GeneralizedContractionShell)
     test._exps = [2.0, 3.0]
     assert test.exps == [2.0, 3.0]
 
 
 def test_coeffs_setter():
-    """Test setter for ContractedCartesianGaussians.coeffs."""
-    test = skip_init(ContractedCartesianGaussians)
+    """Test setter for GeneralizedContractionShell.coeffs."""
+    test = skip_init(GeneralizedContractionShell)
     test.coeffs = np.array([1.0, 2.0, 3.0])
     assert (
         isinstance(test._coeffs, np.ndarray)
@@ -132,7 +132,7 @@ def test_coeffs_setter():
         and np.allclose(test._coeffs, np.array([[1], [2], [3]]))
     )
 
-    test = skip_init(ContractedCartesianGaussians)
+    test = skip_init(GeneralizedContractionShell)
     test.exps = np.array([4.0, 5.0, 6.0])
     test.coeffs = np.array([1.0, 2.0, 3.0])
     assert (
@@ -141,7 +141,7 @@ def test_coeffs_setter():
         and np.allclose(test._coeffs, np.array([[1], [2], [3]]))
     )
 
-    test = skip_init(ContractedCartesianGaussians)
+    test = skip_init(GeneralizedContractionShell)
     test.exps = np.array([4.0, 5.0, 6.0])
     test.coeffs = np.array([[1.0], [2.0], [3.0]])
     assert (
@@ -150,7 +150,7 @@ def test_coeffs_setter():
         and np.allclose(test._coeffs, np.array([[1], [2], [3]]))
     )
 
-    test = skip_init(ContractedCartesianGaussians)
+    test = skip_init(GeneralizedContractionShell)
     test.exps = np.array([4.0, 5.0, 6.0])
     test.coeffs = np.array([[1.0, 4.0], [2.0, 5.0], [3.0, 6.0]])
     assert (
@@ -159,7 +159,7 @@ def test_coeffs_setter():
         and np.allclose(test._coeffs, np.array([[1, 4], [2, 5], [3, 6]]))
     )
 
-    test = skip_init(ContractedCartesianGaussians)
+    test = skip_init(GeneralizedContractionShell)
     with pytest.raises(TypeError):
         test.coeffs = [1, 2, 3]
     with pytest.raises(TypeError):
@@ -179,15 +179,15 @@ def test_coeffs_setter():
 
 
 def test_coeffs_getter():
-    """Test getter for ContractedCartesianGaussians.coeffs."""
-    test = skip_init(ContractedCartesianGaussians)
+    """Test getter for GeneralizedContractionShell.coeffs."""
+    test = skip_init(GeneralizedContractionShell)
     test._coeffs = [2.0, 3.0]
     assert test.coeffs == [2.0, 3.0]
 
 
 def tests_init():
-    """Test ContractedCartesianGaussians.__init__."""
-    test = ContractedCartesianGaussians(
+    """Test GeneralizedContractionShell.__init__."""
+    test = GeneralizedContractionShell(
         1,
         np.array([0, 1, 2]),
         0,
@@ -202,8 +202,8 @@ def tests_init():
 
 
 def test_angmom_components():
-    """Test ContractedCartesianGaussians.angmom_components."""
-    test = skip_init(ContractedCartesianGaussians)
+    """Test GeneralizedContractionShell.angmom_components."""
+    test = skip_init(GeneralizedContractionShell)
     test._angmom = 0
     assert np.allclose(test.angmom_components, [(0, 0, 0)])
     test._angmom = 1
@@ -233,8 +233,8 @@ def test_angmom_components():
 
 
 def test_spherical_order():
-    """Test ContractedCartesianGaussians.spherical_order."""
-    test = skip_init(ContractedCartesianGaussians)
+    """Test GeneralizedContractionShell.spherical_order."""
+    test = skip_init(GeneralizedContractionShell)
     test._angmom = 0
     assert np.allclose(test.spherical_order, (0,))
     test._angmom = 1
@@ -248,18 +248,16 @@ def test_spherical_order():
 # TODO: Test norm using actual integrals
 # TODO: add more tests
 def test_norm_prim():
-    """Test ContractedCartesianGaussians.norm_prim."""
-    test = ContractedCartesianGaussians(
-        0, np.array([0, 0, 0]), 0, np.array([1.0]), np.array([0.25])
-    )
+    """Test GeneralizedContractionShell.norm_prim."""
+    test = GeneralizedContractionShell(0, np.array([0, 0, 0]), 0, np.array([1.0]), np.array([0.25]))
     assert np.isclose(test.norm_prim, 0.2519794355383807303479140)
-    test = ContractedCartesianGaussians(3, np.array([0, 0, 0]), 0, np.array([1.0]), np.array([0.5]))
+    test = GeneralizedContractionShell(3, np.array([0, 0, 0]), 0, np.array([1.0]), np.array([0.5]))
     assert np.isclose(test.norm_prim[7], 0.6920252830162908851679097)
 
 
 def test_num_cart():
-    """Test ContractedCartesianGaussians.num_cart."""
-    test = skip_init(ContractedCartesianGaussians)
+    """Test GeneralizedContractionShell.num_cart."""
+    test = skip_init(GeneralizedContractionShell)
     last_num_cart = 0
     for i in range(100):
         test._angmom = i
@@ -268,8 +266,8 @@ def test_num_cart():
 
 
 def test_num_sph():
-    """Test ContractedCartesianGaussians.num_sph."""
-    test = skip_init(ContractedCartesianGaussians)
+    """Test GeneralizedContractionShell.num_sph."""
+    test = skip_init(GeneralizedContractionShell)
     last_num_sph = 1
     for i in range(100):
         test._angmom = i
@@ -278,8 +276,8 @@ def test_num_sph():
 
 
 def test_num_seg_cont():
-    """Test ContractedCartesianGaussians.num_seg_cont."""
-    test = skip_init(ContractedCartesianGaussians)
+    """Test GeneralizedContractionShell.num_seg_cont."""
+    test = skip_init(GeneralizedContractionShell)
     test._coeffs = np.random.rand(10, 21)
     assert test.num_seg_cont == 21
 
@@ -362,21 +360,15 @@ def test_make_contractions():
 
 
 def test_assign_norm_cont():
-    """Test ContractedCartesianGaussians.assign_norm_cont."""
-    test = ContractedCartesianGaussians(
-        0, np.array([0, 0, 0]), 0, np.array([1.0]), np.array([0.25])
-    )
+    """Test GeneralizedContractionShell.assign_norm_cont."""
+    test = GeneralizedContractionShell(0, np.array([0, 0, 0]), 0, np.array([1.0]), np.array([0.25]))
     test.assign_norm_cont()
     assert np.allclose(test.norm_cont, 1)
 
-    test = ContractedCartesianGaussians(
-        1, np.array([0, 0, 0]), 0, np.array([1.0]), np.array([0.25])
-    )
+    test = GeneralizedContractionShell(1, np.array([0, 0, 0]), 0, np.array([1.0]), np.array([0.25]))
     test.assign_norm_cont()
     assert np.allclose(test.norm_cont, 1)
 
-    test = ContractedCartesianGaussians(
-        2, np.array([0, 0, 0]), 0, np.array([1.0]), np.array([0.25])
-    )
+    test = GeneralizedContractionShell(2, np.array([0, 0, 0]), 0, np.array([1.0]), np.array([0.25]))
     test.assign_norm_cont()
     assert np.allclose(test.norm_cont, 1)

--- a/tests/test_contractions.py
+++ b/tests/test_contractions.py
@@ -236,7 +236,7 @@ def test_spherical_order():
     """Test ContractedCartesianGaussians.spherical_order."""
     test = skip_init(ContractedCartesianGaussians)
     test._angmom = 0
-    assert np.allclose(test.spherical_order, (0, ))
+    assert np.allclose(test.spherical_order, (0,))
     test._angmom = 1
     assert np.allclose(test.spherical_order, (-1, 0, 1))
     test._angmom = 2

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -292,7 +292,7 @@ def test_eval_density_horton():
     # NOTE: used HORTON's conversion factor for angstroms to bohr
     coords = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
     basis = make_contractions(basis_dict, ["H", "He"], coords)
-    basis = [HortonContractions(i.angmom, i.coord, i.charge, i.coeffs, i.exps) for i in basis]
+    basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps) for i in basis]
 
     horton_density = np.load(find_datafile("data_horton_hhe_sph_density.npy"))
 
@@ -317,7 +317,7 @@ def test_eval_density_gradient_horton():
     # NOTE: used HORTON's conversion factor for angstroms to bohr
     coords = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
     basis = make_contractions(basis_dict, ["H", "He"], coords)
-    basis = [HortonContractions(i.angmom, i.coord, i.charge, i.coeffs, i.exps) for i in basis]
+    basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps) for i in basis]
 
     horton_density_gradient = np.load(find_datafile("data_horton_hhe_sph_density_gradient.npy"))
 
@@ -343,7 +343,7 @@ def test_eval_hessian_deriv_horton():
     # NOTE: used HORTON's conversion factor for angstroms to bohr
     coords = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
     basis = make_contractions(basis_dict, ["H", "He"], coords)
-    basis = [HortonContractions(i.angmom, i.coord, i.charge, i.coeffs, i.exps) for i in basis]
+    basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps) for i in basis]
 
     horton_density_hessian = np.zeros((10 ** 3, 3, 3))
     horton_density_hessian[:, [0, 0, 0, 1, 1, 2], [0, 1, 2, 1, 2, 2]] = np.load(
@@ -375,7 +375,7 @@ def test_eval_laplacian_deriv_horton():
     # NOTE: used HORTON's conversion factor for angstroms to bohr
     coords = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
     basis = make_contractions(basis_dict, ["H", "He"], coords)
-    basis = [HortonContractions(i.angmom, i.coord, i.charge, i.coeffs, i.exps) for i in basis]
+    basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps) for i in basis]
 
     horton_density_laplacian = np.load(find_datafile("data_horton_hhe_sph_density_laplacian.npy"))
 
@@ -401,7 +401,7 @@ def test_eval_posdef_kinetic_energy_density():
     # NOTE: used HORTON's conversion factor for angstroms to bohr
     coords = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
     basis = make_contractions(basis_dict, ["H", "He"], coords)
-    basis = [HortonContractions(i.angmom, i.coord, i.charge, i.coeffs, i.exps) for i in basis]
+    basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps) for i in basis]
 
     horton_density_kinetic_density = np.load(
         find_datafile("data_horton_hhe_sph_posdef_kinetic_density.npy")

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -1,5 +1,4 @@
 """Test gbasis.density."""
-from gbasis.contractions import make_contractions
 from gbasis.density import (
     eval_density,
     eval_density_gradient,
@@ -11,7 +10,7 @@ from gbasis.density import (
 )
 from gbasis.eval import evaluate_basis_lincomb
 from gbasis.eval_deriv import evaluate_deriv_basis_lincomb
-from gbasis.parsers import parse_nwchem
+from gbasis.parsers import make_contractions, parse_nwchem
 import numpy as np
 import pytest
 from utils import find_datafile, HortonContractions

--- a/tests/test_electrostatic_potential.py
+++ b/tests/test_electrostatic_potential.py
@@ -23,7 +23,7 @@ def test_electrostatic_potential_base():
     basis_dict = parse_nwchem(test_basis)
     coords = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
     basis = make_contractions(basis_dict, ["H", "He"], coords)
-    basis = [HortonContractions(i.angmom, i.coord, i.charge, i.coeffs, i.exps) for i in basis]
+    basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps) for i in basis]
 
     # check density_matrix type
     with pytest.raises(TypeError):
@@ -176,7 +176,7 @@ def test_electrostatic_potential_cartesian():
     # NOTE: used HORTON's conversion factor for angstroms to bohr
     coords = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
     basis = make_contractions(basis_dict, ["H", "He"], coords)
-    basis = [HortonContractions(i.angmom, i.coord, i.charge, i.coeffs, i.exps) for i in basis]
+    basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps) for i in basis]
 
     grid_1d = np.linspace(-2, 2, num=5)
     grid_x, grid_y, grid_z = np.meshgrid(grid_1d, grid_1d, grid_1d)
@@ -204,7 +204,7 @@ def test_electrostatic_potential_spherical():
     # NOTE: used HORTON's conversion factor for angstroms to bohr
     coords = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
     basis = make_contractions(basis_dict, ["H", "He"], coords)
-    basis = [HortonContractions(i.angmom, i.coord, i.charge, i.coeffs, i.exps) for i in basis]
+    basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps) for i in basis]
 
     grid_1d = np.linspace(-2, 2, num=5)
     grid_x, grid_y, grid_z = np.meshgrid(grid_1d, grid_1d, grid_1d)
@@ -232,7 +232,7 @@ def test_electrostatic_potential_mix():
     # NOTE: used HORTON's conversion factor for angstroms to bohr
     coords = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
     basis = make_contractions(basis_dict, ["H", "He"], coords)
-    basis = [HortonContractions(i.angmom, i.coord, i.charge, i.coeffs, i.exps) for i in basis]
+    basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps) for i in basis]
 
     grid_1d = np.linspace(-2, 2, num=5)
     grid_x, grid_y, grid_z = np.meshgrid(grid_1d, grid_1d, grid_1d)

--- a/tests/test_electrostatic_potential.py
+++ b/tests/test_electrostatic_potential.py
@@ -1,12 +1,11 @@
 """Tests for gbasis.electrostatic_potential."""
-from gbasis.contractions import make_contractions
 from gbasis.electrostatic_potential import (
     _electrostatic_potential_base,
     electrostatic_potential_cartesian,
     electrostatic_potential_mix,
     electrostatic_potential_spherical,
 )
-from gbasis.parsers import parse_nwchem
+from gbasis.parsers import make_contractions, parse_nwchem
 import numpy as np
 import pytest
 from utils import find_datafile, HortonContractions

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,6 +1,6 @@
 """Test gbasis.eval."""
 from gbasis._deriv import _eval_deriv_contractions
-from gbasis.contractions import ContractedCartesianGaussians, make_contractions
+from gbasis.contractions import GeneralizedContractionShell, make_contractions
 from gbasis.eval import (
     Eval,
     evaluate_basis_cartesian,
@@ -17,7 +17,7 @@ from utils import find_datafile
 
 def test_eval_construct_array_contraction():
     """Test gbasis.eval.Eval.construct_array_contraction."""
-    test = ContractedCartesianGaussians(
+    test = GeneralizedContractionShell(
         1, np.array([0.5, 1, 1.5]), 0, np.array([1.0, 2.0]), np.array([0.1, 0.01])
     )
     answer = np.array(

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -18,7 +18,7 @@ from utils import find_datafile
 def test_eval_construct_array_contraction():
     """Test gbasis.eval.Eval.construct_array_contraction."""
     test = GeneralizedContractionShell(
-        1, np.array([0.5, 1, 1.5]), 0, np.array([1.0, 2.0]), np.array([0.1, 0.01])
+        1, np.array([0.5, 1, 1.5]), np.array([1.0, 2.0]), np.array([0.1, 0.01])
     )
     answer = np.array(
         [

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,6 +1,6 @@
 """Test gbasis.eval."""
 from gbasis._deriv import _eval_deriv_contractions
-from gbasis.contractions import GeneralizedContractionShell, make_contractions
+from gbasis.contractions import GeneralizedContractionShell
 from gbasis.eval import (
     Eval,
     evaluate_basis_cartesian,
@@ -8,7 +8,7 @@ from gbasis.eval import (
     evaluate_basis_mix,
     evaluate_basis_spherical,
 )
-from gbasis.parsers import parse_nwchem
+from gbasis.parsers import make_contractions, parse_nwchem
 import numpy as np
 import pytest
 from scipy.special import factorial2

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -42,7 +42,7 @@ def test_eval_construct_array_contraction():
                     ]
                 ),
             )
-            for angmom_comp in test.angmom_components
+            for angmom_comp in test.angmom_components_cart
         ]
     ).reshape(3, 1)
     assert np.allclose(

--- a/tests/test_eval_deriv.py
+++ b/tests/test_eval_deriv.py
@@ -83,7 +83,7 @@ def test_eval_deriv_construct_array_contraction():
                         ]
                     ),
                 )
-                for angmom_comp in test.angmom_components
+                for angmom_comp in test.angmom_components_cart
             ]
         ).reshape(3, 1)
         assert np.allclose(
@@ -123,7 +123,7 @@ def test_eval_deriv_construct_array_contraction():
                         ]
                     ),
                 )
-                for angmom_comp in test.angmom_components
+                for angmom_comp in test.angmom_components_cart
             ]
         ).reshape(3, 1)
         assert np.allclose(

--- a/tests/test_eval_deriv.py
+++ b/tests/test_eval_deriv.py
@@ -2,7 +2,7 @@
 import itertools as it
 
 from gbasis._deriv import _eval_deriv_contractions
-from gbasis.contractions import ContractedCartesianGaussians, make_contractions
+from gbasis.contractions import GeneralizedContractionShell, make_contractions
 from gbasis.eval_deriv import (
     EvalDeriv,
     evaluate_deriv_basis_cartesian,
@@ -21,7 +21,7 @@ def test_eval_deriv_construct_array_contraction():
     """Test gbasis.eval_deriv.EvalDeriv.construct_array_contraction."""
     coords = np.array([[2, 3, 4]])
     orders = np.array([0, 0, 0])
-    contractions = ContractedCartesianGaussians(
+    contractions = GeneralizedContractionShell(
         1, np.array([0.5, 1, 1.5]), 0, np.array([1.0, 2.0]), np.array([0.1, 0.01])
     )
     with pytest.raises(TypeError):
@@ -58,7 +58,7 @@ def test_eval_deriv_construct_array_contraction():
         orders = np.zeros(3, dtype=int)
         orders[k] = 1
 
-        test = ContractedCartesianGaussians(
+        test = GeneralizedContractionShell(
             1, np.array([0.5, 1, 1.5]), 0, np.array([1.0, 2.0]), np.array([0.1, 0.01])
         )
         answer = np.array(
@@ -98,7 +98,7 @@ def test_eval_deriv_construct_array_contraction():
         orders[k] += 1
         orders[l] += 1
 
-        test = ContractedCartesianGaussians(
+        test = GeneralizedContractionShell(
             1, np.array([0.5, 1, 1.5]), 0, np.array([1.0, 2.0]), np.array([0.1, 0.01])
         )
         answer = np.array(

--- a/tests/test_eval_deriv.py
+++ b/tests/test_eval_deriv.py
@@ -22,7 +22,7 @@ def test_eval_deriv_construct_array_contraction():
     coords = np.array([[2, 3, 4]])
     orders = np.array([0, 0, 0])
     contractions = GeneralizedContractionShell(
-        1, np.array([0.5, 1, 1.5]), 0, np.array([1.0, 2.0]), np.array([0.1, 0.01])
+        1, np.array([0.5, 1, 1.5]), np.array([1.0, 2.0]), np.array([0.1, 0.01])
     )
     with pytest.raises(TypeError):
         EvalDeriv.construct_array_contraction(
@@ -59,7 +59,7 @@ def test_eval_deriv_construct_array_contraction():
         orders[k] = 1
 
         test = GeneralizedContractionShell(
-            1, np.array([0.5, 1, 1.5]), 0, np.array([1.0, 2.0]), np.array([0.1, 0.01])
+            1, np.array([0.5, 1, 1.5]), np.array([1.0, 2.0]), np.array([0.1, 0.01])
         )
         answer = np.array(
             [
@@ -99,7 +99,7 @@ def test_eval_deriv_construct_array_contraction():
         orders[l] += 1
 
         test = GeneralizedContractionShell(
-            1, np.array([0.5, 1, 1.5]), 0, np.array([1.0, 2.0]), np.array([0.1, 0.01])
+            1, np.array([0.5, 1, 1.5]), np.array([1.0, 2.0]), np.array([0.1, 0.01])
         )
         answer = np.array(
             [

--- a/tests/test_eval_deriv.py
+++ b/tests/test_eval_deriv.py
@@ -2,7 +2,7 @@
 import itertools as it
 
 from gbasis._deriv import _eval_deriv_contractions
-from gbasis.contractions import GeneralizedContractionShell, make_contractions
+from gbasis.contractions import GeneralizedContractionShell
 from gbasis.eval_deriv import (
     EvalDeriv,
     evaluate_deriv_basis_cartesian,
@@ -10,7 +10,7 @@ from gbasis.eval_deriv import (
     evaluate_deriv_basis_mix,
     evaluate_deriv_basis_spherical,
 )
-from gbasis.parsers import parse_nwchem
+from gbasis.parsers import make_contractions, parse_nwchem
 import numpy as np
 import pytest
 from scipy.special import factorial2

--- a/tests/test_kinetic_energy.py
+++ b/tests/test_kinetic_energy.py
@@ -61,9 +61,9 @@ def test_kinetic_energy_construct_array_contraction():
                         ]
                     ),
                 )
-                for angmom_comp_two in test_two.angmom_components
+                for angmom_comp_two in test_two.angmom_components_cart
             ]
-            for angmom_comp_one in test_one.angmom_components
+            for angmom_comp_one in test_one.angmom_components_cart
         ]
     )
     answer += np.array(
@@ -104,9 +104,9 @@ def test_kinetic_energy_construct_array_contraction():
                         ]
                     ),
                 )
-                for angmom_comp_two in test_two.angmom_components
+                for angmom_comp_two in test_two.angmom_components_cart
             ]
-            for angmom_comp_one in test_one.angmom_components
+            for angmom_comp_one in test_one.angmom_components_cart
         ]
     )
     answer += np.array(
@@ -147,9 +147,9 @@ def test_kinetic_energy_construct_array_contraction():
                         ]
                     ),
                 )
-                for angmom_comp_two in test_two.angmom_components
+                for angmom_comp_two in test_two.angmom_components_cart
             ]
-            for angmom_comp_one in test_one.angmom_components
+            for angmom_comp_one in test_one.angmom_components_cart
         ]
     )
     assert np.allclose(

--- a/tests/test_kinetic_energy.py
+++ b/tests/test_kinetic_energy.py
@@ -1,6 +1,6 @@
 """Test gbasis.kinetic_energy."""
 from gbasis._diff_operator_int import _compute_differential_operator_integrals
-from gbasis.contractions import GeneralizedContractionShell, make_contractions
+from gbasis.contractions import GeneralizedContractionShell
 from gbasis.kinetic_energy import (
     kinetic_energy_integral_cartesian,
     kinetic_energy_integral_lincomb,
@@ -8,7 +8,7 @@ from gbasis.kinetic_energy import (
     kinetic_energy_integral_spherical,
     KineticEnergyIntegral,
 )
-from gbasis.parsers import parse_nwchem
+from gbasis.parsers import make_contractions, parse_nwchem
 import numpy as np
 import pytest
 from scipy.special import factorial2

--- a/tests/test_kinetic_energy.py
+++ b/tests/test_kinetic_energy.py
@@ -18,10 +18,10 @@ from utils import find_datafile, HortonContractions
 def test_kinetic_energy_construct_array_contraction():
     """Test gbasis.kinetic_energy.KineticEnergyIntegral.construct_array_contraction."""
     test_one = GeneralizedContractionShell(
-        1, np.array([0.5, 1, 1.5]), 0, np.array([1.0, 2.0]), np.array([0.1, 0.01])
+        1, np.array([0.5, 1, 1.5]), np.array([1.0, 2.0]), np.array([0.1, 0.01])
     )
     test_two = GeneralizedContractionShell(
-        2, np.array([1.5, 2, 3]), 0, np.array([3.0, 4.0]), np.array([0.2, 0.02])
+        2, np.array([1.5, 2, 3]), np.array([3.0, 4.0]), np.array([0.2, 0.02])
     )
     answer = np.array(
         [
@@ -231,7 +231,7 @@ def test_kinetic_energy_integral_horton_anorcc_hhe():
     basis = make_contractions(
         basis_dict, ["H", "He"], np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
     )
-    basis = [HortonContractions(i.angmom, i.coord, i.charge, i.coeffs, i.exps) for i in basis]
+    basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps) for i in basis]
 
     horton_kinetic_energy_integral = np.load(
         find_datafile("data_horton_hhe_cart_kinetic_energy_integral.npy")
@@ -252,7 +252,7 @@ def test_kinetic_energy_integral_horton_anorcc_bec():
     basis = make_contractions(
         basis_dict, ["Be", "C"], np.array([[0, 0, 0], [1.0 * 1.0 / 0.5291772083, 0, 0]])
     )
-    basis = [HortonContractions(i.angmom, i.coord, i.charge, i.coeffs, i.exps) for i in basis]
+    basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps) for i in basis]
 
     horton_kinetic_energy_integral = np.load(
         find_datafile("data_horton_bec_cart_kinetic_energy_integral.npy")

--- a/tests/test_kinetic_energy.py
+++ b/tests/test_kinetic_energy.py
@@ -1,6 +1,6 @@
 """Test gbasis.kinetic_energy."""
 from gbasis._diff_operator_int import _compute_differential_operator_integrals
-from gbasis.contractions import ContractedCartesianGaussians, make_contractions
+from gbasis.contractions import GeneralizedContractionShell, make_contractions
 from gbasis.kinetic_energy import (
     kinetic_energy_integral_cartesian,
     kinetic_energy_integral_lincomb,
@@ -17,10 +17,10 @@ from utils import find_datafile, HortonContractions
 
 def test_kinetic_energy_construct_array_contraction():
     """Test gbasis.kinetic_energy.KineticEnergyIntegral.construct_array_contraction."""
-    test_one = ContractedCartesianGaussians(
+    test_one = GeneralizedContractionShell(
         1, np.array([0.5, 1, 1.5]), 0, np.array([1.0, 2.0]), np.array([0.1, 0.01])
     )
-    test_two = ContractedCartesianGaussians(
+    test_two = GeneralizedContractionShell(
         2, np.array([1.5, 2, 3]), 0, np.array([3.0, 4.0]), np.array([0.2, 0.02])
     )
     answer = np.array(

--- a/tests/test_moment.py
+++ b/tests/test_moment.py
@@ -69,9 +69,9 @@ def test_moment_construct_array_contraction():
                         ]
                     ),
                 )
-                for angmom_comp_two in test_two.angmom_components
+                for angmom_comp_two in test_two.angmom_components_cart
             ]
-            for angmom_comp_one in test_one.angmom_components
+            for angmom_comp_one in test_one.angmom_components_cart
         ]
     )
     assert np.allclose(

--- a/tests/test_moment.py
+++ b/tests/test_moment.py
@@ -1,8 +1,8 @@
 """Test gbasis.moment."""
 from gbasis._moment_int import _compute_multipole_moment_integrals
-from gbasis.contractions import GeneralizedContractionShell, make_contractions
+from gbasis.contractions import GeneralizedContractionShell
 from gbasis.moment import Moment, moment_cartesian, moment_lincomb, moment_mix, moment_spherical
-from gbasis.parsers import parse_nwchem
+from gbasis.parsers import make_contractions, parse_nwchem
 import numpy as np
 import pytest
 from scipy.special import factorial2

--- a/tests/test_moment.py
+++ b/tests/test_moment.py
@@ -12,10 +12,10 @@ from utils import find_datafile
 def test_moment_construct_array_contraction():
     """Test gbasis.moment.Moment.construct_array_contraction."""
     test_one = GeneralizedContractionShell(
-        1, np.array([0.5, 1, 1.5]), 0, np.array([1.0, 2.0]), np.array([0.1, 0.01])
+        1, np.array([0.5, 1, 1.5]), np.array([1.0, 2.0]), np.array([0.1, 0.01])
     )
     test_two = GeneralizedContractionShell(
-        2, np.array([1.5, 2, 3]), 0, np.array([3.0, 4.0]), np.array([0.2, 0.02])
+        2, np.array([1.5, 2, 3]), np.array([3.0, 4.0]), np.array([0.2, 0.02])
     )
     answer = np.array(
         [

--- a/tests/test_moment.py
+++ b/tests/test_moment.py
@@ -1,6 +1,6 @@
 """Test gbasis.moment."""
 from gbasis._moment_int import _compute_multipole_moment_integrals
-from gbasis.contractions import ContractedCartesianGaussians, make_contractions
+from gbasis.contractions import GeneralizedContractionShell, make_contractions
 from gbasis.moment import Moment, moment_cartesian, moment_lincomb, moment_mix, moment_spherical
 from gbasis.parsers import parse_nwchem
 import numpy as np
@@ -11,10 +11,10 @@ from utils import find_datafile
 
 def test_moment_construct_array_contraction():
     """Test gbasis.moment.Moment.construct_array_contraction."""
-    test_one = ContractedCartesianGaussians(
+    test_one = GeneralizedContractionShell(
         1, np.array([0.5, 1, 1.5]), 0, np.array([1.0, 2.0]), np.array([0.1, 0.01])
     )
-    test_two = ContractedCartesianGaussians(
+    test_two = GeneralizedContractionShell(
         2, np.array([1.5, 2, 3]), 0, np.array([3.0, 4.0]), np.array([0.2, 0.02])
     )
     answer = np.array(

--- a/tests/test_nuclear_electron_attraction.py
+++ b/tests/test_nuclear_electron_attraction.py
@@ -1,12 +1,11 @@
 """Test gbasis.nuclear_electron_attraction."""
-from gbasis.contractions import make_contractions
 from gbasis.nuclear_electron_attraction import (
     nuclear_electron_attraction_cartesian,
     nuclear_electron_attraction_lincomb,
     nuclear_electron_attraction_mix,
     nuclear_electron_attraction_spherical,
 )
-from gbasis.parsers import parse_nwchem
+from gbasis.parsers import make_contractions, parse_nwchem
 from gbasis.point_charge import (
     point_charge_cartesian,
     point_charge_lincomb,

--- a/tests/test_nuclear_electron_attraction.py
+++ b/tests/test_nuclear_electron_attraction.py
@@ -29,7 +29,7 @@ def test_nuclear_electron_attraction_horton_anorcc_hhe():
     # NOTE: used HORTON's conversion factor for angstroms to bohr
     coords = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
     basis = make_contractions(basis_dict, ["H", "He"], coords)
-    basis = [HortonContractions(i.angmom, i.coord, i.charge, i.coeffs, i.exps) for i in basis]
+    basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps) for i in basis]
 
     horton_nucattract = np.load(find_datafile("data_horton_hhe_cart_nucattract.npy"))
     assert np.allclose(
@@ -49,7 +49,7 @@ def test_nuclear_electron_attraction_horton_anorcc_bec():
     # NOTE: used HORTON's conversion factor for angstroms to bohr
     coords = np.array([[0, 0, 0], [1.0 * 1.0 / 0.5291772083, 0, 0]])
     basis = make_contractions(basis_dict, ["Be", "C"], coords)
-    basis = [HortonContractions(i.angmom, i.coord, i.charge, i.coeffs, i.exps) for i in basis]
+    basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps) for i in basis]
 
     horton_nucattract = np.load(find_datafile("data_horton_bec_cart_nucattract.npy"))
     assert np.allclose(

--- a/tests/test_one_elec_int.py
+++ b/tests/test_one_elec_int.py
@@ -1,6 +1,6 @@
 """Test gbasis._one_elec_int."""
 from gbasis._one_elec_int import _compute_one_elec_integrals
-from gbasis.contractions import ContractedCartesianGaussians
+from gbasis.contractions import GeneralizedContractionShell
 import numpy as np
 import pytest
 from scipy.special import hyp1f1
@@ -49,10 +49,10 @@ def boys_func(order, weighted_dist):
 )
 def test_compute_one_elec_int_v_recursion():
     """Test vertical recursion in _one_elec_int._compute_one_elec_integrals."""
-    contr_one = ContractedCartesianGaussians(
+    contr_one = GeneralizedContractionShell(
         3, np.array([0.5, 1, 1.5]), 0, np.array([1.0, 2.0]), np.array([0.1, 0.25])
     )
-    contr_two = ContractedCartesianGaussians(
+    contr_two = GeneralizedContractionShell(
         2, np.array([1.5, 2, 3]), 0, np.array([3.0, 4.0]), np.array([0.02, 0.01])
     )
     coord_a = contr_one.coord
@@ -104,11 +104,11 @@ def test_compute_one_elec_int_v_recursion():
 )
 def test_compute_one_elec_int_s_type():
     """Test _one_elec_int._compute_one_electron_integrals for s-type primitives."""
-    # ContractedCartesianGaussians(angmom, coord, charge, coeffs, exps)
-    s_type_one = ContractedCartesianGaussians(
+    # GeneralizedContractionShell(angmom, coord, charge, coeffs, exps)
+    s_type_one = GeneralizedContractionShell(
         1, np.array([0.5, 1, 1.5]), 0, np.array([1.0]), np.array([0.1])
     )
-    s_type_two = ContractedCartesianGaussians(
+    s_type_two = GeneralizedContractionShell(
         1, np.array([1.5, 2, 3]), 0, np.array([3.0]), np.array([0.02])
     )
     coord_a = s_type_one.coord
@@ -178,11 +178,11 @@ def test_compute_one_elec_int_s_type():
 )
 def test_compute_one_elec_int_multiple_contractions():
     """Test _one_elec_int._compute_one_electron_integrals for s-type contractions."""
-    # ContractedCartesianGaussians(angmom, coord, charge, coeffs, exps)
-    contr_one = ContractedCartesianGaussians(
+    # GeneralizedContractionShell(angmom, coord, charge, coeffs, exps)
+    contr_one = GeneralizedContractionShell(
         1, np.array([0.5, 1, 1.5]), 0, np.array([1.0, 2.0]), np.array([0.1, 0.25])
     )
-    contr_two = ContractedCartesianGaussians(
+    contr_two = GeneralizedContractionShell(
         1, np.array([1.5, 2, 3]), 0, np.array([3.0, 4.0]), np.array([0.02, 0.01])
     )
     coord_a = contr_one.coord
@@ -224,10 +224,10 @@ def test_compute_one_elec_int_multiple_contractions():
 )
 def test_compute_one_elec_int_generalized_contraction():
     """Test _one_elec_int._compute_one_electron_integrals for generalized contractions."""
-    contr_one = ContractedCartesianGaussians(
+    contr_one = GeneralizedContractionShell(
         3, np.array([0.5, 1, 1.5]), 0, np.array([[1.0, 2.0], [1.5, 2.5]]), np.array([0.1, 0.25])
     )
-    contr_two = ContractedCartesianGaussians(
+    contr_two = GeneralizedContractionShell(
         2, np.array([1.5, 2, 3]), 0, np.array([[3.0, 4.0], [3.5, 4.5]]), np.array([0.02, 0.01])
     )
     coord_a = contr_one.coord

--- a/tests/test_one_elec_int.py
+++ b/tests/test_one_elec_int.py
@@ -50,10 +50,10 @@ def boys_func(order, weighted_dist):
 def test_compute_one_elec_int_v_recursion():
     """Test vertical recursion in _one_elec_int._compute_one_elec_integrals."""
     contr_one = GeneralizedContractionShell(
-        3, np.array([0.5, 1, 1.5]), 0, np.array([1.0, 2.0]), np.array([0.1, 0.25])
+        3, np.array([0.5, 1, 1.5]), np.array([1.0, 2.0]), np.array([0.1, 0.25])
     )
     contr_two = GeneralizedContractionShell(
-        2, np.array([1.5, 2, 3]), 0, np.array([3.0, 4.0]), np.array([0.02, 0.01])
+        2, np.array([1.5, 2, 3]), np.array([3.0, 4.0]), np.array([0.02, 0.01])
     )
     coord_a = contr_one.coord
     angmom_a = contr_one.angmom
@@ -106,10 +106,10 @@ def test_compute_one_elec_int_s_type():
     """Test _one_elec_int._compute_one_electron_integrals for s-type primitives."""
     # GeneralizedContractionShell(angmom, coord, charge, coeffs, exps)
     s_type_one = GeneralizedContractionShell(
-        1, np.array([0.5, 1, 1.5]), 0, np.array([1.0]), np.array([0.1])
+        1, np.array([0.5, 1, 1.5]), np.array([1.0]), np.array([0.1])
     )
     s_type_two = GeneralizedContractionShell(
-        1, np.array([1.5, 2, 3]), 0, np.array([3.0]), np.array([0.02])
+        1, np.array([1.5, 2, 3]), np.array([3.0]), np.array([0.02])
     )
     coord_a = s_type_one.coord
     angmom_a = s_type_one.angmom
@@ -180,10 +180,10 @@ def test_compute_one_elec_int_multiple_contractions():
     """Test _one_elec_int._compute_one_electron_integrals for s-type contractions."""
     # GeneralizedContractionShell(angmom, coord, charge, coeffs, exps)
     contr_one = GeneralizedContractionShell(
-        1, np.array([0.5, 1, 1.5]), 0, np.array([1.0, 2.0]), np.array([0.1, 0.25])
+        1, np.array([0.5, 1, 1.5]), np.array([1.0, 2.0]), np.array([0.1, 0.25])
     )
     contr_two = GeneralizedContractionShell(
-        1, np.array([1.5, 2, 3]), 0, np.array([3.0, 4.0]), np.array([0.02, 0.01])
+        1, np.array([1.5, 2, 3]), np.array([3.0, 4.0]), np.array([0.02, 0.01])
     )
     coord_a = contr_one.coord
     angmom_a = contr_one.angmom
@@ -225,10 +225,10 @@ def test_compute_one_elec_int_multiple_contractions():
 def test_compute_one_elec_int_generalized_contraction():
     """Test _one_elec_int._compute_one_electron_integrals for generalized contractions."""
     contr_one = GeneralizedContractionShell(
-        3, np.array([0.5, 1, 1.5]), 0, np.array([[1.0, 2.0], [1.5, 2.5]]), np.array([0.1, 0.25])
+        3, np.array([0.5, 1, 1.5]), np.array([[1.0, 2.0], [1.5, 2.5]]), np.array([0.1, 0.25])
     )
     contr_two = GeneralizedContractionShell(
-        2, np.array([1.5, 2, 3]), 0, np.array([[3.0, 4.0], [3.5, 4.5]]), np.array([0.02, 0.01])
+        2, np.array([1.5, 2, 3]), np.array([[3.0, 4.0], [3.5, 4.5]]), np.array([0.02, 0.01])
     )
     coord_a = contr_one.coord
     angmom_a = contr_one.angmom

--- a/tests/test_overlap.py
+++ b/tests/test_overlap.py
@@ -62,9 +62,9 @@ def test_overlap_construct_array_contraction():
                         ]
                     ),
                 )
-                for angmom_comp_two in test_two.angmom_components
+                for angmom_comp_two in test_two.angmom_components_cart
             ]
-            for angmom_comp_one in test_one.angmom_components
+            for angmom_comp_one in test_one.angmom_components_cart
         ]
     )
     assert np.allclose(

--- a/tests/test_overlap.py
+++ b/tests/test_overlap.py
@@ -1,6 +1,6 @@
 """Test gbasis.overlap."""
 from gbasis._moment_int import _compute_multipole_moment_integrals
-from gbasis.contractions import ContractedCartesianGaussians, make_contractions
+from gbasis.contractions import GeneralizedContractionShell, make_contractions
 from gbasis.overlap import (
     Overlap,
     overlap_cartesian,
@@ -17,10 +17,10 @@ from utils import find_datafile, HortonContractions
 
 def test_overlap_construct_array_contraction():
     """Test gbasis.overlap.Overlap.construct_array_contraction."""
-    test_one = ContractedCartesianGaussians(
+    test_one = GeneralizedContractionShell(
         1, np.array([0.5, 1, 1.5]), 0, np.array([1.0, 2.0]), np.array([0.1, 0.01])
     )
-    test_two = ContractedCartesianGaussians(
+    test_two = GeneralizedContractionShell(
         2, np.array([1.5, 2, 3]), 0, np.array([3.0, 4.0]), np.array([0.2, 0.02])
     )
     answer = np.array(

--- a/tests/test_overlap.py
+++ b/tests/test_overlap.py
@@ -18,10 +18,10 @@ from utils import find_datafile, HortonContractions
 def test_overlap_construct_array_contraction():
     """Test gbasis.overlap.Overlap.construct_array_contraction."""
     test_one = GeneralizedContractionShell(
-        1, np.array([0.5, 1, 1.5]), 0, np.array([1.0, 2.0]), np.array([0.1, 0.01])
+        1, np.array([0.5, 1, 1.5]), np.array([1.0, 2.0]), np.array([0.1, 0.01])
     )
     test_two = GeneralizedContractionShell(
-        2, np.array([1.5, 2, 3]), 0, np.array([3.0, 4.0]), np.array([0.2, 0.02])
+        2, np.array([1.5, 2, 3]), np.array([3.0, 4.0]), np.array([0.2, 0.02])
     )
     answer = np.array(
         [
@@ -204,7 +204,7 @@ def test_overlap_horton_anorcc_hhe():
     basis = make_contractions(
         basis_dict, ["H", "He"], np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
     )
-    basis = [HortonContractions(i.angmom, i.coord, i.charge, i.coeffs, i.exps) for i in basis]
+    basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps) for i in basis]
 
     horton_overlap = np.load(find_datafile("data_horton_hhe_cart_overlap.npy"))
     assert np.allclose(overlap_cartesian(basis), horton_overlap)
@@ -223,7 +223,7 @@ def test_overlap_horton_anorcc_bec():
     basis = make_contractions(
         basis_dict, ["Be", "C"], np.array([[0, 0, 0], [1.0 * 1.0 / 0.5291772083, 0, 0]])
     )
-    basis = [HortonContractions(i.angmom, i.coord, i.charge, i.coeffs, i.exps) for i in basis]
+    basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps) for i in basis]
 
     horton_overlap = np.load(find_datafile("data_horton_bec_cart_overlap.npy"))
     assert np.allclose(overlap_cartesian(basis), horton_overlap)

--- a/tests/test_overlap.py
+++ b/tests/test_overlap.py
@@ -1,6 +1,6 @@
 """Test gbasis.overlap."""
 from gbasis._moment_int import _compute_multipole_moment_integrals
-from gbasis.contractions import GeneralizedContractionShell, make_contractions
+from gbasis.contractions import GeneralizedContractionShell
 from gbasis.overlap import (
     Overlap,
     overlap_cartesian,
@@ -8,7 +8,7 @@ from gbasis.overlap import (
     overlap_mix,
     overlap_spherical,
 )
-from gbasis.parsers import parse_nwchem
+from gbasis.parsers import make_contractions, parse_nwchem
 import numpy as np
 import pytest
 from scipy.special import factorial2

--- a/tests/test_point_charge.py
+++ b/tests/test_point_charge.py
@@ -1,6 +1,6 @@
 """Test gbasis.point_charge."""
-from gbasis.contractions import GeneralizedContractionShell, make_contractions
-from gbasis.parsers import parse_nwchem
+from gbasis.contractions import GeneralizedContractionShell
+from gbasis.parsers import make_contractions, parse_nwchem
 from gbasis.point_charge import (
     point_charge_cartesian,
     point_charge_lincomb,

--- a/tests/test_point_charge.py
+++ b/tests/test_point_charge.py
@@ -39,9 +39,9 @@ def test_boys_func():
 def test_construct_array_contraction():
     """Test gbasis.point_charge.PointChargeIntegral.construct_array_contraction."""
     coord_one = np.array([0.5, 1, 1.5])
-    test_one = GeneralizedContractionShell(0, coord_one, 0, np.array([1.0]), np.array([0.1]))
+    test_one = GeneralizedContractionShell(0, coord_one, np.array([1.0]), np.array([0.1]))
     coord_two = np.array([1.5, 2, 3])
-    test_two = GeneralizedContractionShell(0, coord_two, 0, np.array([3.0]), np.array([0.2]))
+    test_two = GeneralizedContractionShell(0, coord_two, np.array([3.0]), np.array([0.2]))
     coord = np.array([[0, 0, 0]])
     charge = np.array([1])
     coord_wac = (0.1 * coord_one + 0.2 * coord_two) / (0.1 + 0.2)
@@ -76,10 +76,10 @@ def test_construct_array_contraction():
     )
 
     test_one = GeneralizedContractionShell(
-        1, np.array([0.5, 1, 1.5]), 0, np.array([1.0]), np.array([0.1])
+        1, np.array([0.5, 1, 1.5]), np.array([1.0]), np.array([0.1])
     )
     test_two = GeneralizedContractionShell(
-        0, np.array([1.5, 2, 3]), 0, np.array([3.0]), np.array([0.2])
+        0, np.array([1.5, 2, 3]), np.array([3.0]), np.array([0.2])
     )
     v_000_000 = [
         2
@@ -103,10 +103,10 @@ def test_construct_array_contraction():
     )
 
     test_one = GeneralizedContractionShell(
-        0, np.array([0.5, 1, 1.5]), 0, np.array([1.0]), np.array([0.1])
+        0, np.array([0.5, 1, 1.5]), np.array([1.0]), np.array([0.1])
     )
     test_two = GeneralizedContractionShell(
-        1, np.array([1.5, 2, 3]), 0, np.array([3.0]), np.array([0.2])
+        1, np.array([1.5, 2, 3]), np.array([3.0]), np.array([0.2])
     )
     assert np.allclose(
         PointChargeIntegral.construct_array_contraction(test_one, test_two, coord, charge).ravel(),

--- a/tests/test_point_charge.py
+++ b/tests/test_point_charge.py
@@ -1,5 +1,5 @@
 """Test gbasis.point_charge."""
-from gbasis.contractions import ContractedCartesianGaussians, make_contractions
+from gbasis.contractions import GeneralizedContractionShell, make_contractions
 from gbasis.parsers import parse_nwchem
 from gbasis.point_charge import (
     point_charge_cartesian,
@@ -39,9 +39,9 @@ def test_boys_func():
 def test_construct_array_contraction():
     """Test gbasis.point_charge.PointChargeIntegral.construct_array_contraction."""
     coord_one = np.array([0.5, 1, 1.5])
-    test_one = ContractedCartesianGaussians(0, coord_one, 0, np.array([1.0]), np.array([0.1]))
+    test_one = GeneralizedContractionShell(0, coord_one, 0, np.array([1.0]), np.array([0.1]))
     coord_two = np.array([1.5, 2, 3])
-    test_two = ContractedCartesianGaussians(0, coord_two, 0, np.array([3.0]), np.array([0.2]))
+    test_two = GeneralizedContractionShell(0, coord_two, 0, np.array([3.0]), np.array([0.2]))
     coord = np.array([[0, 0, 0]])
     charge = np.array([1])
     coord_wac = (0.1 * coord_one + 0.2 * coord_two) / (0.1 + 0.2)
@@ -75,10 +75,10 @@ def test_construct_array_contraction():
         ),
     )
 
-    test_one = ContractedCartesianGaussians(
+    test_one = GeneralizedContractionShell(
         1, np.array([0.5, 1, 1.5]), 0, np.array([1.0]), np.array([0.1])
     )
-    test_two = ContractedCartesianGaussians(
+    test_two = GeneralizedContractionShell(
         0, np.array([1.5, 2, 3]), 0, np.array([3.0]), np.array([0.2])
     )
     v_000_000 = [
@@ -102,10 +102,10 @@ def test_construct_array_contraction():
         ),
     )
 
-    test_one = ContractedCartesianGaussians(
+    test_one = GeneralizedContractionShell(
         0, np.array([0.5, 1, 1.5]), 0, np.array([1.0]), np.array([0.1])
     )
-    test_two = ContractedCartesianGaussians(
+    test_two = GeneralizedContractionShell(
         1, np.array([1.5, 2, 3]), 0, np.array([3.0]), np.array([0.2])
     )
     assert np.allclose(

--- a/tests/test_spherical.py
+++ b/tests/test_spherical.py
@@ -154,7 +154,7 @@ def test_generate_transformation():
         generate_transformation(1, np.array([(1, 0, 0), (0, 1, 0), (0, 0, 1)]), (-1, 0, 1), "up")
     with pytest.raises(ValueError):
         generate_transformation(1, np.array([(1, 0, 0), (0, 1, 0), (0, 0, 1)]), (-1, 0, 1), "")
-    # check spherical_order type
+    # check angmom_components_sph type
     with pytest.raises(TypeError):
         generate_transformation(
             1, np.array([(1, 0, 0), (0, 1, 0), (0, 0, 1)]), np.array([-1, 0, 1]), "left"
@@ -165,7 +165,7 @@ def test_generate_transformation():
         generate_transformation(
             1, np.array([(1, 0, 0), (0, 1, 0), (0, 0, 1)]), [-1, 0, 1.0], "left"
         )
-    # check spherical_order value
+    # check angmom_components_sph value
     with pytest.raises(ValueError):
         generate_transformation(
             1, np.array([(1, 0, 0), (0, 1, 0), (0, 0, 1)]), (-1, 0, 1, 1), "left"

--- a/tests/test_spherical.py
+++ b/tests/test_spherical.py
@@ -108,44 +108,70 @@ def test_real_solid_harmonic():
 def test_generate_transformation():
     """Test spherical.generate_transformation."""
     assert np.array_equal(
-        generate_transformation(0, np.array([(0, 0, 0)]), "right"), np.array([[1.0]])
+        generate_transformation(0, np.array([(0, 0, 0)]), (0,), "right"), np.array([[1.0]])
     )
     assert np.array_equal(
-        generate_transformation(1, np.array([(1, 0, 0), (0, 1, 0), (0, 0, 1)]), "right"),
+        generate_transformation(
+            1, np.array([(1, 0, 0), (0, 1, 0), (0, 0, 1)]), (-1, 0, 1), "right"
+        ),
         np.array([[0.0, 0.0, 1.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]),
     )
     assert np.array_equal(
-        generate_transformation(0, np.array([(0, 0, 0)]), "right").T,
-        generate_transformation(0, np.array([(0, 0, 0)]), "left"),
+        generate_transformation(0, np.array([(0, 0, 0)]), (0,), "right").T,
+        generate_transformation(0, np.array([(0, 0, 0)]), (0,), "left"),
     )
     assert np.array_equal(
-        generate_transformation(1, np.array([(1, 0, 0), (0, 1, 0), (0, 0, 1)]), "right").T,
-        generate_transformation(1, np.array([(1, 0, 0), (0, 1, 0), (0, 0, 1)]), "left"),
+        generate_transformation(
+            1, np.array([(1, 0, 0), (0, 1, 0), (0, 0, 1)]), (-1, 0, 1), "right"
+        ).T,
+        generate_transformation(1, np.array([(1, 0, 0), (0, 1, 0), (0, 0, 1)]), (-1, 0, 1), "left"),
     )
     with pytest.raises(TypeError):
-        generate_transformation(0.0, np.array([(0, 0, 0)]), "right")
+        generate_transformation(0.0, np.array([(0, 0, 0)]), (0,), "right")
     with pytest.raises(TypeError):
-        generate_transformation(0, 0, "right")
+        generate_transformation(0, 0, (0,), "right")
     with pytest.raises(ValueError):
-        generate_transformation(-1, np.array([(1, 0, 0), (0, 1, 0), (0, 0, 1)]), "right")
+        generate_transformation(
+            -1, np.array([(1, 0, 0), (0, 1, 0), (0, 0, 1)]), (-1, 0, 1), "right"
+        )
     with pytest.raises(ValueError):
-        generate_transformation(0, np.array([(0, 0, 0, 0)]), "right")
+        generate_transformation(0, np.array([(0, 0, 0, 0)]), (0,), "right")
     with pytest.raises(ValueError):
-        generate_transformation(1, np.array([(1, 0, 0), (0, 1, 0), (0, 1)]), "right")
+        generate_transformation(1, np.array([(1, 0, 0), (0, 1, 0), (0, 1)]), (-1, 0, 1), "right")
     with pytest.raises(ValueError):
-        generate_transformation(1, np.array([(1, 0, 0), (0, 1, 0), (0, 0, 1), (1, 0, 0)]), "right")
+        generate_transformation(
+            1, np.array([(1, 0, 0), (0, 1, 0), (0, 0, 1), (1, 0, 0)]), (-1, 0, 1), "right"
+        )
     with pytest.raises(ValueError):
-        generate_transformation(1, np.array([(1, 0, 0), (0, 1, 0)]), "right")
+        generate_transformation(1, np.array([(1, 0, 0), (0, 1, 0)]), (-1, 0, 1), "right")
     with pytest.raises(ValueError):
-        generate_transformation(1, np.array([(1, 0, 0), (0, 0, 0), (0, 0, 2)]), "right")
+        generate_transformation(1, np.array([(1, 0, 0), (0, 0, 0), (0, 0, 2)]), (-1, 0, 1), "right")
     with pytest.raises(TypeError):
-        generate_transformation(1, np.array([(1, 0, 0), (0, 1, 0), (0, 0, 1)]), 1)
+        generate_transformation(1, np.array([(1, 0, 0), (0, 1, 0), (0, 0, 1)]), (-1, 0, 1), 1)
     with pytest.raises(TypeError):
-        generate_transformation(1, np.array([(1, 0, 0), (0, 1, 0), (0, 0, 1)]), None)
+        generate_transformation(1, np.array([(1, 0, 0), (0, 1, 0), (0, 0, 1)]), (-1, 0, 1), None)
     with pytest.raises(ValueError):
-        generate_transformation(1, np.array([(1, 0, 0), (0, 1, 0), (0, 0, 1)]), "up")
+        generate_transformation(1, np.array([(1, 0, 0), (0, 1, 0), (0, 0, 1)]), (-1, 0, 1), "up")
     with pytest.raises(ValueError):
-        generate_transformation(1, np.array([(1, 0, 0), (0, 1, 0), (0, 0, 1)]), "")
+        generate_transformation(1, np.array([(1, 0, 0), (0, 1, 0), (0, 0, 1)]), (-1, 0, 1), "")
+    # check spherical_order type
+    with pytest.raises(TypeError):
+        generate_transformation(
+            1, np.array([(1, 0, 0), (0, 1, 0), (0, 0, 1)]), np.array([-1, 0, 1]), "left"
+        )
+    with pytest.raises(TypeError):
+        generate_transformation(1, np.array([(1, 0, 0), (0, 1, 0), (0, 0, 1)]), {-1, 0, 1}, "left")
+    with pytest.raises(TypeError):
+        generate_transformation(
+            1, np.array([(1, 0, 0), (0, 1, 0), (0, 0, 1)]), [-1, 0, 1.0], "left"
+        )
+    # check spherical_order value
+    with pytest.raises(ValueError):
+        generate_transformation(
+            1, np.array([(1, 0, 0), (0, 1, 0), (0, 0, 1)]), (-1, 0, 1, 1), "left"
+        )
+    with pytest.raises(ValueError):
+        generate_transformation(1, np.array([(1, 0, 0), (0, 1, 0), (0, 0, 1)]), (-1, 2, 1), "left")
 
 
 # FIXME: cannot reproduce horton results for the angular momentum 4. I  have a feeling that the
@@ -168,7 +194,10 @@ def test_generate_transformation_horton():
     answer = answer[[4, 2, 0, 1, 3], :]
     assert np.allclose(
         generate_transformation(
-            2, np.array([[2, 0, 0], [1, 1, 0], [1, 0, 1], [0, 2, 0], [0, 1, 1], [0, 0, 2]]), "left"
+            2,
+            np.array([[2, 0, 0], [1, 1, 0], [1, 0, 1], [0, 2, 0], [0, 1, 1], [0, 0, 2]]),
+            (-2, -1, 0, 1, 2),
+            "left",
         ),
         answer,
     )
@@ -203,6 +232,7 @@ def test_generate_transformation_horton():
                     [0, 0, 3],
                 ]
             ),
+            (-3, -2, -1, 0, 1, 2, 3),
             "left",
         ),
         answer,
@@ -341,6 +371,7 @@ def test_generate_transformation_horton():
     #                 [0, 0, 4],
     #             ]
     #         ),
+    #         (-4, -3, -2, -1, 0, 1, 2, 3, 4),
     #         "left",
     #     ),
     #     answer,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -175,7 +175,7 @@ class HortonContractions(GeneralizedContractionShell):
     """GeneralizedContractionShell following HORTON's angular momentum convention."""
 
     @property
-    def angmom_components(self):
+    def angmom_components_cart(self):
         """Angular momentum components for HORTON's convention."""
         return np.array(
             [

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,7 +2,7 @@
 import itertools as it
 import os
 
-from gbasis.contractions import ContractedCartesianGaussians
+from gbasis.contractions import GeneralizedContractionShell
 import numpy as np
 
 
@@ -171,8 +171,8 @@ def find_datafile(file_name):
     return os.path.join(os.path.dirname(__file__), file_name)
 
 
-class HortonContractions(ContractedCartesianGaussians):
-    """ContractedCartesianGaussians following HORTON's angular momentum convention."""
+class HortonContractions(GeneralizedContractionShell):
+    """GeneralizedContractionShell following HORTON's angular momentum convention."""
 
     @property
     def angmom_components(self):


### PR DESCRIPTION
1. Control ordering of the spherical contractions
2. Change name of class from ContractedCartesianGaussians to GeneralizedContractionShell
3. Rename attribute angmom_components to angmom_components_cart
4. Rename attribute spherical_order to angmomg_components_sph
5. Rename attribute norm_prim to norm_prim_cart
6. Move make_contractions from contractions module to parsers module
7. Update docstring
