### PR TITLE
Add low level  two-electron integrals

### DIFF
--- a/gbasis/_two_elec_int.py
+++ b/gbasis/_two_elec_int.py
@@ -1,0 +1,533 @@
+"""Two-electron integrals involving Contracted Cartesian Gaussians."""
+import numpy as np
+from scipy.special import factorial2
+from memory_profiler import profile
+
+
+# pylint: disable=C0103,R0914,R0915
+# FIXME: returns nan when exponent is zero
+@profile
+def _compute_two_elec_integrals(
+    boys_func,
+    coord_a,
+    angmom_a,
+    exps_a,
+    coeffs_a,
+    coord_b,
+    angmom_b,
+    exps_b,
+    coeffs_b,
+    coord_c,
+    angmom_c,
+    exps_c,
+    coeffs_c,
+    coord_d,
+    angmom_d,
+    exps_d,
+    coeffs_d,
+):
+    r"""Return the two-electron integrals for electron-electron repulsion.
+
+    .. math::
+
+        \int \int \phi^*_a(\mathbf{r}_1) \phi_b(\mathbf{r}_1) g(\mathbf{r}_1 - \mathbf{r}_2)
+        \phi^*_c(\mathbf{r}_2) \phi_d(\mathbf{r}_2) d\mathbf{r}_1 d\mathbf{r}_2
+
+    Parameters
+    ----------
+    boys_func : function(orders, weighted_dist)
+        Boys function used to evaluate the one-electron integral.
+        `orders` is the orders of the Boys integral that will be evaluated. It should be a
+        three-dimensional numpy array of integers with shape `(M, 1, 1, 1)` where `M` is the number
+        of orders that will be evaluated.
+        `weighted_dist` is the weighted interatomic distance, i.e.
+        :math:`\frac{\alpha_i \beta_j}{\alpha_i + \beta_j} * ||R_{PC}||^2` where :math:`\alpha_i` is
+        the exponent of the ith primitive on the left side and the :math:`\beta_j` is the exponent
+        of the jth primitive on the right side. It should be a four-dimensional numpy array of
+        floats with shape `(1, N, K_b, K_a)` where `N` is the number of point charges, `K_a` and
+        `K_b` are the number of primitives on the left and right side, respectively.
+        Output is the Boys function evaluated for each order and the weighted interactomic distance.
+        It will be a three-dimensional numpy array of shape `(M, N, K_b, K_a)`.
+    coord_a : np.ndarray(3,)
+        Center of the contraction a.
+    angmom_a : int
+        Angular momentum of the contraction a.
+    exps_a : np.ndarray(K_a,)
+        Exponents of the primitives in contraction a.
+    coeffs_a : np.ndarray(K_a, M_a)
+        Contraction coefficients of the primitives in contraction a.
+        The coefficients always correspond to generalized contractions, i.e. two-dimensional array
+        where the first index corresponds to the primitive and the second index corresponds to the
+        contraction (with the same exponents and angular momentum).
+    coord_b : np.ndarray(3,)
+        Center of the contraction b.
+    angmom_b : int
+        Angular momentum of the contraction b.
+    exps_b : np.ndarray(K_b,)
+        Exponents of the primitives in contraction b.
+    coeffs_b : np.ndarray(K_b, M_b)
+        Contraction coefficients of the primitives in contraction b.
+        The coefficients always correspond to generalized contractions, i.e. two-dimensional array
+        where the first index corresponds to the primitive and the second index corresponds to the
+        contraction (with the same exponents and angular momentum).
+    coord_c : np.ndarray(3,)
+        Center of the contraction c.
+    angmom_c : int
+        Angular momentum of the contraction c.
+    exps_c : np.ndarray(K_c,)
+        Exponents of the primitives in contraction c.
+    coeffs_c : np.ndarray(K_c, M_c)
+        Contraction coefficients of the primitives in contraction c.
+        The coefficients always correspond to generalized contractions, i.e. two-dimensional array
+        where the first index corresponds to the primitive and the second index corresponds to the
+        contraction (with the same exponents and angular momentum).
+    coord_d : np.ndarray(3,)
+        Center of the contraction d.
+    angmom_d : int
+        Angular momentum of the contraction d.
+    exps_d : np.ndarray(K_d,)
+        Exponents of the primitives in contraction d.
+    coeffs_d : np.ndarray(K_d, M_d)
+        Contraction coefficients of the primitives in contraction d.
+        The coefficients always correspond to generalized contractions, i.e. two-dimensional array
+        where the first index corresponds to the primitive and the second index corresponds to the
+        contraction (with the same exponents and angular momentum).
+
+    Returns
+    -------
+    integrals : np.ndarray(L_a + 1, L_a + 1, L_a + 1, L_b + 1, L_b + 1, L_b + 1, M_a, M_b)
+        One electron integrals for the given `GeneralizedContractionShell` instances.
+        First, second, and third index correspond to the `x`, `y`, and `z` components of the
+        angular momentum for contraction a.
+        Fourth, fifth, and sixth index correspond to the `x`, `y`, and `z` components of the
+        angular momentum for contraction b.
+        Seventh index corresponds to the segmented contractions of contraction a.
+        Eighth index corresponds to the segmented contractions of contraction b.
+
+    """
+
+    m_max = angmom_a + angmom_b + angmom_c + angmom_d + 1
+    m_max_a = angmom_a + angmom_b + 1
+    m_max_c = angmom_c + angmom_d + 1
+
+    # Adjust axes for pre-work
+    # axis 0 : components of vectors (x, y, z) (size: 3)
+    # axis 1 : primitive of contraction d (size: K_d)
+    # axis 2 : primitive of contraction b (size: K_b)
+    # axis 3 : primitive of contraction c (size: K_c)
+    # axis 4 : primitive of contraction a (size: K_a)
+    coord_a = coord_a[:, np.newaxis, np.newaxis, np.newaxis, np.newaxis]
+    coord_b = coord_b[:, np.newaxis, np.newaxis, np.newaxis, np.newaxis]
+    coord_c = coord_c[:, np.newaxis, np.newaxis, np.newaxis, np.newaxis]
+    coord_d = coord_d[:, np.newaxis, np.newaxis, np.newaxis, np.newaxis]
+    # axis 0 : primitive of contraction d (size: K_d)
+    # axis 1 : primitive of contraction b (size: K_b)
+    # axis 2 : primitive of contraction c (size: K_c)
+    # axis 3 : primitive of contraction a (size: K_a)
+    exps_a = exps_a[np.newaxis, np.newaxis, np.newaxis, :]
+    exps_b = exps_b[np.newaxis, :, np.newaxis, np.newaxis]
+    exps_c = exps_c[np.newaxis, np.newaxis, :, np.newaxis]
+    exps_d = exps_d[:, np.newaxis, np.newaxis, np.newaxis]
+
+    # sum of the exponents
+    exps_sum_one = exps_a + exps_b
+    exps_sum_two = exps_c + exps_d
+    exps_sum = exps_sum_one + exps_sum_two
+    # harmonic mean
+    harm_mean_one = (exps_a * exps_b) / exps_sum_one
+    harm_mean_two = (exps_c * exps_d) / exps_sum_two
+    harm_mean = (exps_a + exps_b) * (exps_c + exps_d) / exps_sum
+    # coordinate of the weighted average center
+    coord_wac_one = (exps_a * coord_a + exps_b * coord_b) / exps_sum_one
+    coord_wac_two = (exps_c * coord_c + exps_d * coord_d) / exps_sum_two
+    coord_wac = coord_wac_one - coord_wac_two
+    # relative distance from weighted average center
+    rel_dist_one = coord_a - coord_b
+    rel_dist_two = coord_c - coord_d
+    rel_coord_a = coord_wac_one - coord_a
+    rel_coord_c = coord_wac_two - coord_c
+
+    # NOTE: Ordering convention for vertical recursion of integrals
+    # axis 0 : m (size: m_max)
+    # axis 1 : a_x (size: m_max)
+    # axis 2 : a_y (size: m_max)
+    # axis 3 : a_z (size: m_max)
+    # axis 4 : primitive of contraction d (size: K_d)
+    # axis 5 : primitive of contraction b (size: K_b)
+    # axis 6 : primitive of contraction c (size: K_c)
+    # axis 7 : primitive of contraction a (size: K_a)
+
+    # FIXME: memory heavy here
+    integrals_vert = np.zeros(
+        (m_max, m_max, m_max, m_max, exps_d.size, exps_b.size, exps_c.size, exps_a.size)
+    )
+    # Initialize V(m)(000|000) for all m
+    integrals_vert[:, 0, 0, 0, :, :, :, :] = (
+        (2 * np.pi ** 2.5)
+        / (exps_sum_one * exps_sum_two * exps_sum ** 0.5)
+        * boys_func(
+            np.arange(m_max)[:, None, None, None, None],
+            (harm_mean * np.sum(coord_wac ** 2, axis=0))[None, :, :, :, :],
+        )
+        * np.exp(-harm_mean_one * np.sum(rel_dist_one ** 2, axis=0))
+        * np.exp(-harm_mean_two * np.sum(rel_dist_two ** 2, axis=0))
+    )
+
+    # Vertical recursion for the first index
+    integrals_vert[:-1, 1:2, 0, 0, :, :, :, :] = (
+        rel_coord_a[0] * integrals_vert[:-1, 0:1, 0, 0]
+        - harm_mean / exps_sum_one * coord_wac[0] * integrals_vert[1:, 0:1, 0, 0]
+    )
+    for a in range(1, m_max - 1):
+        integrals_vert[:-1, a + 1, 0, 0, :, :, :, :] = (
+            rel_coord_a[0] * integrals_vert[:-1, a, 0, 0]
+            - harm_mean / exps_sum_one * coord_wac[0] * integrals_vert[1:, a, 0, 0]
+            + a
+            / (2 * exps_sum_one)
+            * (
+                integrals_vert[:-1, a - 1, 0, 0]
+                - harm_mean / exps_sum_one * integrals_vert[1:, a - 1, 0, 0]
+            )
+        )
+
+    # Vertical recursion for the second index
+    integrals_vert[:-1, :, 1:2, 0, :, :, :, :] = (
+        rel_coord_a[1] * integrals_vert[:-1, :, 0:1, 0]
+        - harm_mean / exps_sum_one * coord_wac[1] * integrals_vert[1:, :, 0:1, 0]
+    )
+    for a in range(1, m_max - 1):
+        integrals_vert[:-1, :, a + 1, 0, :, :, :, :] = (
+            rel_coord_a[1] * integrals_vert[:-1, :, a, 0]
+            - harm_mean / exps_sum_one * coord_wac[1] * integrals_vert[1:, :, a, 0]
+            + a
+            / (2 * exps_sum_one)
+            * (
+                integrals_vert[:-1, :, a - 1, 0]
+                - harm_mean / exps_sum_one * integrals_vert[1:, :, a - 1, 0]
+            )
+        )
+
+    # Vertical recursion for the third index
+    integrals_vert[:-1, :, :, 1:2, :, :, :, :] = (
+        rel_coord_a[2] * integrals_vert[:-1, :, :, 0:1]
+        - harm_mean / exps_sum_one * coord_wac[2] * integrals_vert[1:, :, :, 0:1]
+    )
+    for a in range(1, m_max - 1):
+        integrals_vert[:-1, :, :, a + 1, :, :, :, :] = (
+            rel_coord_a[2] * integrals_vert[:-1, :, :, a]
+            - harm_mean / exps_sum_one * coord_wac[2] * integrals_vert[1:, :, :, a]
+            + a
+            / (2 * exps_sum_one)
+            * (
+                integrals_vert[:-1, :, :, a - 1]
+                - harm_mean / exps_sum_one * integrals_vert[1:, :, :, a - 1]
+            )
+        )
+
+    # FIXME: memory heavy here
+    # NOTE: Ordering convention for electorn transfer recursion
+    # axis 0 : c_x (size: m_max_c)
+    # axis 1 : c_y (size: m_max_c)
+    # axis 2 : c_z (size: m_max_c)
+    # axis 3 : a_x (size: m_max)
+    # axis 4 : a_y (size: m_max)
+    # axis 5 : a_z (size: m_max)
+    # axis 6 : primitive of contraction d (size: K_d)
+    # axis 7 : primitive of contraction b (size: K_b)
+    # axis 8 : primitive of contraction c (size: K_c)
+    # axis 9 : primitive of contraction a (size: K_a)
+    integrals_etransf = np.zeros(
+        (
+            m_max_c,
+            m_max_c,
+            m_max_c,
+            m_max,
+            m_max,
+            m_max,
+            exps_d.size,
+            exps_b.size,
+            exps_c.size,
+            exps_a.size,
+        )
+    )
+    # Discard m values
+    integrals_etransf[0, 0, 0, :, :, :, :, :, :, :] = integrals_vert[0, :, :, :, :, :, :, :]
+    # TODO: check if actually discarded
+
+    # electron transfer recursion for first index
+    # NOTE: At this point, numpy (v1.16.3) does not support broadcasting two zero size arrays of
+    # different shapes (e.g. shape(0, 1) and shape(1, 0))into one another. The slices 1:2 on the 0th
+    # and the 3rd axis causes problems when they both have dimension zero. There doesn't seem to be
+    # an easy enough way around it, so the array is reshaped flat (reshape always returns a view) to
+    # make their shapes the same (i.e. 0 and 0). The slices are used because the alternative is an
+    # if statement, which I think may inhibit optimization by some post processing compilers
+    integrals_etransf[1:2, 0, 0, 0:1, :, :, :, :, :, :].reshape(-1)[:] = (
+        (rel_coord_c[0] + exps_sum_one / exps_sum_two * rel_coord_a[0])
+        * integrals_etransf[0:1, 0, 0, 0:1]
+        - exps_sum_one / exps_sum_two * integrals_etransf[0:1, 0, 0, 1:2]
+    ).reshape(-1)
+    integrals_etransf[1:2, 0, 0, 1:-1, :, :, :, :, :, :] = (
+        (rel_coord_c[0] + exps_sum_one / exps_sum_two * rel_coord_a[0])
+        * integrals_etransf[0:1, 0, 0, 1:-1]
+        + np.arange(1, m_max - 1).reshape(1, 1, 1, -1, 1, 1, 1, 1, 1, 1)
+        / (2 * exps_sum_two)
+        * integrals_etransf[0:1, 0, 0, :-2]
+        - exps_sum_one / exps_sum_two * integrals_etransf[0:1:, 0, 0, 2:]
+    )
+    for c in range(1, m_max_c - 1):
+        integrals_etransf[c + 1, 0, 0, 0, :, :, :, :, :, :] = (
+            (rel_coord_c[0] + exps_sum_one / exps_sum_two * rel_coord_a[0])
+            * integrals_etransf[c, 0, 0, 0]
+            + c / (2 * exps_sum_two) * integrals_etransf[c - 1, 0, 0, 0]
+            - exps_sum_one / exps_sum_two * integrals_etransf[c, 0, 0, 1]
+        )
+        integrals_etransf[c + 1, 0, 0, 1:-1, :, :, :, :, :, :] = (
+            (rel_coord_c[0] + exps_sum_one / exps_sum_two * rel_coord_a[0])
+            * integrals_etransf[c, 0, 0, 1:-1]
+            + np.arange(1, m_max - 1).reshape(1, 1, 1, -1, 1, 1, 1, 1, 1, 1)
+            / (2 * exps_sum_two)
+            * integrals_etransf[c, 0, 0, :-2]
+            + c / (2 * exps_sum_two) * integrals_etransf[c - 1, 0, 0, 1:-1]
+            - exps_sum_one / exps_sum_two * integrals_etransf[c, 0, 0, 2:]
+        )
+    # electron transfer recursion for second index
+    integrals_etransf[:, 1:2, 0, :, 0:1, :, :, :, :, :].reshape(-1)[:] = (
+        (rel_coord_c[1] + exps_sum_one / exps_sum_two * rel_coord_a[1])
+        * integrals_etransf[:, 0:1, 0, :, 0:1]
+        - exps_sum_one / exps_sum_two * integrals_etransf[:, 0:1, 0, :, 1:2]
+    ).reshape(-1)
+    integrals_etransf[:, 1:2, 0, :, 1:-1, :, :, :, :, :] = (
+        (rel_coord_c[1] + exps_sum_one / exps_sum_two * rel_coord_a[1])
+        * integrals_etransf[:, 0:1, 0, :, 1:-1]
+        + np.arange(1, m_max - 1).reshape(1, 1, 1, 1, -1, 1, 1, 1, 1, 1)
+        / (2 * exps_sum_two)
+        * integrals_etransf[:, 0:1, 0, :, :-2]
+        - exps_sum_one / exps_sum_two * integrals_etransf[:, 0:1, 0, :, 2:]
+    )
+    for c in range(1, m_max_c - 1):
+        integrals_etransf[:, c + 1, 0, :, 0, :, :, :, :, :] = (
+            (rel_coord_c[1] + exps_sum_one / exps_sum_two * rel_coord_a[1])
+            * integrals_etransf[:, c, 0, :, 0]
+            + c / (2 * exps_sum_two) * integrals_etransf[:, c - 1, 0, :, 0]
+            - exps_sum_one / exps_sum_two * integrals_etransf[:, c, 0, :, 1]
+        )
+        integrals_etransf[:, c + 1, 0, :, 1:-1, :, :, :, :, :] = (
+            (rel_coord_c[1] + exps_sum_one / exps_sum_two * rel_coord_a[1])
+            * integrals_etransf[:, c, 0, :, 1:-1]
+            + np.arange(1, m_max - 1).reshape(1, 1, 1, 1, -1, 1, 1, 1, 1, 1)
+            / (2 * exps_sum_two)
+            * integrals_etransf[:, c, 0, :, :-2]
+            + c / (2 * exps_sum_two) * integrals_etransf[:, c - 1, 0, :, 1:-1]
+            - exps_sum_one / exps_sum_two * integrals_etransf[:, c, 0, :, 2:]
+        )
+    # electron transfer recursion for third index
+    integrals_etransf[:, :, 1:2, :, :, 0:1, :, :, :, :].reshape(-1)[:] = (
+        (rel_coord_c[2] + exps_sum_one / exps_sum_two * rel_coord_a[2])
+        * integrals_etransf[:, :, 0:1, :, :, 0:1]
+        - exps_sum_one / exps_sum_two * integrals_etransf[:, :, 0:1, :, :, 1:2]
+    ).reshape(-1)
+    integrals_etransf[:, :, 1:2, :, :, 1:-1, :, :, :, :] = (
+        (rel_coord_c[2] + exps_sum_one / exps_sum_two * rel_coord_a[2])
+        * integrals_etransf[:, :, 0:1, :, :, 1:-1]
+        + np.arange(1, m_max - 1).reshape(1, 1, 1, 1, 1, -1, 1, 1, 1, 1)
+        / (2 * exps_sum_two)
+        * integrals_etransf[:, :, 0:1, :, :, :-2]
+        - exps_sum_one / exps_sum_two * integrals_etransf[:, :, 0:1, :, :, 2:]
+    )
+    for c in range(1, m_max_c - 1):
+        integrals_etransf[:, :, c + 1, :, :, 0, :, :, :, :] = (
+            (rel_coord_c[2] + exps_sum_one / exps_sum_two * rel_coord_a[2])
+            * integrals_etransf[:, :, c, :, :, 0]
+            + c / (2 * exps_sum_two) * integrals_etransf[:, :, c - 1, :, :, 0]
+            - exps_sum_one / exps_sum_two * integrals_etransf[:, :, c, :, :, 1]
+        )
+        integrals_etransf[:, :, c + 1, :, :, 1:-1, :, :, :, :] = (
+            (rel_coord_c[2] + exps_sum_one / exps_sum_two * rel_coord_a[2])
+            * integrals_etransf[:, :, c, :, :, 1:-1]
+            + np.arange(1, m_max - 1).reshape(1, 1, 1, 1, 1, -1, 1, 1, 1, 1)
+            / (2 * exps_sum_two)
+            * integrals_etransf[:, :, c, :, :, :-2]
+            + c / (2 * exps_sum_two) * integrals_etransf[:, :, c - 1, :, :, 1:-1]
+            - exps_sum_one / exps_sum_two * integrals_etransf[:, :, c, :, :, 2:]
+        )
+
+    # Get normalization constants that correspond to the exponents (and the angular momentum)
+    norm_a = (((2 * exps_a / np.pi) ** (3 / 4)) * ((4 * exps_a) ** (angmom_a / 2))).reshape(
+        1, 1, 1, 1, 1, 1, 1, 1, 1, -1
+    )
+    norm_b = (((2 * exps_b / np.pi) ** (3 / 4)) * ((4 * exps_b) ** (angmom_b / 2))).reshape(
+        1, 1, 1, 1, 1, 1, 1, -1, 1, 1
+    )
+    norm_c = (((2 * exps_c / np.pi) ** (3 / 4)) * ((4 * exps_c) ** (angmom_c / 2))).reshape(
+        1, 1, 1, 1, 1, 1, 1, 1, -1, 1
+    )
+    norm_d = (((2 * exps_d / np.pi) ** (3 / 4)) * ((4 * exps_d) ** (angmom_d / 2))).reshape(
+        1, 1, 1, 1, 1, 1, -1, 1, 1, 1
+    )
+    # Contract primitives
+    integrals_cont = np.tensordot(integrals_etransf * norm_a, coeffs_a, (9, 0))
+    integrals_cont = np.tensordot(integrals_cont * norm_c, coeffs_c, (8, 0))
+    integrals_cont = np.tensordot(integrals_cont * norm_b, coeffs_b, (7, 0))
+    integrals_cont = np.tensordot(integrals_cont * norm_d, coeffs_d, (6, 0))
+
+    # NOTE: Ordering convention for horizontal recursion (d) of integrals
+    # axis 0 : d_x (size: angmom_d + 1)
+    # axis 1 : d_y (size: angmom_d + 1)
+    # axis 2 : d_z (size: angmom_d + 1)
+    # axis 3 : c_x (size: m_max_c)
+    # axis 4 : c_y (size: m_max_c)
+    # axis 5 : c_z (size: m_max_c)
+    # axis 6 : a_x (size: m_max_a)
+    # axis 7 : a_y (size: m_max_a)
+    # axis 8 : a_z (size: m_max_a)
+    # axis 9 : segmented contraction a (size: M_a)
+    # axis 10 : segmented contraction c (size: M_c)
+    # axis 11 : segmented contraction b (size: M_b)
+    # axis 12 : segmented contraction d (size: M_d)
+    # FIXME: memory heavy here
+    integrals_horiz_d = np.zeros(
+        (
+            angmom_d + 1,
+            angmom_d + 1,
+            angmom_d + 1,
+            m_max_c,
+            m_max_c,
+            m_max_c,
+            m_max_a,
+            m_max_a,
+            m_max_a,
+            coeffs_a.shape[1],
+            coeffs_c.shape[1],
+            coeffs_b.shape[1],
+            coeffs_d.shape[1],
+        )
+    )
+    integrals_horiz_d[0, 0, 0, :, :, :, :, :, :, :, :, :, :] = (
+        integrals_cont[:, :, :, :m_max_a, :m_max_a, :m_max_a, :, :, :, :]
+    )
+    # TODO: check if actually discarded
+
+    # FIXME: rearrange indices for slightly better indexing (i.e. order z, y, x)
+    # Horizontal recursion for first index of d
+    for d in range(0, angmom_d):
+        integrals_horiz_d[d + 1, 0, 0, :-1, :, :, :, :, :, :, :, :, :] = (
+            integrals_horiz_d[d, 0, 0, 1:, :, :, :, :, :, :, :, :, :]
+            + rel_dist_two[0] * integrals_horiz_d[d, 0, 0, :-1, :, :, :, :, :, :, :, :, :]
+        )
+    # Horizontal recursion for the second index of d
+    for d in range(0, angmom_d):
+        integrals_horiz_d[:, d + 1, 0, :, :-1, :, :, :, :, :, :, :, :] = (
+            integrals_horiz_d[:, d, 0, :, 1:, :, :, :, :, :, :, :, :]
+            + rel_dist_two[1] * integrals_horiz_d[:, d, 0, :, :-1, :, :, :, :, :, :, :, :]
+        )
+    # Horizontal recursion for the third index of d
+    for d in range(0, angmom_d):
+        integrals_horiz_d[:, :, d + 1, :, :, :-1, :, :, :, :, :, :, :] = (
+            integrals_horiz_d[:, :, d, :, :, 1:, :, :, :, :, :, :, :]
+            + rel_dist_two[2] * integrals_horiz_d[:, :, d, :, :, :-1, :, :, :, :, :, :, :]
+        )
+
+    # NOTE: Ordering convention for horizontal recursion (b) of integrals
+    # axis 0 : b_x (size: angmom_b + 1)
+    # axis 1 : b_y (size: angmom_b + 1)
+    # axis 2 : b_z (size: angmom_b + 1)
+    # axis 3 : a_x (size: m_max_a)
+    # axis 4 : a_y (size: m_max_a)
+    # axis 5 : a_z (size: m_max_a)
+    # axis 6 : d_x (size: angmom_d + 1)
+    # axis 7 : d_y (size: angmom_d + 1)
+    # axis 8 : d_z (size: angmom_d + 1)
+    # axis 9 : c_x (size: angmom_c + 1)
+    # axis 10 : c_y (size: angmom_c + 1)
+    # axis 11 : c_z (size: angmom_c + 1)
+    # axis 12 : segmented contraction a (size: M_a)
+    # axis 13 : segmented contraction c (size: M_c)
+    # axis 14 : segmented contraction b (size: M_b)
+    # axis 15 : segmented contraction d (size: M_d)
+    integrals_horiz_b = np.zeros(
+        (
+            angmom_b + 1,
+            angmom_b + 1,
+            angmom_b + 1,
+            m_max_a,
+            m_max_a,
+            m_max_a,
+            angmom_d + 1,
+            angmom_d + 1,
+            angmom_d + 1,
+            angmom_c + 1,
+            angmom_c + 1,
+            angmom_c + 1,
+            coeffs_a.shape[1],
+            coeffs_c.shape[1],
+            coeffs_b.shape[1],
+            coeffs_d.shape[1],
+        )
+    )
+    integrals_horiz_b[0, 0, 0, :, :, :, :, :, :, :, :, :, :, :, :, :] = (
+        np.transpose(
+            integrals_horiz_d[:, :, :, :angmom_c + 1, :angmom_c + 1, :angmom_c + 1, :, :, :, :, :, :, :],
+            (6, 7, 8, 0, 1, 2, 3, 4, 5, 9, 10, 11, 12)
+        )
+    )
+    # TODO: check if actually discarded
+    # Horizontal recursion for first index of d
+    for b in range(0, angmom_b):
+        integrals_horiz_b[b + 1, 0, 0, :-1, :, :, :, :, :, :, :, :, :, :, :, :] += (
+            integrals_horiz_b[b, 0, 0, 1:, :, :, :, :, :, :, :, :, :, :, :, :]
+            + rel_dist_one[0] * integrals_horiz_b[b, 0, 0, :-1, :, :, :, :, :, :, :, :, :, :, :, :]
+        )
+    # Horizontal recursion for the seconb index of b
+    for b in range(0, angmom_b):
+        integrals_horiz_b[:, b + 1, 0, :, :-1, :, :, :, :, :, :, :, :, :, :, :] = (
+            integrals_horiz_b[:, b, 0, :, 1:, :, :, :, :, :, :, :, :, :, :, :]
+            + rel_dist_one[1] * integrals_horiz_b[:, b, 0, :, :-1, :, :, :, :, :, :, :, :, :, :, :]
+        )
+    # Horizontal recursion for the thirb index of b
+    for b in range(0, angmom_b):
+        integrals_horiz_b[:, :, b + 1, :, :, :-1, :, :, :, :, :, :, :, :, :, :] = (
+            integrals_horiz_b[:, :, b, :, :, 1:, :, :, :, :, :, :, :, :, :, :]
+            + rel_dist_one[2] * integrals_horiz_b[:, :, b, :, :, :-1, :, :, :, :, :, :, :, :, :, :]
+        )
+
+    # rearrange to more sensible order
+    integrals = np.transpose(
+        # discard higher order angular momentum needed for the recursions
+        integrals_horiz_b[:, :, :, : angmom_a + 1, : angmom_a + 1, : angmom_a + 1],
+        (3, 4, 5, 0, 1, 2, 9, 10, 11, 6, 7, 8, 12, 14, 13, 15)
+    )
+
+    # Get normalzation constants that correspond to the angular momentum components
+    angmoms_a = np.arange(angmom_a + 1)
+    norm_a = 1 / np.sqrt(
+        factorial2(2 * angmoms_a.reshape(-1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1) - 1)
+        * factorial2(2 * angmoms_a.reshape(1, -1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1) - 1)
+        * factorial2(2 * angmoms_a.reshape(1, 1, -1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1) - 1)
+    )
+    integrals *= norm_a
+
+    angmoms_b = np.arange(angmom_b + 1)
+    norm_b = 1 / np.sqrt(
+        factorial2(2 * angmoms_b.reshape(1, 1, 1, -1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1) - 1)
+        * factorial2(2 * angmoms_b.reshape(1, 1, 1, 1, -1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1) - 1)
+        * factorial2(2 * angmoms_b.reshape(1, 1, 1, 1, 1, -1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1) - 1)
+    )
+    integrals *= norm_b
+
+    angmoms_c = np.arange(angmom_c + 1)
+    norm_c = 1 / np.sqrt(
+        factorial2(2 * angmoms_c.reshape(1, 1, 1, 1, 1, 1, -1, 1, 1, 1, 1, 1, 1, 1, 1, 1) - 1)
+        * factorial2(2 * angmoms_c.reshape(1, 1, 1, 1, 1, 1, 1, -1, 1, 1, 1, 1, 1, 1, 1, 1) - 1)
+        * factorial2(2 * angmoms_c.reshape(1, 1, 1, 1, 1, 1, 1, 1, -1, 1, 1, 1, 1, 1, 1, 1) - 1)
+    )
+    integrals *= norm_c
+
+    angmoms_d = np.arange(angmom_d + 1)
+    norm_d = 1 / np.sqrt(
+        factorial2(2 * angmoms_d.reshape(1, 1, 1, 1, 1, 1, 1, 1, 1, -1, 1, 1, 1, 1, 1, 1) - 1)
+        * factorial2(2 * angmoms_d.reshape(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, -1, 1, 1, 1, 1, 1) - 1)
+        * factorial2(2 * angmoms_d.reshape(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, -1, 1, 1, 1, 1) - 1)
+    )
+    integrals *= norm_d
+
+    return integrals

--- a/gbasis/_two_elec_int.py
+++ b/gbasis/_two_elec_int.py
@@ -1,12 +1,10 @@
 """Two-electron integrals involving Contracted Cartesian Gaussians."""
 import numpy as np
 from scipy.special import factorial2
-from memory_profiler import profile
 
 
 # pylint: disable=C0103,R0914,R0915
 # FIXME: returns nan when exponent is zero
-@profile
 def _compute_two_elec_integrals(
     boys_func,
     coord_a,

--- a/tests/test_two_elec_int.py
+++ b/tests/test_two_elec_int.py
@@ -456,10 +456,10 @@ def test_two_int_brute():
 
 def test_compute_two_elec_integrals_prim():
     """Test gbasis._two_elec_int._compute_two_elec_integrals on primitives."""
-    angmom_a = 6
-    angmom_b = 6
-    angmom_c = 6
-    angmom_d = 6
+    angmom_a = 7
+    angmom_b = 7
+    angmom_c = 7
+    angmom_d = 7
     print(
         _compute_two_elec_integrals(
             boys_func,

--- a/tests/test_two_elec_int.py
+++ b/tests/test_two_elec_int.py
@@ -1,6 +1,7 @@
 """Test gbasis._two_elec_int."""
-from gbasis._two_elec_int import _compute_two_elec_integrals
+from gbasis._two_elec_int import _compute_two_elec_integrals, _compute_two_elec_integrals_angmom_zero
 import numpy as np
+import pytest
 from scipy.special import factorial2, hyp1f1  # pylint: disable=E0611
 
 
@@ -454,59 +455,233 @@ def test_two_int_brute():
     )
 
 
-def test_compute_two_elec_integrals_prim():
-    """Test gbasis._two_elec_int._compute_two_elec_integrals on primitives."""
-    angmom_a = 7
-    angmom_b = 7
-    angmom_c = 7
-    angmom_d = 7
-    print(
-        _compute_two_elec_integrals(
+def test_compute_two_elec_integrals_angmom_zero_prim():
+    """Test gbasis._two_elec_int._compute_two_elec_integrals_angmom_zero on primitives."""
+    assert np.allclose(
+        _compute_two_elec_integrals_angmom_zero(
             boys_func,
             np.array([0.2, 0.4, 0.6]),
-            angmom_a,
-            np.array(
-                [
-                    (x, y, angmom_a - x - y)
-                    for x in range(angmom_a + 1)[::-1]
-                    for y in range(angmom_a - x + 1)[::-1]
-                ]
-            ),
             np.array([0.1]),
             np.array([[1.0]]),
             np.array([1.0, 1.5, 2.0]),
-            angmom_b,
-            np.array(
-                [
-                    (x, y, angmom_b - x - y)
-                    for x in range(angmom_b + 1)[::-1]
-                    for y in range(angmom_b - x + 1)[::-1]
-                ]
-            ),
             np.array([0.2]),
             np.array([[1.0]]),
             np.array([0.1, 0.3, 0.5]),
-            angmom_c,
-            np.array(
-                [
-                    (x, y, angmom_c - x - y)
-                    for x in range(angmom_c + 1)[::-1]
-                    for y in range(angmom_c - x + 1)[::-1]
-                ]
-            ),
             np.array([0.3]),
             np.array([[1.0]]),
             np.array([1.1, 1.6, 2.1]),
-            angmom_d,
-            np.array(
-                [
-                    (x, y, angmom_d - x - y)
-                    for x in range(angmom_d + 1)[::-1]
-                    for y in range(angmom_d - x + 1)[::-1]
-                ]
-            ),
             np.array([0.4]),
             np.array([[1.0]]),
-        ).shape
+        ),
+        two_int_brute(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, output=True),
     )
-    print(two_int_brute(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, output=True))
+
+
+def test_compute_two_elec_integrals_prim():
+    """Test gbasis._two_elec_int._compute_two_elec_integrals on primitives."""
+    with pytest.raises(ValueError):
+        _compute_two_elec_integrals(
+            boys_func,
+            np.array([0.2, 0.4, 0.6]),
+            0,
+            np.array([[0, 0, 0]]),
+            np.array([0.1]),
+            np.array([[1.0]]),
+            np.array([1.0, 1.5, 2.0]),
+            0,
+            np.array([[0, 0, 0]]),
+            np.array([0.2]),
+            np.array([[1.0]]),
+            np.array([0.1, 0.3, 0.5]),
+            0,
+            np.array([[0, 0, 0]]),
+            np.array([0.3]),
+            np.array([[1.0]]),
+            np.array([1.1, 1.6, 2.1]),
+            0,
+            np.array([[0, 0, 0]]),
+            np.array([0.4]),
+            np.array([[1.0]]),
+        )
+
+    assert np.allclose(
+        _compute_two_elec_integrals(
+            boys_func,
+            np.array([0.2, 0.4, 0.6]),
+            1,
+            np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+            np.array([0.1]),
+            np.array([[1.0]]),
+            np.array([1.0, 1.5, 2.0]),
+            0,
+            np.array([[0, 0, 0]]),
+            np.array([0.2]),
+            np.array([[1.0]]),
+            np.array([0.1, 0.3, 0.5]),
+            0,
+            np.array([[0, 0, 0]]),
+            np.array([0.3]),
+            np.array([[1.0]]),
+            np.array([1.1, 1.6, 2.1]),
+            0,
+            np.array([[0, 0, 0]]),
+            np.array([0.4]),
+            np.array([[1.0]]),
+        ),
+        np.array(
+            [
+                two_int_brute(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, output=True),
+                two_int_brute(0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, output=True),
+                two_int_brute(0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, output=True),
+            ]
+        ).reshape(3, 1, 1, 1, 1, 1, 1, 1),
+    )
+    assert np.allclose(
+        _compute_two_elec_integrals(
+            boys_func,
+            np.array([0.2, 0.4, 0.6]),
+            0,
+            np.array([[0, 0, 0]]),
+            np.array([0.1]),
+            np.array([[1.0]]),
+            np.array([1.0, 1.5, 2.0]),
+            1,
+            np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+            np.array([0.2]),
+            np.array([[1.0]]),
+            np.array([0.1, 0.3, 0.5]),
+            0,
+            np.array([[0, 0, 0]]),
+            np.array([0.3]),
+            np.array([[1.0]]),
+            np.array([1.1, 1.6, 2.1]),
+            0,
+            np.array([[0, 0, 0]]),
+            np.array([0.4]),
+            np.array([[1.0]]),
+        ),
+        np.array(
+            [
+                two_int_brute(0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, output=True),
+                two_int_brute(0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, output=True),
+                two_int_brute(0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, output=True),
+            ]
+        ).reshape(1, 3, 1, 1, 1, 1, 1, 1),
+    )
+    assert np.allclose(
+        _compute_two_elec_integrals(
+            boys_func,
+            np.array([0.2, 0.4, 0.6]),
+            0,
+            np.array([[0, 0, 0]]),
+            np.array([0.1]),
+            np.array([[1.0]]),
+            np.array([1.0, 1.5, 2.0]),
+            0,
+            np.array([[0, 0, 0]]),
+            np.array([0.2]),
+            np.array([[1.0]]),
+            np.array([0.1, 0.3, 0.5]),
+            1,
+            np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+            np.array([0.3]),
+            np.array([[1.0]]),
+            np.array([1.1, 1.6, 2.1]),
+            0,
+            np.array([[0, 0, 0]]),
+            np.array([0.4]),
+            np.array([[1.0]]),
+        ),
+        np.array(
+            [
+                two_int_brute(0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, output=True),
+                two_int_brute(0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, output=True),
+                two_int_brute(0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, output=True),
+            ]
+        ).reshape(1, 1, 3, 1, 1, 1, 1, 1),
+    )
+    assert np.allclose(
+        _compute_two_elec_integrals(
+            boys_func,
+            np.array([0.2, 0.4, 0.6]),
+            0,
+            np.array([[0, 0, 0]]),
+            np.array([0.1]),
+            np.array([[1.0]]),
+            np.array([1.0, 1.5, 2.0]),
+            0,
+            np.array([[0, 0, 0]]),
+            np.array([0.2]),
+            np.array([[1.0]]),
+            np.array([0.1, 0.3, 0.5]),
+            0,
+            np.array([[0, 0, 0]]),
+            np.array([0.3]),
+            np.array([[1.0]]),
+            np.array([1.1, 1.6, 2.1]),
+            1,
+            np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+            np.array([0.4]),
+            np.array([[1.0]]),
+        ),
+        np.array(
+            [
+                two_int_brute(0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, output=True),
+                two_int_brute(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, output=True),
+                two_int_brute(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, output=True),
+            ]
+        ).reshape(1, 1, 1, 3, 1, 1, 1, 1),
+    )
+
+    assert np.allclose(
+        _compute_two_elec_integrals(
+            boys_func,
+            np.array([0.2, 0.4, 0.6]),
+            2,
+            np.array([[0, 1, 1]]),
+            np.array([0.1]),
+            np.array([[1.0]]),
+            np.array([1.0, 1.5, 2.0]),
+            2,
+            np.array([[0, 0, 2]]),
+            np.array([0.2]),
+            np.array([[1.0]]),
+            np.array([0.1, 0.3, 0.5]),
+            2,
+            np.array([[2, 0, 0]]),
+            np.array([0.3]),
+            np.array([[1.0]]),
+            np.array([1.1, 1.6, 2.1]),
+            3,
+            np.array([[1, 1, 1]]),
+            np.array([0.4]),
+            np.array([[1.0]]),
+        ),
+        two_int_brute(0, 1, 1, 0, 0, 2, 2, 0, 0, 1, 1, 1, 0, output=True),
+    )
+    assert np.allclose(
+        _compute_two_elec_integrals(
+            boys_func,
+            np.array([0.2, 0.4, 0.6]),
+            2,
+            np.array([[0, 1, 1]]),
+            np.array([0.1]),
+            np.array([[2.0]]),
+            np.array([1.0, 1.5, 2.0]),
+            2,
+            np.array([[0, 0, 2]]),
+            np.array([0.2]),
+            np.array([[1.0]]),
+            np.array([0.1, 0.3, 0.5]),
+            2,
+            np.array([[2, 0, 0]]),
+            np.array([0.3]),
+            np.array([[1.0]]),
+            np.array([1.1, 1.6, 2.1]),
+            3,
+            np.array([[1, 1, 1]]),
+            np.array([0.4]),
+            np.array([[1.0]]),
+        ),
+        2 * two_int_brute(0, 1, 1, 0, 0, 2, 2, 0, 0, 1, 1, 1, 0, output=True),
+    )

--- a/tests/test_two_elec_int.py
+++ b/tests/test_two_elec_int.py
@@ -456,27 +456,55 @@ def test_two_int_brute():
 
 def test_compute_two_elec_integrals_prim():
     """Test gbasis._two_elec_int._compute_two_elec_integrals on primitives."""
-    angmom_a = 4
-    angmom_b = 4
-    angmom_c = 4
-    angmom_d = 3
+    angmom_a = 6
+    angmom_b = 6
+    angmom_c = 6
+    angmom_d = 6
     print(
         _compute_two_elec_integrals(
             boys_func,
             np.array([0.2, 0.4, 0.6]),
             angmom_a,
+            np.array(
+                [
+                    (x, y, angmom_a - x - y)
+                    for x in range(angmom_a + 1)[::-1]
+                    for y in range(angmom_a - x + 1)[::-1]
+                ]
+            ),
             np.array([0.1]),
             np.array([[1.0]]),
             np.array([1.0, 1.5, 2.0]),
             angmom_b,
+            np.array(
+                [
+                    (x, y, angmom_b - x - y)
+                    for x in range(angmom_b + 1)[::-1]
+                    for y in range(angmom_b - x + 1)[::-1]
+                ]
+            ),
             np.array([0.2]),
             np.array([[1.0]]),
             np.array([0.1, 0.3, 0.5]),
             angmom_c,
+            np.array(
+                [
+                    (x, y, angmom_c - x - y)
+                    for x in range(angmom_c + 1)[::-1]
+                    for y in range(angmom_c - x + 1)[::-1]
+                ]
+            ),
             np.array([0.3]),
             np.array([[1.0]]),
             np.array([1.1, 1.6, 2.1]),
             angmom_d,
+            np.array(
+                [
+                    (x, y, angmom_d - x - y)
+                    for x in range(angmom_d + 1)[::-1]
+                    for y in range(angmom_d - x + 1)[::-1]
+                ]
+            ),
             np.array([0.4]),
             np.array([[1.0]]),
         ).shape

--- a/tests/test_two_elec_int.py
+++ b/tests/test_two_elec_int.py
@@ -1,5 +1,8 @@
 """Test gbasis._two_elec_int."""
-from gbasis._two_elec_int import _compute_two_elec_integrals, _compute_two_elec_integrals_angmom_zero
+from gbasis._two_elec_int import (
+    _compute_two_elec_integrals,
+    _compute_two_elec_integrals_angmom_zero,
+)
 import numpy as np
 import pytest
 from scipy.special import factorial2, hyp1f1  # pylint: disable=E0611
@@ -42,27 +45,42 @@ def boys_func(order, weighted_dist):
     return hyp1f1(order + 1 / 2, order + 3 / 2, -weighted_dist) / (2 * order + 1)
 
 
-def two_int_brute(i_0, i_1, i_2, j_0, j_1, j_2, k_0, k_1, k_2, l_0, l_1, l_2, m, output=False):
+def two_int_brute(
+    i_0,
+    i_1,
+    i_2,
+    j_0,
+    j_1,
+    j_2,
+    k_0,
+    k_1,
+    k_2,
+    l_0,
+    l_1,
+    l_2,
+    m,
+    alpha=0.1,
+    beta=0.2,
+    gamma=0.3,
+    delta=0.4,
+    output=False,
+):
     """Return the answer to the two-electron integral tests.
 
     Data for first primitive on the left:
     - Coordinate: [0.2, 0.4, 0.6]
-    - Exponents: [0.1]
     - Coefficients: [1.0]
 
     Data for first primitive on the right:
     - Coordinate: [1.0, 1.5, 2.0]
-    - Exponents: [0.2]
     - Coefficients: [1.0]
 
     Data for second primitive on the left:
     - Coordinate: [0.1, 0.3, 0.5]
-    - Exponents: [0.3]
     - Coefficients: [1.0]
 
     Data for second primitive on the right:
     - Coordinate: [1.1, 1.6, 2.1]
-    - Exponents: [0.4]
     - Coefficients: [1.0]
 
 
@@ -101,10 +119,6 @@ def two_int_brute(i_0, i_1, i_2, j_0, j_1, j_2, k_0, k_1, k_2, l_0, l_1, l_2, m,
     answer : float
 
     """
-    alpha = 0.1
-    beta = 0.2
-    gamma = 0.3
-    delta = 0.4
     zeta = alpha + beta
     eta = gamma + delta
     rho = zeta * eta / (zeta + eta)
@@ -177,119 +191,405 @@ def two_int_brute(i_0, i_1, i_2, j_0, j_1, j_2, k_0, k_1, k_2, l_0, l_1, l_2, m,
     # vertical recursion
     if i_1 == i_2 == j_0 == j_1 == j_2 == k_0 == k_1 == k_2 == l_0 == l_1 == l_2 == 0:
         return (
-            (x_p - x_a) * two_int_brute(i_0 - 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, m)
+            (x_p - x_a)
+            * two_int_brute(i_0 - 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, m, alpha, beta, gamma, delta)
             - rho
             / zeta
             * (x_p - x_q)
-            * two_int_brute(i_0 - 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, m + 1)
+            * two_int_brute(
+                i_0 - 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, m + 1, alpha, beta, gamma, delta
+            )
             + (i_0 - 1)
             / 2
             / zeta
             * (
-                two_int_brute(i_0 - 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, m)
-                - rho / zeta * two_int_brute(i_0 - 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, m + 1)
+                two_int_brute(
+                    i_0 - 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, m, alpha, beta, gamma, delta
+                )
+                - rho
+                / zeta
+                * two_int_brute(
+                    i_0 - 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, m + 1, alpha, beta, gamma, delta
+                )
             )
         ) * norm
     if i_2 == j_0 == j_1 == j_2 == k_0 == k_1 == k_2 == l_0 == l_1 == l_2 == 0:
         return (
-            (y_p - y_a) * two_int_brute(i_0, i_1 - 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, m)
+            (y_p - y_a)
+            * two_int_brute(
+                i_0, i_1 - 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, m, alpha, beta, gamma, delta
+            )
             - rho
             / zeta
             * (y_p - y_q)
-            * two_int_brute(i_0, i_1 - 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, m + 1)
+            * two_int_brute(
+                i_0, i_1 - 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, m + 1, alpha, beta, gamma, delta
+            )
             + (i_1 - 1)
             / 2
             / zeta
             * (
-                two_int_brute(i_0, i_1 - 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, m)
-                - rho / zeta * two_int_brute(i_0, i_1 - 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, m + 1)
+                two_int_brute(
+                    i_0, i_1 - 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, m, alpha, beta, gamma, delta
+                )
+                - rho
+                / zeta
+                * two_int_brute(
+                    i_0, i_1 - 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, m + 1, alpha, beta, gamma, delta
+                )
             )
         ) * norm
     if j_0 == j_1 == j_2 == k_0 == k_1 == k_2 == l_0 == l_1 == l_2 == 0:
         return (
-            (z_p - z_a) * two_int_brute(i_0, i_1, i_2 - 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, m)
+            (z_p - z_a)
+            * two_int_brute(
+                i_0, i_1, i_2 - 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, m, alpha, beta, gamma, delta
+            )
             - rho
             / zeta
             * (z_p - z_q)
-            * two_int_brute(i_0, i_1, i_2 - 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, m + 1)
+            * two_int_brute(
+                i_0, i_1, i_2 - 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, m + 1, alpha, beta, gamma, delta
+            )
             + (i_2 - 1)
             / 2
             / zeta
             * (
-                two_int_brute(i_0, i_1, i_2 - 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, m)
-                - rho / zeta * two_int_brute(i_0, i_1, i_2 - 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, m + 1)
+                two_int_brute(
+                    i_0, i_1, i_2 - 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, m, alpha, beta, gamma, delta
+                )
+                - rho
+                / zeta
+                * two_int_brute(
+                    i_0, i_1, i_2 - 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, m + 1, alpha, beta, gamma, delta
+                )
             )
         ) * norm
     # electron transfer
     if j_0 == j_1 == j_2 == k_1 == k_2 == l_0 == l_1 == l_2 == 0:
         return (
             ((x_q - x_c) + zeta / eta * (x_p - x_a))
-            * two_int_brute(i_0, i_1, i_2, 0, 0, 0, k_0 - 1, 0, 0, 0, 0, 0, m)
-            + i_0 / 2 / eta * two_int_brute(i_0 - 1, i_1, i_2, 0, 0, 0, k_0 - 1, 0, 0, 0, 0, 0, m)
-            + (k_0 - 1) / 2 / eta * two_int_brute(i_0, i_1, i_2, 0, 0, 0, k_0 - 2, 0, 0, 0, 0, 0, m)
-            - zeta / eta * two_int_brute(i_0 + 1, i_1, i_2, 0, 0, 0, k_0 - 1, 0, 0, 0, 0, 0, m)
+            * two_int_brute(
+                i_0, i_1, i_2, 0, 0, 0, k_0 - 1, 0, 0, 0, 0, 0, m, alpha, beta, gamma, delta
+            )
+            + i_0
+            / 2
+            / eta
+            * two_int_brute(
+                i_0 - 1, i_1, i_2, 0, 0, 0, k_0 - 1, 0, 0, 0, 0, 0, m, alpha, beta, gamma, delta
+            )
+            + (k_0 - 1)
+            / 2
+            / eta
+            * two_int_brute(
+                i_0, i_1, i_2, 0, 0, 0, k_0 - 2, 0, 0, 0, 0, 0, m, alpha, beta, gamma, delta
+            )
+            - zeta
+            / eta
+            * two_int_brute(
+                i_0 + 1, i_1, i_2, 0, 0, 0, k_0 - 1, 0, 0, 0, 0, 0, m, alpha, beta, gamma, delta
+            )
         ) * norm
     if j_0 == j_1 == j_2 == k_2 == l_0 == l_1 == l_2 == 0:
         return (
             ((y_q - y_c) + zeta / eta * (y_p - y_a))
-            * two_int_brute(i_0, i_1, i_2, 0, 0, 0, k_0, k_1 - 1, 0, 0, 0, 0, m)
-            + i_1 / 2 / eta * two_int_brute(i_0, i_1 - 1, i_2, 0, 0, 0, k_0, k_1 - 1, 0, 0, 0, 0, m)
+            * two_int_brute(
+                i_0, i_1, i_2, 0, 0, 0, k_0, k_1 - 1, 0, 0, 0, 0, m, alpha, beta, gamma, delta
+            )
+            + i_1
+            / 2
+            / eta
+            * two_int_brute(
+                i_0, i_1 - 1, i_2, 0, 0, 0, k_0, k_1 - 1, 0, 0, 0, 0, m, alpha, beta, gamma, delta
+            )
             + (k_1 - 1)
             / 2
             / eta
-            * two_int_brute(i_0, i_1, i_2, 0, 0, 0, k_0, k_1 - 2, 0, 0, 0, 0, m)
-            - zeta / eta * two_int_brute(i_0, i_1 + 1, i_2, 0, 0, 0, k_0, k_1 - 1, 0, 0, 0, 0, m)
+            * two_int_brute(
+                i_0, i_1, i_2, 0, 0, 0, k_0, k_1 - 2, 0, 0, 0, 0, m, alpha, beta, gamma, delta
+            )
+            - zeta
+            / eta
+            * two_int_brute(
+                i_0, i_1 + 1, i_2, 0, 0, 0, k_0, k_1 - 1, 0, 0, 0, 0, m, alpha, beta, gamma, delta
+            )
         ) * norm
     if j_0 == j_1 == j_2 == l_0 == l_1 == l_2 == 0:
         return (
             ((z_q - z_c) + zeta / eta * (z_p - z_a))
-            * two_int_brute(i_0, i_1, i_2, 0, 0, 0, k_0, k_1, k_2 - 1, 0, 0, 0, m)
+            * two_int_brute(
+                i_0, i_1, i_2, 0, 0, 0, k_0, k_1, k_2 - 1, 0, 0, 0, m, alpha, beta, gamma, delta
+            )
             + i_2
             / 2
             / eta
-            * two_int_brute(i_0, i_1, i_2 - 1, 0, 0, 0, k_0, k_1, k_2 - 1, 0, 0, 0, m)
+            * two_int_brute(
+                i_0, i_1, i_2 - 1, 0, 0, 0, k_0, k_1, k_2 - 1, 0, 0, 0, m, alpha, beta, gamma, delta
+            )
             + (k_2 - 1)
             / 2
             / eta
-            * two_int_brute(i_0, i_1, i_2, 0, 0, 0, k_0, k_1, k_2 - 2, 0, 0, 0, m)
-            - zeta / eta * two_int_brute(i_0, i_1, i_2 + 1, 0, 0, 0, k_0, k_1, k_2 - 1, 0, 0, 0, m)
+            * two_int_brute(
+                i_0, i_1, i_2, 0, 0, 0, k_0, k_1, k_2 - 2, 0, 0, 0, m, alpha, beta, gamma, delta
+            )
+            - zeta
+            / eta
+            * two_int_brute(
+                i_0, i_1, i_2 + 1, 0, 0, 0, k_0, k_1, k_2 - 1, 0, 0, 0, m, alpha, beta, gamma, delta
+            )
         ) * norm
-    # horizontal recurision for b
+    # horizontal recursion for b
     if j_1 == j_2 == l_0 == l_1 == l_2 == 0:
         return (
-            two_int_brute(i_0 + 1, i_1, i_2, j_0 - 1, 0, 0, k_0, k_1, k_2, 0, 0, 0, m)
+            two_int_brute(
+                i_0 + 1,
+                i_1,
+                i_2,
+                j_0 - 1,
+                0,
+                0,
+                k_0,
+                k_1,
+                k_2,
+                0,
+                0,
+                0,
+                m,
+                alpha,
+                beta,
+                gamma,
+                delta,
+            )
             + (x_a - x_b)
-            * two_int_brute(i_0, i_1, i_2, j_0 - 1, j_1, j_2, k_0, k_1, k_2, 0, 0, 0, m)
+            * two_int_brute(
+                i_0,
+                i_1,
+                i_2,
+                j_0 - 1,
+                j_1,
+                j_2,
+                k_0,
+                k_1,
+                k_2,
+                0,
+                0,
+                0,
+                m,
+                alpha,
+                beta,
+                gamma,
+                delta,
+            )
         ) * norm
     if j_2 == l_0 == l_1 == l_2 == 0:
         return (
-            two_int_brute(i_0, i_1 + 1, i_2, j_0, j_1 - 1, 0, k_0, k_1, k_2, 0, 0, 0, m)
+            two_int_brute(
+                i_0,
+                i_1 + 1,
+                i_2,
+                j_0,
+                j_1 - 1,
+                0,
+                k_0,
+                k_1,
+                k_2,
+                0,
+                0,
+                0,
+                m,
+                alpha,
+                beta,
+                gamma,
+                delta,
+            )
             + (y_a - y_b)
-            * two_int_brute(i_0, i_1, i_2, j_0, j_1 - 1, j_2, k_0, k_1, k_2, 0, 0, 0, m)
+            * two_int_brute(
+                i_0,
+                i_1,
+                i_2,
+                j_0,
+                j_1 - 1,
+                j_2,
+                k_0,
+                k_1,
+                k_2,
+                0,
+                0,
+                0,
+                m,
+                alpha,
+                beta,
+                gamma,
+                delta,
+            )
         ) * norm
     if l_0 == l_1 == l_2 == 0:
         return (
-            two_int_brute(i_0, i_1, i_2 + 1, j_0, j_1, j_2 - 1, k_0, k_1, k_2, 0, 0, 0, m)
+            two_int_brute(
+                i_0,
+                i_1,
+                i_2 + 1,
+                j_0,
+                j_1,
+                j_2 - 1,
+                k_0,
+                k_1,
+                k_2,
+                0,
+                0,
+                0,
+                m,
+                alpha,
+                beta,
+                gamma,
+                delta,
+            )
             + (z_a - z_b)
-            * two_int_brute(i_0, i_1, i_2, j_0, j_1, j_2 - 1, k_0, k_1, k_2, 0, 0, 0, m)
+            * two_int_brute(
+                i_0,
+                i_1,
+                i_2,
+                j_0,
+                j_1,
+                j_2 - 1,
+                k_0,
+                k_1,
+                k_2,
+                0,
+                0,
+                0,
+                m,
+                alpha,
+                beta,
+                gamma,
+                delta,
+            )
         ) * norm
-    # horizontal recurision for d
+    # horizontal recursion for d
     if l_1 == l_2 == 0:
         return (
-            two_int_brute(i_0, i_1, i_2, j_0, j_1, j_2, k_0 + 1, k_1, k_2, l_0 - 1, 0, 0, m)
+            two_int_brute(
+                i_0,
+                i_1,
+                i_2,
+                j_0,
+                j_1,
+                j_2,
+                k_0 + 1,
+                k_1,
+                k_2,
+                l_0 - 1,
+                0,
+                0,
+                m,
+                alpha,
+                beta,
+                gamma,
+                delta,
+            )
             + (x_c - x_d)
-            * two_int_brute(i_0, i_1, i_2, j_0, j_1, j_2, k_0, k_1, k_2, l_0 - 1, 0, 0, m)
+            * two_int_brute(
+                i_0,
+                i_1,
+                i_2,
+                j_0,
+                j_1,
+                j_2,
+                k_0,
+                k_1,
+                k_2,
+                l_0 - 1,
+                0,
+                0,
+                m,
+                alpha,
+                beta,
+                gamma,
+                delta,
+            )
         ) * norm
     if l_2 == 0:
         return (
-            two_int_brute(i_0, i_1, i_2, j_0, j_1, j_2, k_0, k_1 + 1, k_2, l_0, l_1 - 1, 0, m)
+            two_int_brute(
+                i_0,
+                i_1,
+                i_2,
+                j_0,
+                j_1,
+                j_2,
+                k_0,
+                k_1 + 1,
+                k_2,
+                l_0,
+                l_1 - 1,
+                0,
+                m,
+                alpha,
+                beta,
+                gamma,
+                delta,
+            )
             + (y_c - y_d)
-            * two_int_brute(i_0, i_1, i_2, j_0, j_1, j_2, k_0, k_1, k_2, l_0, l_1 - 1, 0, m)
+            * two_int_brute(
+                i_0,
+                i_1,
+                i_2,
+                j_0,
+                j_1,
+                j_2,
+                k_0,
+                k_1,
+                k_2,
+                l_0,
+                l_1 - 1,
+                0,
+                m,
+                alpha,
+                beta,
+                gamma,
+                delta,
+            )
         ) * norm
     return (
-        two_int_brute(i_0, i_1, i_2, j_0, j_1, j_2, k_0, k_1, k_2 + 1, l_0, l_1, l_2 - 1, m)
+        two_int_brute(
+            i_0,
+            i_1,
+            i_2,
+            j_0,
+            j_1,
+            j_2,
+            k_0,
+            k_1,
+            k_2 + 1,
+            l_0,
+            l_1,
+            l_2 - 1,
+            m,
+            alpha,
+            beta,
+            gamma,
+            delta,
+        )
         + (z_c - z_d)
-        * two_int_brute(i_0, i_1, i_2, j_0, j_1, j_2, k_0, k_1, k_2, l_0, l_1, l_2 - 1, m)
+        * two_int_brute(
+            i_0,
+            i_1,
+            i_2,
+            j_0,
+            j_1,
+            j_2,
+            k_0,
+            k_1,
+            k_2,
+            l_0,
+            l_1,
+            l_2 - 1,
+            m,
+            alpha,
+            beta,
+            gamma,
+            delta,
+        )
     ) * norm
 
 
@@ -454,6 +754,31 @@ def test_two_int_brute():
         two_int_brute(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, output=True), -0.12506077396766221
     )
 
+    # different exponents
+    assert np.allclose(
+        two_int_brute(
+            1,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            1,
+            2,
+            0,
+            0,
+            0,
+            output=True,
+            alpha=0.2,
+            beta=0.3,
+            gamma=0.4,
+            delta=0.5,
+        ),
+        -0.015147214477383354,
+    )
+
 
 def test_compute_two_elec_integrals_angmom_zero_prim():
     """Test gbasis._two_elec_int._compute_two_elec_integrals_angmom_zero on primitives."""
@@ -474,6 +799,82 @@ def test_compute_two_elec_integrals_angmom_zero_prim():
             np.array([[1.0]]),
         ),
         two_int_brute(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, output=True),
+    )
+    assert np.allclose(
+        _compute_two_elec_integrals_angmom_zero(
+            boys_func,
+            np.array([0.2, 0.4, 0.6]),
+            np.array([0.1, 0.15]),
+            np.array([[1.0], [2.0]]),
+            np.array([1.0, 1.5, 2.0]),
+            np.array([0.2]),
+            np.array([[1.0]]),
+            np.array([0.1, 0.3, 0.5]),
+            np.array([0.3]),
+            np.array([[1.0]]),
+            np.array([1.1, 1.6, 2.1]),
+            np.array([0.4]),
+            np.array([[1.0]]),
+        ),
+        1 * two_int_brute(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, output=True, alpha=0.1)
+        + 2 * two_int_brute(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, output=True, alpha=0.15),
+    )
+    assert np.allclose(
+        _compute_two_elec_integrals_angmom_zero(
+            boys_func,
+            np.array([0.2, 0.4, 0.6]),
+            np.array([0.1]),
+            np.array([[1.0]]),
+            np.array([1.0, 1.5, 2.0]),
+            np.array([0.2, 0.25]),
+            np.array([[1.0], [2.0]]),
+            np.array([0.1, 0.3, 0.5]),
+            np.array([0.3]),
+            np.array([[1.0]]),
+            np.array([1.1, 1.6, 2.1]),
+            np.array([0.4]),
+            np.array([[1.0]]),
+        ),
+        1 * two_int_brute(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, output=True, beta=0.2)
+        + 2 * two_int_brute(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, output=True, beta=0.25),
+    )
+    assert np.allclose(
+        _compute_two_elec_integrals_angmom_zero(
+            boys_func,
+            np.array([0.2, 0.4, 0.6]),
+            np.array([0.1]),
+            np.array([[1.0]]),
+            np.array([1.0, 1.5, 2.0]),
+            np.array([0.2]),
+            np.array([[1.0]]),
+            np.array([0.1, 0.3, 0.5]),
+            np.array([0.3, 0.35]),
+            np.array([[1.0], [2.0]]),
+            np.array([1.1, 1.6, 2.1]),
+            np.array([0.4]),
+            np.array([[1.0]]),
+        ),
+        1 * two_int_brute(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, output=True, gamma=0.3)
+        + 2 * two_int_brute(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, output=True, gamma=0.35),
+    )
+    assert np.allclose(
+        _compute_two_elec_integrals_angmom_zero(
+            boys_func,
+            np.array([0.2, 0.4, 0.6]),
+            np.array([0.1]),
+            np.array([[1.0]]),
+            np.array([1.0, 1.5, 2.0]),
+            np.array([0.2]),
+            np.array([[1.0]]),
+            np.array([0.1, 0.3, 0.5]),
+            np.array([0.3]),
+            np.array([[1.0]]),
+            np.array([1.1, 1.6, 2.1]),
+            np.array([0.4, 0.45]),
+            np.array([[1.0], [2.0]]),
+        ),
+        1 * two_int_brute(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, output=True, delta=0.4)
+        + 2 * two_int_brute(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, output=True, delta=0.45),
     )
 
 
@@ -684,4 +1085,260 @@ def test_compute_two_elec_integrals_prim():
             np.array([[1.0]]),
         ),
         2 * two_int_brute(0, 1, 1, 0, 0, 2, 2, 0, 0, 1, 1, 1, 0, output=True),
+    )
+
+
+def test_compute_two_elec_integrals_segmented_contractions():
+    """Test gbasis._two_elec_int._compute_two_elec_integrals on segmented contractions."""
+    assert np.allclose(
+        _compute_two_elec_integrals(
+            boys_func,
+            np.array([0.2, 0.4, 0.6]),
+            2,
+            np.array([[0, 1, 1]]),
+            np.array([0.1, 0.15]),
+            np.array([[1.0], [0.5]]),
+            np.array([1.0, 1.5, 2.0]),
+            1,
+            np.array([[0, 0, 1]]),
+            np.array([0.2]),
+            np.array([[1.0]]),
+            np.array([0.1, 0.3, 0.5]),
+            1,
+            np.array([[1, 0, 0]]),
+            np.array([0.3]),
+            np.array([[1.0]]),
+            np.array([1.1, 1.6, 2.1]),
+            3,
+            np.array([[1, 1, 1]]),
+            np.array([0.4]),
+            np.array([[1.0]]),
+        ),
+        1 * two_int_brute(0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, output=True, alpha=0.1)
+        + 0.5 * two_int_brute(0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, output=True, alpha=0.15),
+    )
+    assert np.allclose(
+        _compute_two_elec_integrals(
+            boys_func,
+            np.array([0.2, 0.4, 0.6]),
+            2,
+            np.array([[0, 1, 1]]),
+            np.array([0.1]),
+            np.array([[1.0]]),
+            np.array([1.0, 1.5, 2.0]),
+            1,
+            np.array([[0, 0, 1]]),
+            np.array([0.2, 0.25]),
+            np.array([[1.0], [0.6]]),
+            np.array([0.1, 0.3, 0.5]),
+            1,
+            np.array([[1, 0, 0]]),
+            np.array([0.3]),
+            np.array([[1.0]]),
+            np.array([1.1, 1.6, 2.1]),
+            3,
+            np.array([[1, 1, 1]]),
+            np.array([0.4]),
+            np.array([[1.0]]),
+        ),
+        1 * two_int_brute(0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, output=True, beta=0.2)
+        + 0.6 * two_int_brute(0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, output=True, beta=0.25),
+    )
+    assert np.allclose(
+        _compute_two_elec_integrals(
+            boys_func,
+            np.array([0.2, 0.4, 0.6]),
+            2,
+            np.array([[0, 1, 1]]),
+            np.array([0.1]),
+            np.array([[1.0]]),
+            np.array([1.0, 1.5, 2.0]),
+            1,
+            np.array([[0, 0, 1]]),
+            np.array([0.2]),
+            np.array([[1.0]]),
+            np.array([0.1, 0.3, 0.5]),
+            1,
+            np.array([[1, 0, 0]]),
+            np.array([0.3, 0.35]),
+            np.array([[1.0], [0.7]]),
+            np.array([1.1, 1.6, 2.1]),
+            3,
+            np.array([[1, 1, 1]]),
+            np.array([0.4]),
+            np.array([[1.0]]),
+        ),
+        1 * two_int_brute(0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, output=True, gamma=0.3)
+        + 0.7 * two_int_brute(0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, output=True, gamma=0.35),
+    )
+    assert np.allclose(
+        _compute_two_elec_integrals(
+            boys_func,
+            np.array([0.2, 0.4, 0.6]),
+            2,
+            np.array([[0, 1, 1]]),
+            np.array([0.1]),
+            np.array([[1.0]]),
+            np.array([1.0, 1.5, 2.0]),
+            1,
+            np.array([[0, 0, 1]]),
+            np.array([0.2]),
+            np.array([[1.0]]),
+            np.array([0.1, 0.3, 0.5]),
+            1,
+            np.array([[1, 0, 0]]),
+            np.array([0.3]),
+            np.array([[1.0]]),
+            np.array([1.1, 1.6, 2.1]),
+            3,
+            np.array([[1, 1, 1]]),
+            np.array([0.4, 0.45]),
+            np.array([[1.0], [0.8]]),
+        ),
+        1 * two_int_brute(0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, output=True, delta=0.4)
+        + 0.8 * two_int_brute(0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, output=True, delta=0.45),
+    )
+
+
+def test_compute_two_elec_integrals_generalized_contractions():
+    """Test gbasis._two_elec_int._compute_two_elec_integrals on generalized contractions."""
+    assert np.allclose(
+        _compute_two_elec_integrals(
+            boys_func,
+            np.array([0.2, 0.4, 0.6]),
+            2,
+            np.array([[0, 1, 1]]),
+            np.array([0.1, 0.15]),
+            np.array([[1.0, 2.0], [0.5, 1.0]]),
+            np.array([1.0, 1.5, 2.0]),
+            1,
+            np.array([[0, 0, 1]]),
+            np.array([0.2]),
+            np.array([[1.0]]),
+            np.array([0.1, 0.3, 0.5]),
+            1,
+            np.array([[1, 0, 0]]),
+            np.array([0.3]),
+            np.array([[1.0]]),
+            np.array([1.1, 1.6, 2.1]),
+            3,
+            np.array([[1, 1, 1]]),
+            np.array([0.4]),
+            np.array([[1.0]]),
+        ),
+        np.array(
+            [
+                1 * two_int_brute(0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, output=True, alpha=0.1)
+                + 0.5
+                * two_int_brute(0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, output=True, alpha=0.15),
+                2 * two_int_brute(0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, output=True, alpha=0.1)
+                + 1.0
+                * two_int_brute(0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, output=True, alpha=0.15),
+            ]
+        ).reshape(1, 1, 1, 1, 2, 1, 1, 1),
+    )
+    assert np.allclose(
+        _compute_two_elec_integrals(
+            boys_func,
+            np.array([0.2, 0.4, 0.6]),
+            2,
+            np.array([[0, 1, 1]]),
+            np.array([0.1]),
+            np.array([[1.0]]),
+            np.array([1.0, 1.5, 2.0]),
+            1,
+            np.array([[0, 0, 1]]),
+            np.array([0.2, 0.25]),
+            np.array([[1.0, 0.9], [0.6, 0.5]]),
+            np.array([0.1, 0.3, 0.5]),
+            1,
+            np.array([[1, 0, 0]]),
+            np.array([0.3]),
+            np.array([[1.0]]),
+            np.array([1.1, 1.6, 2.1]),
+            3,
+            np.array([[1, 1, 1]]),
+            np.array([0.4]),
+            np.array([[1.0]]),
+        ),
+        np.array(
+            [
+                1 * two_int_brute(0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, output=True, beta=0.2)
+                + 0.6
+                * two_int_brute(0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, output=True, beta=0.25),
+                0.9 * two_int_brute(0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, output=True, beta=0.2)
+                + 0.5
+                * two_int_brute(0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, output=True, beta=0.25),
+            ]
+        ).reshape(1, 1, 1, 1, 1, 2, 1, 1),
+    )
+    assert np.allclose(
+        _compute_two_elec_integrals(
+            boys_func,
+            np.array([0.2, 0.4, 0.6]),
+            2,
+            np.array([[0, 1, 1]]),
+            np.array([0.1]),
+            np.array([[1.0]]),
+            np.array([1.0, 1.5, 2.0]),
+            1,
+            np.array([[0, 0, 1]]),
+            np.array([0.2]),
+            np.array([[1.0]]),
+            np.array([0.1, 0.3, 0.5]),
+            1,
+            np.array([[1, 0, 0]]),
+            np.array([0.3, 0.35]),
+            np.array([[1.0, 0.8], [0.7, 0.8]]),
+            np.array([1.1, 1.6, 2.1]),
+            3,
+            np.array([[1, 1, 1]]),
+            np.array([0.4]),
+            np.array([[1.0]]),
+        ),
+        np.array(
+            [
+                1 * two_int_brute(0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, output=True, gamma=0.3)
+                + 0.7
+                * two_int_brute(0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, output=True, gamma=0.35),
+                0.8 * two_int_brute(0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, output=True, gamma=0.3)
+                + 0.8
+                * two_int_brute(0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, output=True, gamma=0.35),
+            ]
+        ).reshape(1, 1, 1, 1, 1, 1, 2, 1),
+    )
+    assert np.allclose(
+        _compute_two_elec_integrals(
+            boys_func,
+            np.array([0.2, 0.4, 0.6]),
+            2,
+            np.array([[0, 1, 1]]),
+            np.array([0.1]),
+            np.array([[1.0]]),
+            np.array([1.0, 1.5, 2.0]),
+            1,
+            np.array([[0, 0, 1]]),
+            np.array([0.2]),
+            np.array([[1.0]]),
+            np.array([0.1, 0.3, 0.5]),
+            1,
+            np.array([[1, 0, 0]]),
+            np.array([0.3]),
+            np.array([[1.0]]),
+            np.array([1.1, 1.6, 2.1]),
+            3,
+            np.array([[1, 1, 1]]),
+            np.array([0.4, 0.45]),
+            np.array([[1.0, 1.1], [0.8, 0.9]]),
+        ),
+        np.array(
+            [
+                1 * two_int_brute(0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, output=True, delta=0.4)
+                + 0.8
+                * two_int_brute(0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, output=True, delta=0.45),
+                1.1 * two_int_brute(0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, output=True, delta=0.4)
+                + 0.9
+                * two_int_brute(0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, output=True, delta=0.45),
+            ]
+        ),
     )

--- a/tests/test_two_elec_int.py
+++ b/tests/test_two_elec_int.py
@@ -1,0 +1,484 @@
+"""Test gbasis._two_elec_int."""
+from gbasis._two_elec_int import _compute_two_elec_integrals
+import numpy as np
+from scipy.special import factorial2, hyp1f1  # pylint: disable=E0611
+
+
+def boys_func(order, weighted_dist):
+    r"""Boys function for evaluating the one-electron Coulomb interaction integral.
+
+    The Coulombic Boys function can be written as a renormalized special case of the Kummer
+    confluent hypergeometric function, as derived in Helgaker (eq. 9.8.39).
+
+    Parameters
+    ----------
+    order : int
+        Differentiation order of the helper function.
+        Same as m in eq. 23, Aldrichs, R. Phys. Chem. Chem. Phys., 2006, 8, 3072-3077.
+    weighted_dist : np.ndarray(L_b, L_a)
+        The weighted interatomic distance, :math:`\\mu * R_{AB}^{2}`, where `\\mu` is the
+        harmonic mean of the exponents for primitive one and two,
+        :math:`\\mu = \\alpha * \\beta / (\\alpha + \\beta)`.
+        `L_a` and `L_b` are the angular momentum of contraction one and two respectively.
+
+    Returns
+    -------
+    boys_eval : np.ndarray(L_b, L_a)
+        The evaluation of the Boys function for the given values. This output corresponds
+        to the evaluation for every Gaussian primitive at the given differentiation order.
+
+    Notes
+    -----
+    There's some documented instability for hyp1f1, mainly for large values or complex numbers.
+    In this case it seems fine, since m should be less than 10 in most cases, and except for
+    exceptional cases the input, while negative, shouldn't be very large. In scipy > 0.16, this
+    problem becomes a precision error in most cases where it was an overflow error before, so
+    the values should be close even when they are wrong.
+    This function cannot be vectorized for both m and x.
+
+    """
+
+    return hyp1f1(order + 1 / 2, order + 3 / 2, -weighted_dist) / (2 * order + 1)
+
+
+def two_int_brute(i_0, i_1, i_2, j_0, j_1, j_2, k_0, k_1, k_2, l_0, l_1, l_2, m, output=False):
+    """Return the answer to the two-electron integral tests.
+
+    Data for first primitive on the left:
+    - Coordinate: [0.2, 0.4, 0.6]
+    - Exponents: [0.1]
+    - Coefficients: [1.0]
+
+    Data for first primitive on the right:
+    - Coordinate: [1.0, 1.5, 2.0]
+    - Exponents: [0.2]
+    - Coefficients: [1.0]
+
+    Data for second primitive on the left:
+    - Coordinate: [0.1, 0.3, 0.5]
+    - Exponents: [0.3]
+    - Coefficients: [1.0]
+
+    Data for second primitive on the right:
+    - Coordinate: [1.1, 1.6, 2.1]
+    - Exponents: [0.4]
+    - Coefficients: [1.0]
+
+
+    Parameters
+    ----------
+    i_0 : int
+        Angular momentum component (x) for the given coordinate of the first primitive on the left.
+    i_1 : int
+        Angular momentum component (y) for the given coordinate of the first primitive on the left.
+    i_2 : int
+        Angular momentum component (z) for the given coordinate of the first primitive on the left.
+    j_0 : int
+        Angular momentum component (x) for the given coordinate of the first primitive on the right.
+    j_1 : int
+        Angular momentum component (y) for the given coordinate of the first primitive on the right.
+    j_2 : int
+        Angular momentum component (z) for the given coordinate of the first primitive on the right.
+    k_0 : int
+        Angular momentum component (x) for the given coordinate of the second primitive on the left.
+    k_1 : int
+        Angular momentum component (y) for the given coordinate of the second primitive on the left.
+    k_2 : int
+        Angular momentum component (z) for the given coordinate of the second primitive on the left.
+    l_0 : int
+        Angular momentum component (x) for the given coordinate of the second primitive on the
+        right.
+    l_1 : int
+        Angular momentum component (y) for the given coordinate of the second primitive on the
+        right.
+    l_2 : int
+        Angular momentum component (z) for the given coordinate of the second primitive on the
+        right.
+
+    Returns
+    -------
+    answer : float
+
+    """
+    alpha = 0.1
+    beta = 0.2
+    gamma = 0.3
+    delta = 0.4
+    zeta = alpha + beta
+    eta = gamma + delta
+    rho = zeta * eta / (zeta + eta)
+    x_a, y_a, z_a = 0.2, 0.4, 0.6
+    x_b, y_b, z_b = 1.0, 1.5, 2.0
+    x_c, y_c, z_c = 0.1, 0.3, 0.5
+    x_d, y_d, z_d = 1.1, 1.6, 2.1
+
+    x_p = (alpha * x_a + beta * x_b) / zeta
+    y_p = (alpha * y_a + beta * y_b) / zeta
+    z_p = (alpha * z_a + beta * z_b) / zeta
+    x_q = (gamma * x_c + delta * x_d) / eta
+    y_q = (gamma * y_c + delta * y_d) / eta
+    z_q = (gamma * z_c + delta * z_d) / eta
+
+    olp_ab = np.exp(-alpha * beta / zeta * ((x_a - x_b) ** 2 + (y_a - y_b) ** 2 + (z_a - z_b) ** 2))
+    olp_cd = np.exp(-gamma * delta / eta * ((x_c - x_d) ** 2 + (y_c - y_d) ** 2 + (z_c - z_d) ** 2))
+
+    if (
+        i_0 < 0
+        or i_1 < 0
+        or i_2 < 0
+        or j_0 < 0
+        or j_1 < 0
+        or j_2 < 0
+        or k_0 < 0
+        or k_1 < 0
+        or k_2 < 0
+        or l_0 < 0
+        or l_1 < 0
+        or l_2 < 0
+    ):
+        return 0.0
+
+    if output:
+        norm_a = (
+            (2 * alpha / np.pi) ** (3 / 4)
+            * ((4 * alpha) ** ((i_0 + i_1 + i_2) / 2.0))
+            / ((factorial2(2 * i_0 - 1) * factorial2(2 * i_1 - 1) * factorial2(2 * i_2 - 1)) ** 0.5)
+        )
+        norm_b = (
+            (2 * beta / np.pi) ** (3 / 4)
+            * ((4 * beta) ** ((j_0 + j_1 + j_2) / 2))
+            / ((factorial2(2 * j_0 - 1) * factorial2(2 * j_1 - 1) * factorial2(2 * j_2 - 1)) ** 0.5)
+        )
+        norm_c = (
+            (2 * gamma / np.pi) ** (3 / 4)
+            * ((4 * gamma) ** ((k_0 + k_1 + k_2) / 2))
+            / ((factorial2(2 * k_0 - 1) * factorial2(2 * k_1 - 1) * factorial2(2 * k_2 - 1)) ** 0.5)
+        )
+        norm_d = (
+            (2 * delta / np.pi) ** (3 / 4)
+            * ((4 * delta) ** ((l_0 + l_1 + l_2) / 2))
+            / ((factorial2(2 * l_0 - 1) * factorial2(2 * l_1 - 1) * factorial2(2 * l_2 - 1)) ** 0.5)
+        )
+        norm = norm_a * norm_b * norm_c * norm_d
+    else:
+        norm = 1
+
+    # initial
+    if i_0 == i_1 == i_2 == j_0 == j_1 == j_2 == k_0 == k_1 == k_2 == l_0 == l_1 == l_2 == 0:
+        return (
+            (2 * np.pi ** 2.5)
+            / (zeta * eta * (zeta + eta) ** 0.5)
+            * boys_func(m, (rho) * ((x_p - x_q) ** 2 + (y_p - y_q) ** 2 + (z_p - z_q) ** 2))
+            * olp_ab
+            * olp_cd
+            * norm
+        )
+    # vertical recursion
+    if i_1 == i_2 == j_0 == j_1 == j_2 == k_0 == k_1 == k_2 == l_0 == l_1 == l_2 == 0:
+        return (
+            (x_p - x_a) * two_int_brute(i_0 - 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, m)
+            - rho
+            / zeta
+            * (x_p - x_q)
+            * two_int_brute(i_0 - 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, m + 1)
+            + (i_0 - 1)
+            / 2
+            / zeta
+            * (
+                two_int_brute(i_0 - 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, m)
+                - rho / zeta * two_int_brute(i_0 - 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, m + 1)
+            )
+        ) * norm
+    if i_2 == j_0 == j_1 == j_2 == k_0 == k_1 == k_2 == l_0 == l_1 == l_2 == 0:
+        return (
+            (y_p - y_a) * two_int_brute(i_0, i_1 - 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, m)
+            - rho
+            / zeta
+            * (y_p - y_q)
+            * two_int_brute(i_0, i_1 - 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, m + 1)
+            + (i_1 - 1)
+            / 2
+            / zeta
+            * (
+                two_int_brute(i_0, i_1 - 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, m)
+                - rho / zeta * two_int_brute(i_0, i_1 - 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, m + 1)
+            )
+        ) * norm
+    if j_0 == j_1 == j_2 == k_0 == k_1 == k_2 == l_0 == l_1 == l_2 == 0:
+        return (
+            (z_p - z_a) * two_int_brute(i_0, i_1, i_2 - 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, m)
+            - rho
+            / zeta
+            * (z_p - z_q)
+            * two_int_brute(i_0, i_1, i_2 - 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, m + 1)
+            + (i_2 - 1)
+            / 2
+            / zeta
+            * (
+                two_int_brute(i_0, i_1, i_2 - 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, m)
+                - rho / zeta * two_int_brute(i_0, i_1, i_2 - 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, m + 1)
+            )
+        ) * norm
+    # electron transfer
+    if j_0 == j_1 == j_2 == k_1 == k_2 == l_0 == l_1 == l_2 == 0:
+        return (
+            ((x_q - x_c) + zeta / eta * (x_p - x_a))
+            * two_int_brute(i_0, i_1, i_2, 0, 0, 0, k_0 - 1, 0, 0, 0, 0, 0, m)
+            + i_0 / 2 / eta * two_int_brute(i_0 - 1, i_1, i_2, 0, 0, 0, k_0 - 1, 0, 0, 0, 0, 0, m)
+            + (k_0 - 1) / 2 / eta * two_int_brute(i_0, i_1, i_2, 0, 0, 0, k_0 - 2, 0, 0, 0, 0, 0, m)
+            - zeta / eta * two_int_brute(i_0 + 1, i_1, i_2, 0, 0, 0, k_0 - 1, 0, 0, 0, 0, 0, m)
+        ) * norm
+    if j_0 == j_1 == j_2 == k_2 == l_0 == l_1 == l_2 == 0:
+        return (
+            ((y_q - y_c) + zeta / eta * (y_p - y_a))
+            * two_int_brute(i_0, i_1, i_2, 0, 0, 0, k_0, k_1 - 1, 0, 0, 0, 0, m)
+            + i_1 / 2 / eta * two_int_brute(i_0, i_1 - 1, i_2, 0, 0, 0, k_0, k_1 - 1, 0, 0, 0, 0, m)
+            + (k_1 - 1)
+            / 2
+            / eta
+            * two_int_brute(i_0, i_1, i_2, 0, 0, 0, k_0, k_1 - 2, 0, 0, 0, 0, m)
+            - zeta / eta * two_int_brute(i_0, i_1 + 1, i_2, 0, 0, 0, k_0, k_1 - 1, 0, 0, 0, 0, m)
+        ) * norm
+    if j_0 == j_1 == j_2 == l_0 == l_1 == l_2 == 0:
+        return (
+            ((z_q - z_c) + zeta / eta * (z_p - z_a))
+            * two_int_brute(i_0, i_1, i_2, 0, 0, 0, k_0, k_1, k_2 - 1, 0, 0, 0, m)
+            + i_2
+            / 2
+            / eta
+            * two_int_brute(i_0, i_1, i_2 - 1, 0, 0, 0, k_0, k_1, k_2 - 1, 0, 0, 0, m)
+            + (k_2 - 1)
+            / 2
+            / eta
+            * two_int_brute(i_0, i_1, i_2, 0, 0, 0, k_0, k_1, k_2 - 2, 0, 0, 0, m)
+            - zeta / eta * two_int_brute(i_0, i_1, i_2 + 1, 0, 0, 0, k_0, k_1, k_2 - 1, 0, 0, 0, m)
+        ) * norm
+    # horizontal recurision for b
+    if j_1 == j_2 == l_0 == l_1 == l_2 == 0:
+        return (
+            two_int_brute(i_0 + 1, i_1, i_2, j_0 - 1, 0, 0, k_0, k_1, k_2, 0, 0, 0, m)
+            + (x_a - x_b)
+            * two_int_brute(i_0, i_1, i_2, j_0 - 1, j_1, j_2, k_0, k_1, k_2, 0, 0, 0, m)
+        ) * norm
+    if j_2 == l_0 == l_1 == l_2 == 0:
+        return (
+            two_int_brute(i_0, i_1 + 1, i_2, j_0, j_1 - 1, 0, k_0, k_1, k_2, 0, 0, 0, m)
+            + (y_a - y_b)
+            * two_int_brute(i_0, i_1, i_2, j_0, j_1 - 1, j_2, k_0, k_1, k_2, 0, 0, 0, m)
+        ) * norm
+    if l_0 == l_1 == l_2 == 0:
+        return (
+            two_int_brute(i_0, i_1, i_2 + 1, j_0, j_1, j_2 - 1, k_0, k_1, k_2, 0, 0, 0, m)
+            + (z_a - z_b)
+            * two_int_brute(i_0, i_1, i_2, j_0, j_1, j_2 - 1, k_0, k_1, k_2, 0, 0, 0, m)
+        ) * norm
+    # horizontal recurision for d
+    if l_1 == l_2 == 0:
+        return (
+            two_int_brute(i_0, i_1, i_2, j_0, j_1, j_2, k_0 + 1, k_1, k_2, l_0 - 1, 0, 0, m)
+            + (x_c - x_d)
+            * two_int_brute(i_0, i_1, i_2, j_0, j_1, j_2, k_0, k_1, k_2, l_0 - 1, 0, 0, m)
+        ) * norm
+    if l_2 == 0:
+        return (
+            two_int_brute(i_0, i_1, i_2, j_0, j_1, j_2, k_0, k_1 + 1, k_2, l_0, l_1 - 1, 0, m)
+            + (y_c - y_d)
+            * two_int_brute(i_0, i_1, i_2, j_0, j_1, j_2, k_0, k_1, k_2, l_0, l_1 - 1, 0, m)
+        ) * norm
+    return (
+        two_int_brute(i_0, i_1, i_2, j_0, j_1, j_2, k_0, k_1, k_2 + 1, l_0, l_1, l_2 - 1, m)
+        + (z_c - z_d)
+        * two_int_brute(i_0, i_1, i_2, j_0, j_1, j_2, k_0, k_1, k_2, l_0, l_1, l_2 - 1, m)
+    ) * norm
+
+
+def test_two_int_brute():
+    """Test two_int_brute by comparing it to HORTON's results.
+
+    A basis set was created with the given specifications
+
+        Data for first primitive on the left:
+        - Coordinate: [0.2, 0.4, 0.6]
+        - Exponents: [0.1]
+        - Coefficients: [1.0]
+
+        Data for first primitive on the right:
+        - Coordinate: [1.0, 1.5, 2.0]
+        - Exponents: [0.2]
+        - Coefficients: [1.0]
+
+        Data for second primitive on the left:
+        - Coordinate: [0.1, 0.3, 0.5]
+        - Exponents: [0.3]
+        - Coefficients: [1.0]
+
+        Data for second primitive on the right:
+        - Coordinate: [1.1, 1.6, 2.1]
+        - Exponents: [0.4]
+        - Coefficients: [1.0]
+
+    with the given angular momentum. Then the two-electron integrals were obtained, appropriate
+    pieces were used as a reference. Following code was used to generate the two-electron integrals:
+
+    ```python
+    from horton import *
+    import numpy as np
+
+    mol = IOData.from_file('example.xyz')
+    obasis = get_gobasis(mol.coordinates, mol.numbers, 'ano-rcc', pure=False)
+
+    lf = DenseLinalgFactory(obasis.nbasis)
+
+    er = obasis.compute_electron_repulsion(lf)
+    np.save("../../gbasis/tests/data_horton_test_initial.npy", er._array)
+    ```
+
+    """
+    # initial
+    #  s orbitals
+    assert np.allclose(
+        two_int_brute(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, output=True), 0.1467279087841229
+    )
+
+    # vertical recursion
+    #  p orbitals
+    assert np.allclose(
+        two_int_brute(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, output=True), 0.048154271426258756
+    )
+    assert np.allclose(
+        two_int_brute(0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, output=True), 0.06609629465618197
+    )
+    assert np.allclose(
+        two_int_brute(0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, output=True), 0.08403831788610522
+    )
+    #  d orbitals
+    assert np.allclose(
+        two_int_brute(2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, output=True), 0.05244715697793453
+    )
+    assert np.allclose(
+        two_int_brute(1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, output=True), 0.0217062830727606
+    )
+    assert np.allclose(
+        two_int_brute(1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, output=True), 0.027599148189803257
+    )
+    assert np.allclose(
+        two_int_brute(0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, output=True), 0.060519542518842465
+    )
+    assert np.allclose(
+        two_int_brute(0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, output=True), 0.03788411662894913
+    )
+    assert np.allclose(
+        two_int_brute(0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, output=True), 0.07112771009507537
+    )
+
+    # electron transfer recursion
+    #  s & p orbitals
+    assert np.allclose(
+        two_int_brute(0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, output=True), 0.0928406204255668
+    )
+    assert np.allclose(
+        two_int_brute(0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, output=True), 0.12085330330691318
+    )
+    assert np.allclose(
+        two_int_brute(0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, output=True), 0.14886598618825944
+    )
+    #  s & d orbitals
+    assert np.allclose(
+        two_int_brute(0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, output=True), 0.09927994323113691
+    )
+    assert np.allclose(
+        two_int_brute(0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, output=True), 0.07647660304843684
+    )
+    assert np.allclose(
+        two_int_brute(0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, output=True), 0.09420383743511908
+    )
+    assert np.allclose(
+        two_int_brute(0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, output=True), 0.1228379603032861
+    )
+    assert np.allclose(
+        two_int_brute(0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, output=True), 0.12262949926414721
+    )
+    assert np.allclose(
+        two_int_brute(0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, output=True), 0.15257271733917935
+    )
+    #  p & p orbitals
+    assert np.allclose(
+        two_int_brute(1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, output=True), 0.047379713835400634
+    )
+    assert np.allclose(
+        two_int_brute(1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, output=True), 0.039651931284181034
+    )
+    assert np.allclose(
+        two_int_brute(1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, output=True), 0.04884199202229442
+    )
+    assert np.allclose(
+        two_int_brute(0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, output=True), 0.04181115399876404
+    )
+    assert np.allclose(
+        two_int_brute(0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, output=True), 0.07134292715508984
+    )
+    assert np.allclose(
+        two_int_brute(0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, output=True), 0.06703901373274967
+    )
+    assert np.allclose(
+        two_int_brute(0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, output=True), 0.053160437451460436
+    )
+    assert np.allclose(
+        two_int_brute(0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, output=True), 0.06919823644733271
+    )
+    assert np.allclose(
+        two_int_brute(0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, output=True), 0.10215387873253794
+    )
+
+    # horizontal recursion for b
+    #  p orbital
+    assert np.allclose(
+        two_int_brute(0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, output=True), -0.03688952129884961
+    )
+    assert np.allclose(
+        two_int_brute(0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, output=True), -0.05088689809920155
+    )
+    assert np.allclose(
+        two_int_brute(0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, output=True), -0.0648842748995535
+    )
+    # horizontal recursion for d
+    #  p orbital
+    assert np.allclose(
+        two_int_brute(0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, output=True), -0.07839464083963653
+    )
+    assert np.allclose(
+        two_int_brute(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, output=True), -0.1017277074036494
+    )
+    assert np.allclose(
+        two_int_brute(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, output=True), -0.12506077396766221
+    )
+
+
+def test_compute_two_elec_integrals_prim():
+    """Test gbasis._two_elec_int._compute_two_elec_integrals on primitives."""
+    angmom_a = 4
+    angmom_b = 4
+    angmom_c = 4
+    angmom_d = 3
+    print(
+        _compute_two_elec_integrals(
+            boys_func,
+            np.array([0.2, 0.4, 0.6]),
+            angmom_a,
+            np.array([0.1]),
+            np.array([[1.0]]),
+            np.array([1.0, 1.5, 2.0]),
+            angmom_b,
+            np.array([0.2]),
+            np.array([[1.0]]),
+            np.array([0.1, 0.3, 0.5]),
+            angmom_c,
+            np.array([0.3]),
+            np.array([[1.0]]),
+            np.array([1.1, 1.6, 2.1]),
+            angmom_d,
+            np.array([0.4]),
+            np.array([[1.0]]),
+        ).shape
+    )
+    print(two_int_brute(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, output=True))


### PR DESCRIPTION
1. Add `two_int_brute`. This is a brute force implementation of the recursion in two-electron integrals. No vectorization.
2. Add `_two_elec_int._compute_two_elec_integrals_angmom_zero`. This computes the two electron integrals when all four contractions have angular momentum of zero.
3. Add `_two_elec_int._compute_two_elec_integrals`. This computes the two electron integrals for arbitrary angular momentums (except when all contractions have angular momentum of zero).

So lots of trial and error here. The main problem was that the straight forward vectorized approach resulted in the creation of an array that is way too big for larger angular momentums. Since this is a multidimensional array that is being created, memory usage scales very badly with the angular momentum and number of primitives. I did what I could with the scaling problems with angular momentum (we can reach angular momentum 7 for one contraction), but I haven't really checked the problems associated with a larger number of primitives. I think it shouldn't be too bad since the arrays associated with the angular momentum (in horizontal recursion) scales much worse than the number of primitives, but can't be too sure. For now, we'll address the issue when it becomes a problem.

The case with zero angular momentum contractions is treated separately mainly due to the problem with issues with broadcasting two arrays with zero elements into one another. For the moment and one electron integrals, we could use slicing to treat the zero angular momentum cases, but that doesn't seem possible in the electron transfer recursion. It is my belief that inserting an if statement here may cause trouble for optimization in the future (numba maybe?). I'm not 100% sure if this is true, but we can check later when we optimize the code later.
