### PR TITLE
Repair tests for one-electron integrals

### DIFF
--- a/gbasis/_one_elec_int.py
+++ b/gbasis/_one_elec_int.py
@@ -234,7 +234,7 @@ def _compute_one_elec_integrals(
     # discard higher order angular momentum needed for the recursions
     integrals = integrals[: angmom_a + 1, : angmom_a + 1, : angmom_a + 1]
 
-    # Get normalzation constants that correspond to the angular momentum components
+    # Get normalization constants that correspond to the angular momentum components
     angmoms_a = np.arange(angmom_a + 1)
     angmoms_b = np.arange(angmom_b + 1)
     norm_a = 1 / np.sqrt(

--- a/tests/test_one_elec_int.py
+++ b/tests/test_one_elec_int.py
@@ -43,10 +43,6 @@ def boys_func(order, weighted_dist):
     return hyp1f1(order + 1 / 2, order + 3 / 2, -weighted_dist) / (2 * order + 1)
 
 
-# FIXME: test fails because reference/answer does not normalize contractions
-@pytest.mark.skip(
-    reason="The answer that were hand-computed were not using normalized contractions."
-)
 def test_compute_one_elec_int_v_recursion():
     """Test vertical recursion in _one_elec_int._compute_one_elec_integrals."""
     contr_one = GeneralizedContractionShell(
@@ -64,7 +60,7 @@ def test_compute_one_elec_int_v_recursion():
     exps_b = contr_two.exps
     coeffs_b = contr_two.coeffs
     answer = _compute_one_elec_integrals(
-        np.array([0.0, 0.0, 0.0]),  # coord_point
+        np.array([0.0, 0.0, 0.0]).reshape(1, 3),  # coord_point
         boys_func,
         coord_a,
         angmom_a,
@@ -76,32 +72,28 @@ def test_compute_one_elec_int_v_recursion():
         coeffs_b,
     )
     # Test V(0)(000|000) using hand-calculated values
-    assert np.allclose(15.454923601063644, answer[0, 0, 0, 0, 0, 0])
+    assert np.allclose(0.12077036178347592, answer[0, 0, 0, 0, 0, 0])
 
     # Test vertical recursion for one nonzero index
     # Base case for recursion
-    assert np.allclose(-1.1698638244929143, answer[1, 0, 0, 0, 0, 0])
+    assert np.allclose(-0.00869614017728084, answer[1, 0, 0, 0, 0, 0])
     # Recursion loop for all a
-    assert np.allclose(32.000027447778216, answer[2, 0, 0, 0, 0, 0])
-    assert np.allclose(-1.0616103065740603, answer[3, 0, 0, 0, 0, 0])
+    assert np.allclose(0.11662166020358243, answer[2, 0, 0, 0, 0, 0])
+    assert np.allclose(-0.0020384534940189078, answer[3, 0, 0, 0, 0, 0])
 
     # Test vertical recursion for two nonzero indices
     # Base case for recursion
-    assert np.allclose(-3.2916645250193146, answer[2, 1, 0, 0, 0, 0])
+    assert np.allclose(-0.011960055776784264, answer[2, 1, 0, 0, 0, 0])
     # Recursion loop for all a
-    assert np.allclose(88.24749934654083, answer[2, 2, 0, 0, 0, 0])
+    assert np.allclose(0.14385092207210784, answer[2, 2, 0, 0, 0, 0])
 
     # Test vertical recursion for three nonzero indices
     # Base case for recursion
-    assert np.allclose(2.9480682730654943, answer[2, 1, 1, 0, 0, 0])
+    assert np.allclose(0.010332151108923077, answer[2, 1, 1, 0, 0, 0])
     # Recursion loop for all a
-    assert np.allclose(-5.795589744177589, answer[2, 1, 2, 0, 0, 0])
+    assert np.allclose(-0.010379229289999358, answer[2, 1, 2, 0, 0, 0])
 
 
-# FIXME: test fails because reference/answer does not normalize contractions
-@pytest.mark.skip(
-    reason="The answer that were hand-computed were not using normalized contractions."
-)
 def test_compute_one_elec_int_s_type():
     """Test _one_elec_int._compute_one_electron_integrals for s-type primitives."""
     # GeneralizedContractionShell(angmom, coord, charge, coeffs, exps)
@@ -120,7 +112,7 @@ def test_compute_one_elec_int_s_type():
     exps_b = s_type_two.exps
     coeffs_b = s_type_two.coeffs
     s_test = _compute_one_elec_integrals(
-        np.array([0.0, 0.0, 0.0]),  # coord_point
+        np.array([0.0, 0.0, 0.0]).reshape(1, 3),  # coord_point
         boys_func,
         coord_a,
         angmom_a,
@@ -143,10 +135,24 @@ def test_compute_one_elec_int_s_type():
     y_pc = 14 / 12
     z_pc = 7 / 4
     coeff = 3.0
+    norm_1_a = (2 * exps_a / np.pi) ** (3 / 4) * (4 * exps_a) ** (angmom_a / 2)
+    norm_1_b = (2 * exps_b / np.pi) ** (3 / 4) * (4 * exps_b) ** (angmom_b / 2)
+    norm_coeff = coeff * norm_1_a * norm_1_b
+    # Norm_2 is always 1 and thus is omitted from calculations
 
-    v0 = np.exp(-17 / 240) * hyp1f1(1 / 2, 3 / 2, -701 / 1200)
-    v1 = np.exp(-17 / 240) * hyp1f1(1 + 1 / 2, 1 + 3 / 2, -701 / 1200) / (2 * 1 + 1)
-    v2 = np.exp(-17 / 240) * hyp1f1(2 + 1 / 2, 2 + 3 / 2, -701 / 1200) / (2 * 2 + 1)
+    v0 = (2 * np.pi / p) * np.exp(-17 / 240) * hyp1f1(1 / 2, 3 / 2, -701 / 1200)
+    v1 = (
+        (2 * np.pi / p)
+        * np.exp(-17 / 240)
+        * hyp1f1(1 + 1 / 2, 1 + 3 / 2, -701 / 1200)
+        / (2 * 1 + 1)
+    )
+    v2 = (
+        (2 * np.pi / p)
+        * np.exp(-17 / 240)
+        * hyp1f1(2 + 1 / 2, 2 + 3 / 2, -701 / 1200)
+        / (2 * 2 + 1)
+    )
 
     v_100 = x_pa * v0 - x_pc * v1
     v1_100 = x_pa * v1 - x_pc * v2
@@ -161,21 +167,17 @@ def test_compute_one_elec_int_s_type():
     v_110 = y_pa * v_100 - y_pc * v1_100
     v_101 = z_pa * v_100 - z_pc * v1_100
 
-    assert np.allclose(s_test[1, 0, 0, 1, 0, 0], coeff * v_200 + x_ab * coeff * v_100)
-    assert np.allclose(s_test[1, 0, 0, 0, 1, 0], coeff * v_110 + y_ab * coeff * v_100)
-    assert np.allclose(s_test[1, 0, 0, 0, 0, 1], coeff * v_101 + z_ab * coeff * v_100)
-    assert np.allclose(s_test[0, 1, 0, 1, 0, 0], coeff * v_110 + x_ab * coeff * v_010)
-    assert np.allclose(s_test[0, 1, 0, 0, 1, 0], coeff * v_020 + y_ab * coeff * v_010)
-    assert np.allclose(s_test[0, 1, 0, 0, 0, 1], coeff * v_011 + z_ab * coeff * v_010)
-    assert np.allclose(s_test[0, 0, 1, 1, 0, 0], coeff * v_101 + x_ab * coeff * v_001)
-    assert np.allclose(s_test[0, 0, 1, 0, 1, 0], coeff * v_011 + y_ab * coeff * v_001)
-    assert np.allclose(s_test[0, 0, 1, 0, 0, 1], coeff * v_002 + z_ab * coeff * v_001)
+    assert np.allclose(s_test[1, 0, 0, 1, 0, 0], norm_coeff * v_200 + x_ab * norm_coeff * v_100)
+    assert np.allclose(s_test[1, 0, 0, 0, 1, 0], norm_coeff * v_110 + y_ab * norm_coeff * v_100)
+    assert np.allclose(s_test[1, 0, 0, 0, 0, 1], norm_coeff * v_101 + z_ab * norm_coeff * v_100)
+    assert np.allclose(s_test[0, 1, 0, 1, 0, 0], norm_coeff * v_110 + x_ab * norm_coeff * v_010)
+    assert np.allclose(s_test[0, 1, 0, 0, 1, 0], norm_coeff * v_020 + y_ab * norm_coeff * v_010)
+    assert np.allclose(s_test[0, 1, 0, 0, 0, 1], norm_coeff * v_011 + z_ab * norm_coeff * v_010)
+    assert np.allclose(s_test[0, 0, 1, 1, 0, 0], norm_coeff * v_101 + x_ab * norm_coeff * v_001)
+    assert np.allclose(s_test[0, 0, 1, 0, 1, 0], norm_coeff * v_011 + y_ab * norm_coeff * v_001)
+    assert np.allclose(s_test[0, 0, 1, 0, 0, 1], norm_coeff * v_002 + z_ab * norm_coeff * v_001)
 
 
-# FIXME: test fails because reference/answer does not normalize contractions
-@pytest.mark.skip(
-    reason="The answer that were hand-computed were not using normalized contractions."
-)
 def test_compute_one_elec_int_multiple_contractions():
     """Test _one_elec_int._compute_one_electron_integrals for s-type contractions."""
     # GeneralizedContractionShell(angmom, coord, charge, coeffs, exps)
@@ -194,7 +196,7 @@ def test_compute_one_elec_int_multiple_contractions():
     exps_b = contr_two.exps
     coeffs_b = contr_two.coeffs
     answer = _compute_one_elec_integrals(
-        np.array([0.0, 0.0, 0.0]),  # coord_point
+        np.array([0.0, 0.0, 0.0]).reshape(1, 3),  # coord_point
         boys_func,
         coord_a,
         angmom_a,
@@ -206,15 +208,15 @@ def test_compute_one_elec_int_multiple_contractions():
         coeffs_b,
     )
     # Test output array using hand-calculated values
-    assert np.allclose(answer[1, 0, 0, 1, 0, 0], 33.16989127227113)
-    assert np.allclose(answer[1, 0, 0, 0, 1, 0], 2.131647187292573)
-    assert np.allclose(answer[1, 0, 0, 0, 0, 1], 3.1974707809388594)
-    assert np.allclose(answer[0, 1, 0, 1, 0, 0], 4.1837386542199715)
-    assert np.allclose(answer[0, 1, 0, 0, 1, 0], 36.74056538017357)
-    assert np.allclose(answer[0, 1, 0, 0, 0, 1], 7.831446742304523)
-    assert np.allclose(answer[0, 0, 1, 1, 0, 0], 6.275607981329958)
-    assert np.allclose(answer[0, 0, 1, 0, 1, 0], 7.831446742304523)
-    assert np.allclose(answer[0, 0, 1, 0, 0, 1], 43.26677099876067)
+    assert np.allclose(answer[1, 0, 0, 1, 0, 0], 1.1725677458858423)
+    assert np.allclose(answer[1, 0, 0, 0, 1, 0], 0.07610607398731435)
+    assert np.allclose(answer[1, 0, 0, 0, 0, 1], 0.11415911098097152)
+    assert np.allclose(answer[0, 1, 0, 1, 0, 0], 0.1525693722167499)
+    assert np.allclose(answer[0, 1, 0, 0, 1, 0], 1.3047296607539662)
+    assert np.allclose(answer[0, 1, 0, 0, 0, 1], 0.2860362946729374)
+    assert np.allclose(answer[0, 0, 1, 1, 0, 0], 0.22885405832512482)
+    assert np.allclose(answer[0, 0, 1, 0, 1, 0], 0.28603629467293734)
+    assert np.allclose(answer[0, 0, 1, 0, 0, 1], 1.5430932396480808)
 
 
 # FIXME: test fails because reference/answer does not normalize contractions


### PR DESCRIPTION
Tests were failing because normalization constants were not used.