### PR TITLE
Reformat docstrings for Napoleon compliance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ venv.bak/
 *.out
 *.synctex.gz
 *.toc
+
+# PyCharm
+.idea/

--- a/gbasis/base.py
+++ b/gbasis/base.py
@@ -11,7 +11,7 @@ class BaseGaussianRelatedArray(abc.ABC):
     ----------
     _axes_contractions : tuple of tuple of GeneralizedContractionShell
         Contractions that are associated with each index of the array.
-        Each tuple of GeneralizedContractionShell corresponds to an index of the array.
+        Each tuple of `GeneralizedContractionShell` corresponds to an index of the array.
 
     Methods
     -------
@@ -41,7 +41,7 @@ class BaseGaussianRelatedArray(abc.ABC):
         Raises
         ------
         TypeError
-            If `axes_contractions` is not given as a list or tuple of GeneralizedContractionShell.
+            If `axes_contractions` is not given as a list or tuple of `GeneralizedContractionShell`.
         ValueError
             If `axes_contractions` is an empty list or tuple.
 
@@ -49,15 +49,15 @@ class BaseGaussianRelatedArray(abc.ABC):
         for each_contractions in contractions:
             if not isinstance(each_contractions, (list, tuple)):
                 raise TypeError(
-                    "Contractions must be given as a list or tuple of GeneralizedContractionShell "
-                    "instance"
+                    "Contractions must be given as a list or tuple of `GeneralizedContractionShell`"
+                    " instance"
                 )
             if not each_contractions:
                 raise ValueError("At least one `GeneralizedContractionShell` must be given.")
             for contraction in each_contractions:
                 if not isinstance(contraction, GeneralizedContractionShell):
                     raise TypeError(
-                        "Given contractions must be instances of the GeneralizedContractionShell "
+                        "Given contractions must be instances of the `GeneralizedContractionShell` "
                         "class."
                     )
         self._axes_contractions = tuple(
@@ -80,12 +80,12 @@ class BaseGaussianRelatedArray(abc.ABC):
         Returns
         -------
         array_contraction : np.ndarray
-            Array associated with the given instance(s) of GeneralizedContractionShell.
+            Array associated with the given instance(s) of `GeneralizedContractionShell`.
 
         Notes
         -----
         The next level of classes will be divided by number of indices associated with
-        GeneralizedContractionShell. Then this method's parameters will likely be different from
+        `GeneralizedContractionShell`. Then this method's parameters will likely be different from
         it's children. This means that using this method's API blindly (by simply copying and
         pasting) will not be suitable for all its children. Here, we allow arbitrary number of
         `contractions` to indicate that its children may have different number of `contractions` in
@@ -129,12 +129,12 @@ class BaseGaussianRelatedArray(abc.ABC):
 
     @abc.abstractmethod
     def construct_array_mix(self, coord_types, **kwargs):
-        """Return the array associated with set of Gaussians of the given coordinate systems.
+        """Return the array associated with a set of Gaussians of the given coordinate systems.
 
         Parameters
         ----------
         coord_types : list/tuple of str
-            Types of the coordinate system for each GeneralizedContractionShell.
+            Types of the coordinate system for each `GeneralizedContractionShell`.
             Each entry must be one of "cartesian" or "spherical".
         kwargs : dict
             Other keyword arguments that will be used to construct the array.
@@ -162,7 +162,7 @@ class BaseGaussianRelatedArray(abc.ABC):
             If "cartesian", then all of the contractions are treated as Cartesian contractions.
             If "spherical", then all of the contractions are treated as spherical contractions.
             If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-            coordinate type of each GeneralizedContractionShell instance.
+            coordinate type of each `GeneralizedContractionShell` instance.
         kwargs : dict
             Other keyword arguments that will be used to construct the array.
 
@@ -175,7 +175,7 @@ class BaseGaussianRelatedArray(abc.ABC):
         Notes
         -----
         The next level of classes will be divided by number of indices associated with
-        GeneralizedContractionShell. Then this method's parameters will likely be different from
+        `GeneralizedContractionShell`. Then this method's parameters will likely be different from
         it's children. This means that using this method's API blindly (by simply copying and
         pasting) will not be suitable for all its children. Here, we allow arbitrary number of
         `transform` to indicate that its children may have different number of `transform` in

--- a/gbasis/base_four_symm.py
+++ b/gbasis/base_four_symm.py
@@ -29,38 +29,38 @@ class BaseFourIndexSymmetric(BaseGaussianRelatedArray):
     construct_array_contraction(self, cont1, cont2, cont3, cont4, **kwargs) :
     np.ndarray(M_1, L_cart_1, M_2, L_cart_2, M_3, L_cart_3, M_4, L_cart_4, ...)
         Return the array associated with a `GeneralizedContractionShell` instances.
-        :math:`M_1` is the number of segmented contractions with the same exponents (and angular
+        `M_1` is the number of segmented contractions with the same exponents (and angular
         momentum) associated with the first index.
-        :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
+        `L_cart_1` is the number of Cartesian contractions for the given angular momentum
         associated with the first index.
-        :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+        `M_2` is the number of segmented contractions with the same exponents (and angular
         momentum) associated with the second index.
-        :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
+        `L_cart_2` is the number of Cartesian contractions for the given angular momentum
         associated with the second index.
-        :math:`M_3` is the number of segmented contractions with the same exponents (and angular
+        `M_3` is the number of segmented contractions with the same exponents (and angular
         momentum) associated with the third index.
-        :math:`L_cart_3` is the number of Cartesian contractions for the given angular momentum
+        `L_cart_3` is the number of Cartesian contractions for the given angular momentum
         associated with the third index.
-        :math:`M_4` is the number of segmented contractions with the same exponents (and angular
+        `M_4` is the number of segmented contractions with the same exponents (and angular
         momentum) associated with the fourth index.
-        :math:`L_cart_4` is the number of Cartesian contractions for the given angular momentum
+        `L_cart_4` is the number of Cartesian contractions for the given angular momentum
         associated with the fourth index.
     construct_array_cartesian(self, **kwargs) : np.ndarray(K_cart, K_cart, K_cart, K_cart, ...)
         Return the array associated with Cartesian Gaussians.
-        :math:`K_cart` is the total number of Cartesian contractions within the instance.
+        `K_cart` is the total number of Cartesian contractions within the instance.
     construct_array_spherical(self, **kwargs) : np.ndarray(K_sph, K_sph, K_sph, K_sph, ...)
         Return the array associated with spherical Gaussians (atomic orbitals).
-        :math:`K_sph` is the total number of spherical contractions within the instance.
+        `K_sph` is the total number of spherical contractions within the instance.
     construct_array_mix(self, coord_types, **kwargs) :
     np.ndarray(K_cont, K_cont, K_cont, K_cont, ...)
         Return the array associated with all of the contraction in the given coordinate
         system.
-        :math:`K_cont` is the total number of contractions within the given basis set.
+        `K_cont` is the total number of contractions within the given basis set.
     construct_array_lincomb(self, transform, coord_type) :
     np.ndarray(K_orbs, K_orbs, K_orbs, K_orbs, ...)
         Return the array associated with linear combinations of contractions in the given coordinate
         system.
-        :math:`K_orbs` is the number of basis functions produced after the linear combinations.
+        `K_orbs` is the number of basis functions produced after the linear combinations.
 
     """
 
@@ -109,29 +109,29 @@ class BaseFourIndexSymmetric(BaseGaussianRelatedArray):
         -------
         array_cont : np.ndarray(M_1, L_cart_1, M_2, L_cart_2, M_3, L_cart_3, M_4, L_cart_4, ...)
             Return the array associated with a `GeneralizedContractionShell` instances.
-            Dimension 0 corresponds to the segmented contraction within `cont_one`. :math:`M_1` is
+            Dimension 0 corresponds to the segmented contraction within `cont_one`. `M_1` is
             the number of segmented contractions with the same exponents (and angular momentum)
             associated with the first index.
             Dimension 1 corresponds to the angular momentum vector of the `cont_one`.
-            :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
+            `L_cart_1` is the number of Cartesian contractions for the given angular momentum
             associated with the first index.
             Dimension 2 corresponds to the segmented contraction within `cont_two`.
-            :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+            `M_2` is the number of segmented contractions with the same exponents (and angular
             momentum) associated with the second index.
             Dimension 3 corresponds to the angular momentum vector of the `cont_two`.
-            :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
+            `L_cart_2` is the number of Cartesian contractions for the given angular momentum
             associated with the second index.
             Dimension 4 corresponds to the segmented contraction within `cont_three`.
-            :math:`M_3` is the number of segmented contractions with the same exponents (and angular
+            `M_3` is the number of segmented contractions with the same exponents (and angular
             momentum) associated with the third index.
             Dimension 5 corresponds to the angular momentum vector of the `cont_three`.
-            :math:`L_cart_3` is the number of Cartesian contractions for the given angular momentum
+            `L_cart_3` is the number of Cartesian contractions for the given angular momentum
             associated with the third index.
             Dimension 6 corresponds to the segmented contraction within `cont_four`.
-            :math:`M_4` is the number of segmented contractions with the same exponents (and angular
+            `M_4` is the number of segmented contractions with the same exponents (and angular
             momentum) associated with the fourth index.
             Dimension 7 corresponds to the angular momentum vector of the `cont_four`.
-            :math:`L_cart_4` is the number of Cartesian contractions for the given angular momentum
+            `L_cart_4` is the number of Cartesian contractions for the given angular momentum
             associated with the fourth index.
 
         Notes
@@ -150,7 +150,7 @@ class BaseFourIndexSymmetric(BaseGaussianRelatedArray):
         if the shape of the output is different.
         Even if all of `cont1`, `cont2`, `cont3`, and `cont4` are segmented contractions,
         dimensions 0, 2, 4, and 6 must correspond to the contraction. In other words, the shape must
-        still be :math:`(1, L_1, 1, L_2, 1, L_3, 1, L_4)`.
+        still be (1, L_1, 1, L_2, 1, L_3, 1, L_4).
 
         """
 
@@ -169,7 +169,7 @@ class BaseFourIndexSymmetric(BaseGaussianRelatedArray):
         array : np.ndarray(K_cart, K_cart, K_cart, K_cart, ...)
             Array associated with the given set of contracted Cartesian Gaussians.
             Dimensions 0, 1, 2, and 3 of the array are associated with the contracted Cartesian
-            Gaussians. :math:`K_cart` is the total number of Cartesian contractions within the
+            Gaussians. `K_cart` is the total number of Cartesian contractions within the
             instance.
 
         Notes
@@ -256,7 +256,7 @@ class BaseFourIndexSymmetric(BaseGaussianRelatedArray):
             Array associated with the atomic orbitals associated with the given set(s) of contracted
             Cartesian Gaussians.
             Dimensions 0, 1, 2 and 3 of the array are associated with four contracted spherical
-            Gaussians (atomic orbitals). :math:`K_sph` is the total number of spherical contractions
+            Gaussians (atomic orbitals). `K_sph` is the total number of spherical contractions
             within the instance.
 
         Notes
@@ -402,7 +402,7 @@ class BaseFourIndexSymmetric(BaseGaussianRelatedArray):
             Array associated with the atomic orbitals associated with the given set of contracted
             Cartesian Gaussians.
             Dimensions 0, 1, 2 and 3 of the array are associated with two contractions in the given
-            coordinate system. :math:`K_cont` is the total number of contractions within the
+            coordinate system. `K_cont` is the total number of contractions within the
             instance.
 
         Raises
@@ -585,7 +585,7 @@ class BaseFourIndexSymmetric(BaseGaussianRelatedArray):
             Array whose first four indices are associated with the linear combinations of the
             contractions.
             Dimensions 0, 1, 2 and 3 of the array correspond to the linear combination of contracted
-            spherical Gaussians. :math:`K_orbs` is the number of basis functions produced after the
+            spherical Gaussians. `K_orbs` is the number of basis functions produced after the
             linear combinations.
 
         Raises

--- a/gbasis/base_four_symm.py
+++ b/gbasis/base_four_symm.py
@@ -190,15 +190,15 @@ class BaseFourIndexSymmetric(BaseGaussianRelatedArray):
                     cont_one, cont_two, cont_three, cont_four, **kwargs
                 )
                 # normalize contractions
-                block *= cont_one.norm_cont.reshape(*block.shape[:2], *[1 for i in block.shape[2:]])
+                block *= cont_one.norm_cont.reshape(*block.shape[:2], *[1 for _ in block.shape[2:]])
                 block *= cont_two.norm_cont.reshape(
-                    1, 1, *block.shape[2:4], *[1 for i in block.shape[4:]]
+                    1, 1, *block.shape[2:4], *[1 for _ in block.shape[4:]]
                 )
                 block *= cont_three.norm_cont.reshape(
-                    1, 1, 1, 1, *block.shape[4:6], *[1 for i in block.shape[6:]]
+                    1, 1, 1, 1, *block.shape[4:6], *[1 for _ in block.shape[6:]]
                 )
                 block *= cont_four.norm_cont.reshape(
-                    1, 1, 1, 1, 1, 1, *block.shape[6:8], *[1 for i in block.shape[8:]]
+                    1, 1, 1, 1, 1, 1, *block.shape[6:8], *[1 for _ in block.shape[8:]]
                 )
                 # assume array always has shape (M_1, L_1, M_2, L_2, M_3, L_3, M_4, L_4, ..)
                 block = block.reshape(
@@ -304,15 +304,15 @@ class BaseFourIndexSymmetric(BaseGaussianRelatedArray):
                     cont_one, cont_two, cont_three, cont_four, **kwargs
                 )
                 # normalize contractions
-                block *= cont_one.norm_cont.reshape(*block.shape[:2], *[1 for i in block.shape[2:]])
+                block *= cont_one.norm_cont.reshape(*block.shape[:2], *[1 for _ in block.shape[2:]])
                 block *= cont_two.norm_cont.reshape(
-                    1, 1, *block.shape[2:4], *[1 for i in block.shape[4:]]
+                    1, 1, *block.shape[2:4], *[1 for _ in block.shape[4:]]
                 )
                 block *= cont_three.norm_cont.reshape(
-                    1, 1, 1, 1, *block.shape[4:6], *[1 for i in block.shape[6:]]
+                    1, 1, 1, 1, *block.shape[4:6], *[1 for _ in block.shape[6:]]
                 )
                 block *= cont_four.norm_cont.reshape(
-                    1, 1, 1, 1, 1, 1, *block.shape[6:8], *[1 for i in block.shape[8:]]
+                    1, 1, 1, 1, 1, 1, *block.shape[6:8], *[1 for _ in block.shape[8:]]
                 )
 
                 # transform
@@ -465,15 +465,15 @@ class BaseFourIndexSymmetric(BaseGaussianRelatedArray):
                     cont_one, cont_two, cont_three, cont_four, **kwargs
                 )
                 # normalize contractions
-                block *= cont_one.norm_cont.reshape(*block.shape[:2], *[1 for i in block.shape[2:]])
+                block *= cont_one.norm_cont.reshape(*block.shape[:2], *[1 for _ in block.shape[2:]])
                 block *= cont_two.norm_cont.reshape(
-                    1, 1, *block.shape[2:4], *[1 for i in block.shape[4:]]
+                    1, 1, *block.shape[2:4], *[1 for _ in block.shape[4:]]
                 )
                 block *= cont_three.norm_cont.reshape(
-                    1, 1, 1, 1, *block.shape[4:6], *[1 for i in block.shape[6:]]
+                    1, 1, 1, 1, *block.shape[4:6], *[1 for _ in block.shape[6:]]
                 )
                 block *= cont_four.norm_cont.reshape(
-                    1, 1, 1, 1, 1, 1, *block.shape[6:8], *[1 for i in block.shape[8:]]
+                    1, 1, 1, 1, 1, 1, *block.shape[6:8], *[1 for _ in block.shape[8:]]
                 )
 
                 # transform

--- a/gbasis/base_four_symm.py
+++ b/gbasis/base_four_symm.py
@@ -11,18 +11,16 @@ import numpy as np
 class BaseFourIndexSymmetric(BaseGaussianRelatedArray):
     """Base class for constructing arrays associated with four contracted Gaussian.
 
-    The first four axes of the returned array is associated with the given set of contracted
+    The first four axes of the returned array are associated with the given set of contracted
     Gaussian (or a linear combination of a set of Gaussians).
 
     Attributes
     ----------
     _axes_contractions : tuple of tuple of GeneralizedContractionShell
         Sets of contractions associated with each axis of the array.
-
-    Properties
-    ----------
     contractions : tuple of GeneralizedContractionShell
-        Contractions that are associated with the first and second indices of the array.
+        Contractions that are associated with the first four indices of the array.
+        Property of `BaseFourIndexSymmetric`.
 
     Methods
     -------
@@ -31,38 +29,38 @@ class BaseFourIndexSymmetric(BaseGaussianRelatedArray):
     construct_array_contraction(self, cont1, cont2, cont3, cont4, **kwargs) :
     np.ndarray(M_1, L_cart_1, M_2, L_cart_2, M_3, L_cart_3, M_4, L_cart_4, ...)
         Return the array associated with a `GeneralizedContractionShell` instances.
-        `M_1` is the number of segmented contractions with the same exponents (and angular momentum)
+        :math:`M_1` is the number of segmented contractions with the same exponents (and angular
+        momentum) associated with the first index.
+        :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
         associated with the first index.
-        `L_cart_1` is the number of Cartesian contractions for the given angular momentum associated
-        with the first index.
-        `M_2` is the number of segmented contractions with the same exponents (and angular momentum)
+        :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+        momentum) associated with the second index.
+        :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
         associated with the second index.
-        `L_cart_2` is the number of Cartesian contractions for the given angular momentum associated
-        with the second index.
-        `M_3` is the number of segmented contractions with the same exponents (and angular momentum)
+        :math:`M_3` is the number of segmented contractions with the same exponents (and angular
+        momentum) associated with the third index.
+        :math:`L_cart_3` is the number of Cartesian contractions for the given angular momentum
         associated with the third index.
-        `L_cart_3` is the number of Cartesian contractions for the given angular momentum associated
-        with the third index.
-        `M_4` is the number of segmented contractions with the same exponents (and angular momentum)
+        :math:`M_4` is the number of segmented contractions with the same exponents (and angular
+        momentum) associated with the fourth index.
+        :math:`L_cart_4` is the number of Cartesian contractions for the given angular momentum
         associated with the fourth index.
-        `L_cart_4` is the number of Cartesian contractions for the given angular momentum associated
-        with the fourth index.
     construct_array_cartesian(self, **kwargs) : np.ndarray(K_cart, K_cart, K_cart, K_cart, ...)
         Return the array associated with Cartesian Gaussians.
-        `K_cart` is the total number of Cartesian contractions within the instance.
+        :math:`K_cart` is the total number of Cartesian contractions within the instance.
     construct_array_spherical(self, **kwargs) : np.ndarray(K_sph, K_sph, K_sph, K_sph, ...)
         Return the array associated with spherical Gaussians (atomic orbitals).
-        `K_sph` is the total number of spherical contractions within the instance.
+        :math:`K_sph` is the total number of spherical contractions within the instance.
     construct_array_mix(self, coord_types, **kwargs) :
     np.ndarray(K_cont, K_cont, K_cont, K_cont, ...)
         Return the array associated with all of the contraction in the given coordinate
         system.
-        `K_cont` is the total number of contractions within the given basis set.
+        :math:`K_cont` is the total number of contractions within the given basis set.
     construct_array_lincomb(self, transform, coord_type) :
     np.ndarray(K_orbs, K_orbs, K_orbs, K_orbs, ...)
         Return the array associated with linear combinations of contractions in the given coordinate
         system.
-        `K_orbs` is the number of basis functions produced after the linear combinations.
+        :math:`K_orbs` is the number of basis functions produced after the linear combinations.
 
     """
 
@@ -72,19 +70,20 @@ class BaseFourIndexSymmetric(BaseGaussianRelatedArray):
         Parameters
         ----------
         contractions : list/tuple of GeneralizedContractionShell
-            Contractions that are associated with the first and second indices of the array.
+            Contractions that are associated with the first four indices of the array.
 
         """
         super().__init__(contractions)
 
     @property
     def contractions(self):
-        """Contractions that are associated with the first index of the array.
+        """Contractions that are associated with the first four indices of the array.
 
         Returns
         -------
         contractions : tuple of GeneralizedContractionShell
-            Generalized contraction shell that is associated with the all indices of the array.
+            Generalized contraction shell that is associated with the first four indices of the
+            array.
 
         """
         return self._axes_contractions[0]
@@ -110,30 +109,30 @@ class BaseFourIndexSymmetric(BaseGaussianRelatedArray):
         -------
         array_cont : np.ndarray(M_1, L_cart_1, M_2, L_cart_2, M_3, L_cart_3, M_4, L_cart_4, ...)
             Return the array associated with a `GeneralizedContractionShell` instances.
-            First axis corresponds to the segmented contraction within `cont1`. `M_1` is the number
-            of segmented contractions with the same exponents (and angular momentum) associated with
-            the first index.
-            Second axis corresponds to the angular momentum vector of the `cont1`.`L_cart_1` is the
-            number of Cartesian contractions for the given angular momentum associated with the
-            first index.
-            Third axis corresponds to the segmented contraction within `cont2`. `M_2` is the number
-            of segmented contractions with the same exponents (and angular momentum) associated with
-            the second index.
-            Fourth axis corresponds to the angular momentum vector of the `cont2`.`L_cart_2` is the
-            number of Cartesian contractions for the given angular momentum associated with the
-            second index.
-            Fifth axis corresponds to the segmented contraction within `cont3`. `M_3` is the number
-            of segmented contractions with the same exponents (and angular momentum) associated with
-            the third index.
-            Sixth axis corresponds to the angular momentum vector of the `cont3`.`L_cart_3` is the
-            number of Cartesian contractions for the given angular momentum associated with the
-            third index.
-            Seventh axis corresponds to the segmented contraction within `cont4`. `M_4` is the
-            number of segmented contractions with the same exponents (and angular momentum)
+            Dimension 0 corresponds to the segmented contraction within `cont_one`. :math:`M_1` is
+            the number of segmented contractions with the same exponents (and angular momentum)
+            associated with the first index.
+            Dimension 1 corresponds to the angular momentum vector of the `cont_one`.
+            :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
+            associated with the first index.
+            Dimension 2 corresponds to the segmented contraction within `cont_two`.
+            :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+            momentum) associated with the second index.
+            Dimension 3 corresponds to the angular momentum vector of the `cont_two`.
+            :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
+            associated with the second index.
+            Dimension 4 corresponds to the segmented contraction within `cont_three`.
+            :math:`M_3` is the number of segmented contractions with the same exponents (and angular
+            momentum) associated with the third index.
+            Dimension 5 corresponds to the angular momentum vector of the `cont_three`.
+            :math:`L_cart_3` is the number of Cartesian contractions for the given angular momentum
+            associated with the third index.
+            Dimension 6 corresponds to the segmented contraction within `cont_four`.
+            :math:`M_4` is the number of segmented contractions with the same exponents (and angular
+            momentum) associated with the fourth index.
+            Dimension 7 corresponds to the angular momentum vector of the `cont_four`.
+            :math:`L_cart_4` is the number of Cartesian contractions for the given angular momentum
             associated with the fourth index.
-            Eighth axis corresponds to the angular momentum vector of the `cont4`.`L_cart_4` is the
-            number of Cartesian contractions for the given angular momentum associated with the
-            fourth index.
 
         Notes
         -----
@@ -143,14 +142,15 @@ class BaseFourIndexSymmetric(BaseGaussianRelatedArray):
         than the arbitrary number of keywords (as is done here).
 
         The methods `construct_array_cartesian`, `construct_array_spherical`, and
-        `construct_array_lincomb` depend on this function to produce an array whose first
-        and second indices correspond to the contraction (within a generalized contraction) and
-        the angular momentum vector of `contractions_one`, and third and fourth indices correspond
-        to the contraction (within a generalized contraction) and the angular momentum vector of
-        `contractions_two`,. These other methods **will** fail with little warning if the shape of
-        the output is different. Even if all of `cont1`, `cont2`, `cont3`, and `cont4` are
-        segmented contractions, the first, third, fifth, and seventh indices must correspond to the
-        contraction. In other words, the shape must still be (1, L_1, 1, L_2, 1, L_3, 1, L_4).
+        `construct_array_lincomb` depend on this function to produce an array with dimensions 0, 1
+        corresponding to the contraction (within a generalized contraction) and angular momentum
+        vector of `cont_one`, dimensions 2, 3 corresponding to the contraction
+        (within a generalized contraction) and angular momentum vector of `cont_two`, and so
+        on for `cont_three` and `cont_four`. These other methods **will** fail with little warning
+        if the shape of the output is different.
+        Even if all of `cont1`, `cont2`, `cont3`, and `cont4` are segmented contractions,
+        dimensions 0, 2, 4, and 6 must correspond to the contraction. In other words, the shape must
+        still be :math:`(1, L_1, 1, L_2, 1, L_3, 1, L_4)`.
 
         """
 
@@ -168,15 +168,16 @@ class BaseFourIndexSymmetric(BaseGaussianRelatedArray):
         -------
         array : np.ndarray(K_cart, K_cart, K_cart, K_cart, ...)
             Array associated with the given set of contracted Cartesian Gaussians.
-            First and second indices of the array are associated with the contracted Cartesian
-            Gaussians. `K_cart` is the total number of Cartesian contractions within the instance.
+            Dimensions 0, 1, 2, and 3 of the array are associated with the contracted Cartesian
+            Gaussians. :math:`K_cart` is the total number of Cartesian contractions within the
+            instance.
 
         Notes
         -----
         The blocks along the diagonal, i.e. blocks where the first two axes belong to the same
         set of contractions, are transposed in the process of constructing the whole array.
         It is assumed that the array returned from `construct_array_contraction` is symmetric with
-        respect to the swapping of the first and second axes.
+        respect to the swapping of the axes 0 and 1.
 
         """
         # pylint: disable=C0103,R0914
@@ -240,7 +241,7 @@ class BaseFourIndexSymmetric(BaseGaussianRelatedArray):
         )
 
     def construct_array_spherical(self, **kwargs):
-        """Return the array associated with two contracted spherical Gaussians (atomic orbitals).
+        """Return the array associated with four contracted spherical Gaussians (atomic orbitals).
 
         Parameters
         ----------
@@ -251,11 +252,11 @@ class BaseFourIndexSymmetric(BaseGaussianRelatedArray):
 
         Returns
         -------
-        array : np.ndarray(K_sph, K_sph, ...)
+        array : np.ndarray(K_sph, K_sph, K_sph, K_sph, ...)
             Array associated with the atomic orbitals associated with the given set(s) of contracted
             Cartesian Gaussians.
-            First and second indices of the array are associated with two contracted spherical
-            Gaussians (atomic orbitals). `K_sph` is the total number of spherical contractions
+            Dimensions 0, 1, 2 and 3 of the array are associated with four contracted spherical
+            Gaussians (atomic orbitals). :math:`K_sph` is the total number of spherical contractions
             within the instance.
 
         Notes
@@ -263,7 +264,7 @@ class BaseFourIndexSymmetric(BaseGaussianRelatedArray):
         The blocks along the diagonal, i.e. blocks where the first two axes belong to the same
         set of contractions, are transposed in the process of constructing the whole array.
         It is assumed that the array returned from `construct_array_contraction` is symmetric with
-        respect to the swapping of the first and second axes.
+        respect to the swapping of the axes 0 and 1.
 
         """
         # pylint: disable=C0103,R0914
@@ -385,23 +386,24 @@ class BaseFourIndexSymmetric(BaseGaussianRelatedArray):
         )
 
     def construct_array_mix(self, coord_types, **kwargs):
-        """Return the array associated with set of Gaussians of the given coordinate systems.
+        """Return the array associated with a set of Gaussians of the given coordinate systems.
 
         Parameters
         ----------
         coord_types : list/tuple of str
-            Types of the coordinate system for each GeneralizedContractionShell.
+            Types of the coordinate system for each `GeneralizedContractionShell`.
             Each entry must be one of "cartesian" or "spherical".
         kwargs : dict
             Other keyword arguments that will be used to construct the array.
 
         Returns
         -------
-        array : np.ndarray(K_cont, K_cont, ...)
+        array : np.ndarray(K_cont, K_cont, K_cont, K_cont, ...)
             Array associated with the atomic orbitals associated with the given set of contracted
             Cartesian Gaussians.
-            First and second indices of the array are associated with two contractions in the given
-            coordinate system. `K_cont` is the total number of contractions within the instance.
+            Dimensions 0, 1, 2 and 3 of the array are associated with two contractions in the given
+            coordinate system. :math:`K_cont` is the total number of contractions within the
+            instance.
 
         Raises
         ------
@@ -410,7 +412,7 @@ class BaseFourIndexSymmetric(BaseGaussianRelatedArray):
         ValueError
             If `coord_types` has an entry that is not "cartesian" or "spherical".
             If `coord_types` has different number of entries as the number of
-            GeneralizedContractionShell (`contractions`) in instance.
+            `GeneralizedContractionShell` (`contractions`) in instance.
 
         """
         # pylint: disable=C0103,R0914
@@ -423,7 +425,7 @@ class BaseFourIndexSymmetric(BaseGaussianRelatedArray):
         if len(coord_types) != len(self.contractions):
             raise ValueError(
                 "`coord_types` must have the same number of entries as the number of "
-                "GeneralizedContractionShell in the instance."
+                "`GeneralizedContractionShell` in the instance."
             )
 
         all_blocks = np.zeros((len(self.contractions),) * 4, dtype=object)
@@ -563,14 +565,14 @@ class BaseFourIndexSymmetric(BaseGaussianRelatedArray):
             Transformation matrix from contractions in the given coordinate system (e.g. AO) to
             linear combinations of contractions (e.g. MO).
             Transformation is applied to the left.
-            Rows correspond to the linear combinationes (i.e. MO) and the columns correspond to the
+            Rows correspond to the linear combinations (i.e. MO) and the columns correspond to the
             contractions (i.e. AO).
         coord_type : {"cartesian", "spherical", list/tuple of "cartesian" or "spherical}
             Types of the coordinate system for the contractions.
             If "cartesian", then all of the contractions are treated as Cartesian contractions.
             If "spherical", then all of the contractions are treated as spherical contractions.
             If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-            coordinate type of each GeneralizedContractionShell instance.
+            coordinate type of each `GeneralizedContractionShell` instance.
         kwargs : dict
             Other keyword arguments that will be used to construct the array.
             These keyword arguments are passed directly to `construct_array_spherical`, which will
@@ -579,12 +581,12 @@ class BaseFourIndexSymmetric(BaseGaussianRelatedArray):
 
         Returns
         -------
-        array : np.ndarray(K_orbs, K_orbs, ...)
-            Array whose first and second indices are associated with the linear combinations of the
+        array : np.ndarray(K_orbs, K_orbs, K_orbs, K_orbs, ...)
+            Array whose first four indices are associated with the linear combinations of the
             contractions.
-            First and second indices of the array correspond to the linear combination of contracted
-            spherical Gaussians. `K_orbs` is the number of basis functions produced after the linear
-            combinations.
+            Dimensions 0, 1, 2 and 3 of the array correspond to the linear combination of contracted
+            spherical Gaussians. :math:`K_orbs` is the number of basis functions produced after the
+            linear combinations.
 
         Raises
         ------

--- a/gbasis/base_one.py
+++ b/gbasis/base_one.py
@@ -131,7 +131,7 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         for contraction in self.contractions:
             array = self.construct_array_contraction(contraction, **kwargs)
             # normalize contractions
-            array *= contraction.norm_cont.reshape(*array.shape[:2], *[1 for i in array.shape[2:]])
+            array *= contraction.norm_cont.reshape(*array.shape[:2], *[1 for _ in array.shape[2:]])
             # ASSUME array always has shape (M, L, ...)
             matrices.append(np.concatenate(array, axis=0))
         return np.concatenate(matrices, axis=0)
@@ -165,7 +165,7 @@ class BaseOneIndex(BaseGaussianRelatedArray):
             matrix_contraction = self.construct_array_contraction(cont, **kwargs)
             # normalize contractions
             matrix_contraction *= cont.norm_cont.reshape(
-                *matrix_contraction.shape[:2], *[1 for i in matrix_contraction.shape[2:]]
+                *matrix_contraction.shape[:2], *[1 for _ in matrix_contraction.shape[2:]]
             )
             # transform
             # ASSUME array always has shape (M, L, ...)
@@ -228,7 +228,7 @@ class BaseOneIndex(BaseGaussianRelatedArray):
             matrix_contraction = self.construct_array_contraction(cont, **kwargs)
             # normalize contractions
             matrix_contraction *= cont.norm_cont.reshape(
-                *matrix_contraction.shape[:2], *[1 for i in matrix_contraction.shape[2:]]
+                *matrix_contraction.shape[:2], *[1 for _ in matrix_contraction.shape[2:]]
             )
             # transform
             # ASSUME array always has shape (M, L, ...)

--- a/gbasis/base_one.py
+++ b/gbasis/base_one.py
@@ -248,7 +248,6 @@ class BaseOneIndex(BaseGaussianRelatedArray):
 
             \sum_{j} T_{i j} M_{jklm...} = M^{trans}_{iklm...}
 
-
         Parameters
         ----------
         transform : np.ndarray(K_orbs, K_cont)

--- a/gbasis/base_one.py
+++ b/gbasis/base_one.py
@@ -17,12 +17,10 @@ class BaseOneIndex(BaseGaussianRelatedArray):
     ----------
     _axes_contractions : tuple of tuple of GeneralizedContractionShell
         Contractions that are associated with each index of the array.
-        Each tuple of GeneralizedContractionShell corresponds to an index of the array.
-
-    Properties
-    ----------
+        Each tuple of `GeneralizedContractionShell` corresponds to an index of the array.
     contractions : tuple of GeneralizedContractionShell
         Contractions that are associated with the first index of the array.
+        Property of `BaseOneIndex`.
 
     Methods
     -------
@@ -30,21 +28,22 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         Initialize.
     construct_array_contraction(self, contraction) : np.ndarray(M, L_cart, ...)
         Return the array associated with a `GeneralizedContractionShell` instance.
-        `M` is the number of segmented contractions with the same exponents (and angular momentum).
-        `L_cart` is the number of Cartesian contractions for the given angular momentum.
+        :math:`M` is the number of segmented contractions with the same exponents (and angular
+        momentum).
+        :math:`L_cart` is the number of Cartesian contractions for the given angular momentum.
     construct_array_cartesian(self) : np.ndarray(K_cart, ...)
         Return the array associated with Cartesian Gaussians.
-        `K_cart` is the total number of Cartesian contractions within the instance.
+        :math:`K_cart` is the total number of Cartesian contractions within the instance.
     construct_array_spherical(self) : np.ndarray(K_sph, ...)
         Return the array associated with spherical Gaussians (atomic orbitals).
-        `K_sph` is the total number of spherical contractions within the instance.
+        :math:`K_sph` is the total number of spherical contractions within the instance.
     construct_array_mix(self, coord_types, **kwargs) : np.ndarray(K_cont, ...)
         Return the array associated with all of the contraction in the given coordinate system.
-        `K_cont` is the total number of contractions within the given basis set.
+        :math:`K_cont` is the total number of contractions within the given basis set.
     construct_array_lincomb(self, transform, coord_type) : np.ndarray(K_orbs, ...)
         Return the array associated with linear combinations of contractions in the given coordinate
         system.
-        `K_orbs` is the number of basis functions produced after the linear combinations.
+        :math:`K_orbs` is the number of basis functions produced after the linear combinations.
 
     """
 
@@ -86,11 +85,11 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         Returns
         -------
         array_contraction : np.ndarray(M, L_cart, ...)
-            Array associated with the given instance(s) of GeneralizedContractionShell.
-            First index corresponds to segmented contractions within the given generalized
+            Array associated with the given instance(s) of `GeneralizedContractionShell`.
+            Dimension 0 corresponds to segmented contractions within the given generalized
             contraction (same exponents and angular momentum, but different coefficients). `M` is
             the number of segmented contractions with the same exponents (and angular momentum).
-            Second index corresponds to angular momentum vector. `L_cart` is the number of Cartesian
+            Dimension 1 corresponds to angular momentum vector. `L_cart` is the number of Cartesian
             contractions for the given angular momentum.
 
         Notes
@@ -101,12 +100,12 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         than the arbitrary number of keywords (as is done here).
 
         The methods `construct_array_cartesian`, `construct_array_spherical`, and
-        `construct_array_lincomb` depend on this function to produce an array whose first
-        index corresponds to the contraction (within a generalized contraction) and second index
-        corresponds to the angular momentum vector. These other methods **will** fail with little
+        `construct_array_lincomb` depend on this function to produce an array with dimension 0
+        corresponding to the contraction (within a generalized contraction) and dimension 1
+        corresponding to the angular momentum vector. These other methods **will** fail with little
         warning if the shape of the output is different. Even if there is only one contraction (i.e.
         segmented contraction), the first index must correspond to the contraction. In other words,
-        the shape must still be (1, L, N).
+        the shape must still be :math:`(1, L, N)`.
 
         """
 
@@ -124,8 +123,8 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         -------
         array : np.ndarray(K_cart, ...)
             Array associated with the given set of contracted Cartesian Gaussians.
-            First index of the array is associated with the contracted Cartesian Gaussian. `K_cart`
-            is the total number of Cartesian contractions within the instance.
+            Dimension 0 is associated with the contracted Cartesian Gaussian. :math:`K_cart` is the
+            total number of Cartesian contractions within the instance.
 
         """
         matrices = []
@@ -152,8 +151,8 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         array : np.ndarray(K_sph, ...)
             Array associated with the atomic orbitals associated with the given set of contracted
             Cartesian Gaussians.
-            First index of the array is associated with the contracted spherical Gaussian. `K_sph`
-            is the total number of Cartesian contractions within the instance.
+            Dimension 0 is associated with the contracted spherical Gaussian. :math:`K_sph` is the
+            total number of Cartesian contractions within the instance.
 
         """
         matrices_spherical = []
@@ -178,7 +177,7 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         return np.concatenate(matrices_spherical, axis=0)
 
     def construct_array_mix(self, coord_types, **kwargs):
-        """Return the array associated with all of the contraction in the given coordinate system.
+        """Return the array associated with all of the contractions in the given coordinate system.
 
         Parameters
         ----------
@@ -194,8 +193,8 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         -------
         array : np.ndarray(K_cont, ...)
             Array associated with the spherical contrations of the basis set.
-            First index of the array is associated with each spherical contraction in the basis set.
-            `K_cont` is the total number of contractions within the given basis set.
+            Dimension 0 is associated with each spherical contraction in the basis set.
+            :math:`K_cont` is the total number of contractions within the given basis set.
 
         Raises
         ------
@@ -204,7 +203,7 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         ValueError
             If `coord_types` has an entry that is not "cartesian" or "spherical".
             If `coord_types` has different number of entries as the number of
-            GeneralizedContractionShell (`contractions`) in instance.
+            `GeneralizedContractionShell` (`contractions`) in instance.
 
         """
         if not isinstance(coord_types, (list, tuple)):
@@ -216,7 +215,7 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         if len(coord_types) != len(self.contractions):
             raise ValueError(
                 "`coord_types` must have the same number of entries as the number of "
-                "GeneralizedContractionShell in the instance."
+                "`GeneralizedContractionShell` in the instance."
             )
 
         matrices = []
@@ -274,7 +273,7 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         -------
         array : np.ndarray(K_orbs, ...)
             Array whose first index is associated with the linear combinations of the contractions.
-            `K_orbs` is the number of basis functions produced after the linear combinations.
+            :math:`K_orbs` is the number of basis functions produced after the linear combinations.
 
         Raises
         ------

--- a/gbasis/base_one.py
+++ b/gbasis/base_one.py
@@ -28,22 +28,22 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         Initialize.
     construct_array_contraction(self, contraction) : np.ndarray(M, L_cart, ...)
         Return the array associated with a `GeneralizedContractionShell` instance.
-        :math:`M` is the number of segmented contractions with the same exponents (and angular
+        `M` is the number of segmented contractions with the same exponents (and angular
         momentum).
-        :math:`L_cart` is the number of Cartesian contractions for the given angular momentum.
+        `L_cart` is the number of Cartesian contractions for the given angular momentum.
     construct_array_cartesian(self) : np.ndarray(K_cart, ...)
         Return the array associated with Cartesian Gaussians.
-        :math:`K_cart` is the total number of Cartesian contractions within the instance.
+        `K_cart` is the total number of Cartesian contractions within the instance.
     construct_array_spherical(self) : np.ndarray(K_sph, ...)
         Return the array associated with spherical Gaussians (atomic orbitals).
-        :math:`K_sph` is the total number of spherical contractions within the instance.
+        `K_sph` is the total number of spherical contractions within the instance.
     construct_array_mix(self, coord_types, **kwargs) : np.ndarray(K_cont, ...)
         Return the array associated with all of the contraction in the given coordinate system.
-        :math:`K_cont` is the total number of contractions within the given basis set.
+        `K_cont` is the total number of contractions within the given basis set.
     construct_array_lincomb(self, transform, coord_type) : np.ndarray(K_orbs, ...)
         Return the array associated with linear combinations of contractions in the given coordinate
         system.
-        :math:`K_orbs` is the number of basis functions produced after the linear combinations.
+        `K_orbs` is the number of basis functions produced after the linear combinations.
 
     """
 
@@ -105,7 +105,7 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         corresponding to the angular momentum vector. These other methods **will** fail with little
         warning if the shape of the output is different. Even if there is only one contraction (i.e.
         segmented contraction), the first index must correspond to the contraction. In other words,
-        the shape must still be :math:`(1, L, N)`.
+        the shape must still be (1, L, N).
 
         """
 
@@ -123,7 +123,7 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         -------
         array : np.ndarray(K_cart, ...)
             Array associated with the given set of contracted Cartesian Gaussians.
-            Dimension 0 is associated with the contracted Cartesian Gaussian. :math:`K_cart` is the
+            Dimension 0 is associated with the contracted Cartesian Gaussian. `K_cart` is the
             total number of Cartesian contractions within the instance.
 
         """
@@ -151,7 +151,7 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         array : np.ndarray(K_sph, ...)
             Array associated with the atomic orbitals associated with the given set of contracted
             Cartesian Gaussians.
-            Dimension 0 is associated with the contracted spherical Gaussian. :math:`K_sph` is the
+            Dimension 0 is associated with the contracted spherical Gaussian. `K_sph` is the
             total number of Cartesian contractions within the instance.
 
         """
@@ -194,7 +194,7 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         array : np.ndarray(K_cont, ...)
             Array associated with the spherical contrations of the basis set.
             Dimension 0 is associated with each spherical contraction in the basis set.
-            :math:`K_cont` is the total number of contractions within the given basis set.
+            `K_cont` is the total number of contractions within the given basis set.
 
         Raises
         ------
@@ -272,7 +272,7 @@ class BaseOneIndex(BaseGaussianRelatedArray):
         -------
         array : np.ndarray(K_orbs, ...)
             Array whose first index is associated with the linear combinations of the contractions.
-            :math:`K_orbs` is the number of basis functions produced after the linear combinations.
+            `K_orbs` is the number of basis functions produced after the linear combinations.
 
         Raises
         ------

--- a/gbasis/base_two_asymm.py
+++ b/gbasis/base_two_asymm.py
@@ -18,13 +18,12 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
     ----------
     _axes_contractions : tuple of tuple of GeneralizedContractionShell
         Sets of contractions associated with each axis of the array.
-
-    Properties
-    ----------
     contractions_one : tuple of GeneralizedContractionShell
         Contractions that are associated with the first index of the array.
+        Property of `BaseTwoIndexAsymmetric`.
     contractions_two : tuple of GeneralizedContractionShell
         Contractions that are associated with the second index of the array.
+        Property of `BaseTwoIndexAsymmetric`.
 
     Methods
     -------
@@ -33,29 +32,29 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
     construct_array_contraction(self, contractions_one, contractions_two, **kwargs) :
     np.ndarray(M_1, L_cart_1, M_2, L_cart_2, ...)
         Return the array associated with a `GeneralizedContractionShell` instance.
-        `M_1` is the number of segmented contractions with the same exponents (and angular momentum)
+       :math:`M_1` is the number of segmented contractions with the same exponents (and angular
+        momentum) associated with the first index.
+        :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
         associated with the first index.
-        `L_cart_1` is the number of Cartesian contractions for the given angular momentum associated
-        with the first index.
-        `M_2` is the number of segmented contractions with the same exponents (and angular momentum)
+        :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+        momentum) associated with the second index.
+        :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
         associated with the second index.
-        `L_cart_2` is the number of Cartesian contractions for the given angular momentum associated
-        with the second index.
     construct_array_cartesian(self, **kwargs) : np.ndarray(K_cart_1, K_cart_2, ...)
         Return the array associated with Cartesian Gaussians.
-        `K_cart_1` is the total number of Cartesian contractions within the `contractions_one`.
-        `K_cart_2` is the total number of Cartesian contractions within the `contractions_two`.
+        :math:`K_cart_1` is the total number of Cartesian contractions within `contractions_one`.
+        :math:`K_cart_2` is the total number of Cartesian contractions within `contractions_two`.
     construct_array_spherical(self, **kwargs) : np.ndarray(K_sph_1, K_sph_2, ...)
         Return the array associated with spherical Gaussians (atomic orbitals).
-        `K_sph_1` is the total number of spherical contractions within the `contractions_one`.
-        `K_sph_2` is the total number of spherical contractions within the `contractions_two`.
+        :math:`K_sph_1` is the total number of spherical contractions within `contractions_one`.
+        :math:`K_sph_2` is the total number of spherical contractions within `contractions_two`.
     construct_array_lincomb(self, transform_one, transform_two, coord_type, **kwargs) :
     np.ndarray(K_orbs_1, K_orbs_2, ...)
         Return the array associated with linear combinations of contractions in the given coordinate
         system.
-        `K_orbs_1` is the number of basis functions produced after the linear combinations of the
+        :math:`K_orbs_1` is the number of basis functions produced by linear combinations of the
         spherical contractions associated with `contractions_one`.
-        `K_orbs_2` is the number of basis functions produced after the linear combinations of the
+        :math:`K_orbs_2` is the number of basis functions produced by linear combinations of the
         spherical contractions associated with `contractions_two`.
 
     """
@@ -116,17 +115,17 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
         -------
         array_contraction : np.ndarray(M_1, L_cart_1, M_2, L_cart_2, ...)
             Array associated with the given instance(s) of GeneralizedContractionShell.
-            First axis corresponds to the segmented contraction within `contractions_one`. `M_1` is
-            the number of segmented contractions with the same exponents (and angular momentum)
+            Dimension 0 corresponds to the segmented contraction within `contractions_one`.
+            :math:`M_1` is the number of segmented contractions with the same exponents (and angular
+            momentum) associated with the first index.
+            Dimension 1 corresponds to the angular momentum vector of the `contractions_one`.
+            :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
             associated with the first index.
-            Second axis corresponds to the angular momentum vector of the `contractions_one`.
-            `L_cart_1` is the number of Cartesian contractions for the given angular momentum
-            associated with the first index.
-            Third axis corresponds to the segmented contraction within `contractions_two`. `M_2` is
-            the number of segmented contractions with the same exponents (and angular momentum)
-            associated with the second index.
-            Fourth axis corresponds to the angular momentum vector of the `contractions_two`.
-            `L_cart_2` is the number of Cartesian contractions for the given angular momentum
+            Dimension 2 corresponds to the segmented contraction within `contractions_two`.
+            :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+            momentum) associated with the second index.
+            Dimension 3 corresponds to the angular momentum vector of the `contractions_two`.
+            :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
             associated with the second index.
 
         Notes
@@ -137,14 +136,14 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
         than the arbitrary number of keywords (as is done here).
 
         The methods `construct_array_cartesian`, `construct_array_spherical`, and
-        `construct_array_lincomb` depend on this function to produce an array whose first
-        and second indices correspond to the contraction (within a generalized contraction) and
-        the angular momentum vector of `contractions_one`, and third and fourth indices correspond
-        to the contraction (within a generalized contraction) and the angular momentum vector of
-        `contractions_two`,. These other methods **will** fail with little warning if the shape of
-        the output is different. Even if both `contractions_one` and `contractions_two` are
-        segmented contractions, the first and third indices must correspond to the contraction.
-        In other words, the shape must still be (1, L_1, 1, L_2).
+        `construct_array_lincomb` depend on this function to produce an array with dimensions 0, 1
+        corresponding to the contraction (within a generalized contraction) and the angular momentum
+        vector of `contractions_one`, and dimensions 2, 3 corresponding to the contraction (within a
+        generalized contraction) and the angular momentum vector of `contractions_two`.
+        These other methods **will** fail with little warning if the shape of the output is
+        different. Even if both `contractions_one` and `contractions_two` are segmented
+        contractions, the first and third indices must correspond to the contraction. In other
+        words, the shape must still be :math:`(1, L_1, 1, L_2)`.
 
         """
 
@@ -162,10 +161,12 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
         -------
         array :  np.ndarray(K_cart_1, K_cart_2, ...)
             Array associated with the given set of contracted Cartesian Gaussians.
-            First index corresponds to the Cartesian contraction within the `contractions_one`.
-            `K_cart_1` is the total number of Cartesian contractions within the `contractions_one`.
-            Second index corresponds to the Cartesian contraction within the `contractions_two`.
-            `K_cart_2` is the total number of Cartesian contractions within the `contractions_two`.
+            Dimension 0 corresponds to the Cartesian contraction within `contractions_one`.
+            :math:`K_cart_1` is the total number of Cartesian contractions within
+            `contractions_one`.
+            Dimension 1 corresponds to the Cartesian contraction within `contractions_two`.
+            :math:`K_cart_2` is the total number of Cartesian contractions within
+            `contractions_two`.
 
         """
         matrices = []
@@ -204,10 +205,10 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
         array : np.ndarray(K_sph_1, K_sph_2, ...)
             Array associated with the atomic orbitals associated with the given set(s) of contracted
             Cartesian Gaussians.
-            First index corresponds to the spherical contraction within the `contractions_one`.
-            `K_sph_1` is the total number of spherical contractions within the `contractions_one`.
-            Second index corresponds to the spherical contraction within the `contractions_two`.
-            `K_sph_2` is the total number of spherical contractions within the `contractions_two`.
+            Dimension 0 corresponds to the Cartesian contraction within `contractions_one`.
+            :math:`K_sph_1` is the total number of Cartesian contractions within `contractions_one`.
+            Dimension 1 corresponds to the Cartesian contraction within `contractions_two`.
+            :math:`K_sph_2` is the total number of Cartesian contractions within `contractions_two`.
 
         """
         matrices_spherical = []
@@ -254,12 +255,12 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
         return np.concatenate(matrices_spherical, axis=0)
 
     def construct_array_mix(self, coord_types_one, coord_types_two, **kwargs):
-        """Return the array associated with set of Gaussians of the given coordinate systems.
+        """Return the array associated with a set of Gaussians of the given coordinate systems.
 
         Parameters
         ----------
         coord_types_one : list/tuple of str
-            Types of the coordinate system for GeneralizedContractionShell associated with the
+            Types of the coordinate system for `GeneralizedContractionShell` associated with the
             first index of the array.
             Each entry must be one of "cartesian" or "spherical".
         coord_types_two : list/tuple of str
@@ -274,8 +275,9 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
         array : np.ndarray(K_cont, K_cont, ...)
             Array associated with the atomic orbitals associated with the given set of contracted
             Cartesian Gaussians.
-            First and second indices of the array are associated with two contractions in the given
-            coordinate system. `K_cont` is the total number of contractions within the instance.
+            First two indices of the array are associated with two contractions in the given
+            coordinate system. :math:`K_cont` is the total number of contractions within the
+            instance.
 
         Raises
         ------
@@ -285,10 +287,10 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
         ValueError
             If `coord_types_one` has an entry that is not "cartesian" or "spherical".
             If `coord_types_one` has different number of entries as the number of
-            GeneralizedContractionShell (`contractions`) in instance.
+            `GeneralizedContractionShell` (`contractions`) in instance.
             If `coord_types_two` has an entry that is not "cartesian" or "spherical".
             If `coord_types_two` has different number of entries as the number of
-            GeneralizedContractionShell (`contractions`) in instance.
+            `GeneralizedContractionShell` (`contractions`) in instance.
 
         """
         if not isinstance(coord_types_one, (list, tuple)):
@@ -306,12 +308,12 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
         if len(coord_types_one) != len(self.contractions_one):
             raise ValueError(
                 "`coord_types_one` must have the same number of entries as the number of "
-                "GeneralizedContractionShell in the instance."
+                "`GeneralizedContractionShell` in the instance."
             )
         if len(coord_types_two) != len(self.contractions_two):
             raise ValueError(
                 "`coord_types_two` must have the same number of entries as the number of "
-                "GeneralizedContractionShell in the instance."
+                "`GeneralizedContractionShell` in the instance."
             )
 
         matrices_spherical = []
@@ -385,13 +387,13 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
             If "cartesian", then all of the contractions are treated as Cartesian contractions.
             If "spherical", then all of the contractions are treated as spherical contractions.
             If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-            coordinate type of each GeneralizedContractionShell instance.
+            coordinate type of each `GeneralizedContractionShell` instance.
         coord_type_two : {"cartesian", "spherical", list/tuple of "cartesian" or "spherical}
             Types of the coordinate system for the contractions associated with the second index.
             If "cartesian", then all of the contractions are treated as Cartesian contractions.
             If "spherical", then all of the contractions are treated as spherical contractions.
             If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-            coordinate type of each GeneralizedContractionShell instance.
+            coordinate type of each `GeneralizedContractionShell` instance.
         kwargs : dict
             Other keyword arguments that will be used to construct the array.
             These keyword arguments are passed directly to `construct_array_spherical`, which will
@@ -402,19 +404,19 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
         -------
         array : np.ndarray(K_orbs_1, K_orbs_2, ...)
             Array associated with the linear combinations of given two sets of contractions.
-            First index of the array corresponds to the linear combination of contractions with the
-            first set of contractions, `contractions_one`. `K_orbs_1` is the number of basis
-            functions produced after the linear combinations of the spherical contractions
-            associated with `contractions_one`.
-            Second index of the array corresponds to the linear combination of contractions
-            associated with the second set of contractions, `contractions_two`. `K_orbs_2` is the
-            number of basis functions produced after the linear combinations of the spherical
-            contractions associated with `contractions_two`.
+            Dimension 0 corresponds to the linear combination of contractions with the first set of
+            contractions, `contractions_one`. :math:`K_orbs_1` is the number of basis functions
+            produced by linear combination of the spherical contractions associated with
+            `contractions_one`.
+            Dimension 1 corresponds to the linear combination of contractions associated with the
+            second set of contractions, `contractions_two`. :math:`K_orbs_2` is the number of basis
+            functions produced by linear combinations of the spherical contractions associated with
+            `contractions_two`.
 
         Raises
         ------
         TypeError
-            If `coord_type_one` and `coord_type_two` aare not one of "cartesian", "spherical", or a
+            If `coord_type_one` and `coord_type_two` are not one of "cartesian", "spherical", or a
             list/tuple of these strings.
 
         """

--- a/gbasis/base_two_asymm.py
+++ b/gbasis/base_two_asymm.py
@@ -32,29 +32,29 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
     construct_array_contraction(self, contractions_one, contractions_two, **kwargs) :
     np.ndarray(M_1, L_cart_1, M_2, L_cart_2, ...)
         Return the array associated with a `GeneralizedContractionShell` instance.
-       :math:`M_1` is the number of segmented contractions with the same exponents (and angular
+       `M_1` is the number of segmented contractions with the same exponents (and angular
         momentum) associated with the first index.
-        :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
+        `L_cart_1` is the number of Cartesian contractions for the given angular momentum
         associated with the first index.
-        :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+        `M_2` is the number of segmented contractions with the same exponents (and angular
         momentum) associated with the second index.
-        :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
+        `L_cart_2` is the number of Cartesian contractions for the given angular momentum
         associated with the second index.
     construct_array_cartesian(self, **kwargs) : np.ndarray(K_cart_1, K_cart_2, ...)
         Return the array associated with Cartesian Gaussians.
-        :math:`K_cart_1` is the total number of Cartesian contractions within `contractions_one`.
-        :math:`K_cart_2` is the total number of Cartesian contractions within `contractions_two`.
+        `K_cart_1` is the total number of Cartesian contractions within `contractions_one`.
+        `K_cart_2` is the total number of Cartesian contractions within `contractions_two`.
     construct_array_spherical(self, **kwargs) : np.ndarray(K_sph_1, K_sph_2, ...)
         Return the array associated with spherical Gaussians (atomic orbitals).
-        :math:`K_sph_1` is the total number of spherical contractions within `contractions_one`.
-        :math:`K_sph_2` is the total number of spherical contractions within `contractions_two`.
+        `K_sph_1` is the total number of spherical contractions within `contractions_one`.
+        `K_sph_2` is the total number of spherical contractions within `contractions_two`.
     construct_array_lincomb(self, transform_one, transform_two, coord_type, **kwargs) :
     np.ndarray(K_orbs_1, K_orbs_2, ...)
         Return the array associated with linear combinations of contractions in the given coordinate
         system.
-        :math:`K_orbs_1` is the number of basis functions produced by linear combinations of the
+        `K_orbs_1` is the number of basis functions produced by linear combinations of the
         spherical contractions associated with `contractions_one`.
-        :math:`K_orbs_2` is the number of basis functions produced by linear combinations of the
+        `K_orbs_2` is the number of basis functions produced by linear combinations of the
         spherical contractions associated with `contractions_two`.
 
     """
@@ -116,16 +116,16 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
         array_contraction : np.ndarray(M_1, L_cart_1, M_2, L_cart_2, ...)
             Array associated with the given instance(s) of GeneralizedContractionShell.
             Dimension 0 corresponds to the segmented contraction within `contractions_one`.
-            :math:`M_1` is the number of segmented contractions with the same exponents (and angular
+            `M_1` is the number of segmented contractions with the same exponents (and angular
             momentum) associated with the first index.
             Dimension 1 corresponds to the angular momentum vector of the `contractions_one`.
-            :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
+            `L_cart_1` is the number of Cartesian contractions for the given angular momentum
             associated with the first index.
             Dimension 2 corresponds to the segmented contraction within `contractions_two`.
-            :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+            `M_2` is the number of segmented contractions with the same exponents (and angular
             momentum) associated with the second index.
             Dimension 3 corresponds to the angular momentum vector of the `contractions_two`.
-            :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
+            `L_cart_2` is the number of Cartesian contractions for the given angular momentum
             associated with the second index.
 
         Notes
@@ -143,7 +143,7 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
         These other methods **will** fail with little warning if the shape of the output is
         different. Even if both `contractions_one` and `contractions_two` are segmented
         contractions, the first and third indices must correspond to the contraction. In other
-        words, the shape must still be :math:`(1, L_1, 1, L_2)`.
+        words, the shape must still be (1, L_1, 1, L_2).
 
         """
 
@@ -162,10 +162,10 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
         array :  np.ndarray(K_cart_1, K_cart_2, ...)
             Array associated with the given set of contracted Cartesian Gaussians.
             Dimension 0 corresponds to the Cartesian contraction within `contractions_one`.
-            :math:`K_cart_1` is the total number of Cartesian contractions within
+            `K_cart_1` is the total number of Cartesian contractions within
             `contractions_one`.
             Dimension 1 corresponds to the Cartesian contraction within `contractions_two`.
-            :math:`K_cart_2` is the total number of Cartesian contractions within
+            `K_cart_2` is the total number of Cartesian contractions within
             `contractions_two`.
 
         """
@@ -206,9 +206,9 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
             Array associated with the atomic orbitals associated with the given set(s) of contracted
             Cartesian Gaussians.
             Dimension 0 corresponds to the Cartesian contraction within `contractions_one`.
-            :math:`K_sph_1` is the total number of Cartesian contractions within `contractions_one`.
+            `K_sph_1` is the total number of Cartesian contractions within `contractions_one`.
             Dimension 1 corresponds to the Cartesian contraction within `contractions_two`.
-            :math:`K_sph_2` is the total number of Cartesian contractions within `contractions_two`.
+            `K_sph_2` is the total number of Cartesian contractions within `contractions_two`.
 
         """
         matrices_spherical = []
@@ -276,7 +276,7 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
             Array associated with the atomic orbitals associated with the given set of contracted
             Cartesian Gaussians.
             First two indices of the array are associated with two contractions in the given
-            coordinate system. :math:`K_cont` is the total number of contractions within the
+            coordinate system. `K_cont` is the total number of contractions within the
             instance.
 
         Raises
@@ -405,11 +405,11 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
         array : np.ndarray(K_orbs_1, K_orbs_2, ...)
             Array associated with the linear combinations of given two sets of contractions.
             Dimension 0 corresponds to the linear combination of contractions with the first set of
-            contractions, `contractions_one`. :math:`K_orbs_1` is the number of basis functions
+            contractions, `contractions_one`. `K_orbs_1` is the number of basis functions
             produced by linear combination of the spherical contractions associated with
             `contractions_one`.
             Dimension 1 corresponds to the linear combination of contractions associated with the
-            second set of contractions, `contractions_two`. :math:`K_orbs_2` is the number of basis
+            second set of contractions, `contractions_two`. `K_orbs_2` is the number of basis
             functions produced by linear combinations of the spherical contractions associated with
             `contractions_two`.
 

--- a/gbasis/base_two_asymm.py
+++ b/gbasis/base_two_asymm.py
@@ -175,9 +175,9 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
             for cont_two in self.contractions_two:
                 block = self.construct_array_contraction(cont_one, cont_two, **kwargs)
                 # normalize contractions
-                block *= cont_one.norm_cont.reshape(*block.shape[:2], *[1 for i in block.shape[2:]])
+                block *= cont_one.norm_cont.reshape(*block.shape[:2], *[1 for _ in block.shape[2:]])
                 block *= cont_two.norm_cont.reshape(
-                    1, 1, *block.shape[2:4], *[1 for i in block.shape[4:]]
+                    1, 1, *block.shape[2:4], *[1 for _ in block.shape[4:]]
                 )
                 # assume array always has shape (M_1, L_1, M_2, L_2, ...)
                 block = np.concatenate(block, axis=0)
@@ -234,10 +234,10 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
                 matrix_contraction = self.construct_array_contraction(cont_one, cont_two, **kwargs)
                 # normalize contractions
                 matrix_contraction *= cont_one.norm_cont.reshape(
-                    *matrix_contraction.shape[:2], *[1 for i in matrix_contraction.shape[2:]]
+                    *matrix_contraction.shape[:2], *[1 for _ in matrix_contraction.shape[2:]]
                 )
                 matrix_contraction *= cont_two.norm_cont.reshape(
-                    1, 1, *matrix_contraction.shape[2:4], *[1 for i in matrix_contraction.shape[4:]]
+                    1, 1, *matrix_contraction.shape[2:4], *[1 for _ in matrix_contraction.shape[4:]]
                 )
                 # transform
                 # assume array always has shape (M_1, L_1, M_2, L_2, ...)
@@ -338,9 +338,9 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
                 # evaluate
                 block = self.construct_array_contraction(cont_one, cont_two, **kwargs)
                 # normalize contractions
-                block *= cont_one.norm_cont.reshape(*block.shape[:2], *[1 for i in block.shape[2:]])
+                block *= cont_one.norm_cont.reshape(*block.shape[:2], *[1 for _ in block.shape[2:]])
                 block *= cont_two.norm_cont.reshape(
-                    1, 1, *block.shape[2:4], *[1 for i in block.shape[4:]]
+                    1, 1, *block.shape[2:4], *[1 for _ in block.shape[4:]]
                 )
                 # transform
                 # assume array always has shape (M_1, L_1, M_2, L_2, ...)

--- a/gbasis/base_two_symm.py
+++ b/gbasis/base_two_symm.py
@@ -154,9 +154,9 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
             for cont_two in self.contractions[i:]:
                 block = self.construct_array_contraction(cont_one, cont_two, **kwargs)
                 # normalize contractions
-                block *= cont_one.norm_cont.reshape(*block.shape[:2], *[1 for i in block.shape[2:]])
+                block *= cont_one.norm_cont.reshape(*block.shape[:2], *[1 for _ in block.shape[2:]])
                 block *= cont_two.norm_cont.reshape(
-                    1, 1, *block.shape[2:4], *[1 for i in block.shape[4:]]
+                    1, 1, *block.shape[2:4], *[1 for _ in block.shape[4:]]
                 )
                 # assume array always has shape (M_1, L_1, M_2, L_2, ...)
                 block = np.concatenate(block, axis=0)
@@ -225,10 +225,10 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
                 block_sph = self.construct_array_contraction(cont_one, cont_two, **kwargs)
                 # normalize contractions
                 block_sph *= cont_one.norm_cont.reshape(
-                    *block_sph.shape[:2], *[1 for i in block_sph.shape[2:]]
+                    *block_sph.shape[:2], *[1 for _ in block_sph.shape[2:]]
                 )
                 block_sph *= cont_two.norm_cont.reshape(
-                    1, 1, *block_sph.shape[2:4], *[1 for i in block_sph.shape[4:]]
+                    1, 1, *block_sph.shape[2:4], *[1 for _ in block_sph.shape[4:]]
                 )
                 # assume array has shape (M_1, L_1, M_2, L_2, ...)
                 # transform
@@ -314,9 +314,9 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
                 # evaluate
                 block = self.construct_array_contraction(cont_one, cont_two, **kwargs)
                 # normalize contractions
-                block *= cont_one.norm_cont.reshape(*block.shape[:2], *[1 for i in block.shape[2:]])
+                block *= cont_one.norm_cont.reshape(*block.shape[:2], *[1 for _ in block.shape[2:]])
                 block *= cont_two.norm_cont.reshape(
-                    1, 1, *block.shape[2:4], *[1 for i in block.shape[4:]]
+                    1, 1, *block.shape[2:4], *[1 for _ in block.shape[4:]]
                 )
                 # assume array has shape (M_1, L_1, M_2, L_2, ...)
                 if type_one == "spherical":

--- a/gbasis/base_two_symm.py
+++ b/gbasis/base_two_symm.py
@@ -28,24 +28,24 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
     construct_array_contraction(self, contraction, **kwargs) :
     np.ndarray(M_1, L_cart_1, M_2, L_cart_2, ...)
         Return the array associated with a `GeneralizedContractionShell` instance.
-        :math:`M_1` is the number of segmented contractions with the same exponents (and angular
+        `M_1` is the number of segmented contractions with the same exponents (and angular
         momentum) associated with the first index.
-        :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
+        `L_cart_1` is the number of Cartesian contractions for the given angular momentum
         associated with the first index.
-        :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+        `M_2` is the number of segmented contractions with the same exponents (and angular
         momentum) associated with the second index.
-        :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
+        `L_cart_2` is the number of Cartesian contractions for the given angular momentum
         associated with the second index.
     construct_array_cartesian(self, **kwargs) : np.ndarray(K_cart, K_cart, ...)
         Return the array associated with Cartesian Gaussians.
-        :math:`K_cart` is the total number of Cartesian contractions within the instance.
+        `K_cart` is the total number of Cartesian contractions within the instance.
     construct_array_spherical(self, **kwargs) : np.ndarray(K_sph, K_sph, ...)
         Return the array associated with spherical Gaussians (atomic orbitals).
-        :math:`K_sph` is the total number of spherical contractions within the instance.
+        `K_sph` is the total number of spherical contractions within the instance.
     construct_array_lincomb(self, transform, coord_type) : np.ndarray(K_orbs, K_orbs, ...)
         Return the array associated with linear combinations of contractions in the given coordinate
         system.
-        :math:`K_orbs` is the number of basis functions produced after the linear combinations.
+        `K_orbs` is the number of basis functions produced after the linear combinations.
 
     """
 
@@ -93,16 +93,16 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
         array_contraction : np.ndarray(M_1, L_cart_1, M_2, L_cart_2, ...)
             Array associated with the given instances of GeneralizedContractionShell.
             Dimension 0 corresponds to the segmented contraction within `contractions_one`.
-            :math:`M_1` is the number of segmented contractions with the same exponents (and angular
+            `M_1` is the number of segmented contractions with the same exponents (and angular
             momentum) associated with the first index.
             Dimension 1 corresponds to the angular momentum vector of the `contractions_one`.
-            :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
+            `L_cart_1` is the number of Cartesian contractions for the given angular momentum
             associated with the first index.
             Dimension 2 corresponds to the segmented contraction within `contractions_two`.
-            :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+            `M_2` is the number of segmented contractions with the same exponents (and angular
             momentum) associated with the second index.
             Dimension 3 corresponds to the angular momentum vector of the `contractions_two`.
-            :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
+            `L_cart_2` is the number of Cartesian contractions for the given angular momentum
             associated with the second index.
 
         Notes
@@ -120,7 +120,7 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
         These other methods **will** fail with little warning if the shape of
         the output is different. Even if both `contractions_one` and `contractions_two` are
         segmented contractions, the dimensions 0 and 2 must correspond to the contraction.
-        In other words, the shape must still be :math:`(1, L_1, 1, L_2)`.
+        In other words, the shape must still be (1, L_1, 1, L_2).
 
         """
 
@@ -139,7 +139,7 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
         array : np.ndarray(K_cart, K_cart, ...)
             Array associated with the given set of contracted Cartesian Gaussians.
             Dimensions 0 and 1 of the array are associated with the contracted Cartesian Gaussians.
-            :math:`K_cart` is the total number of Cartesian contractions within the instance.
+            `K_cart` is the total number of Cartesian contractions within the instance.
 
         Notes
         -----
@@ -194,7 +194,7 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
             Array associated with the atomic orbitals associated with the given set(s) of contracted
             Cartesian Gaussians.
             Dimensions 0 and 1 are associated with two contracted spherical Gaussians (atomic
-            orbitals). :math:`K_sph` is the total number of spherical contractions within the
+            orbitals). `K_sph` is the total number of spherical contractions within the
             instance.
 
         Notes
@@ -271,7 +271,7 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
             Array associated with the atomic orbitals associated with the given set of contracted
             Cartesian Gaussians.
             Dimensions 0 and 1 are associated with two contractions in the given coordinate system.
-            :math:`K_cont` is the total number of contractions within the instance.
+            `K_cont` is the total number of contractions within the instance.
 
         Raises
         ------
@@ -380,7 +380,7 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
             Array whose first two indices are associated with the linear combinations of the
             contractions.
             Dimensions 0 and 1 correspond to the linear combination of contracted spherical
-            Gaussians. :math:`K_orbs` is the number of basis functions produced after the linear
+            Gaussians. `K_orbs` is the number of basis functions produced after the linear
             combinations.
 
         Raises

--- a/gbasis/base_two_symm.py
+++ b/gbasis/base_two_symm.py
@@ -17,11 +17,9 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
     ----------
     _axes_contractions : tuple of tuple of GeneralizedContractionShell
         Sets of contractions associated with each axis of the array.
-
-    Properties
-    ----------
     contractions : tuple of GeneralizedContractionShell
         Contractions that are associated with the first and second indices of the array.
+        Property of `BaseTwoIndexSymmetric`.
 
     Methods
     -------
@@ -30,24 +28,24 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
     construct_array_contraction(self, contraction, **kwargs) :
     np.ndarray(M_1, L_cart_1, M_2, L_cart_2, ...)
         Return the array associated with a `GeneralizedContractionShell` instance.
-        `M_1` is the number of segmented contractions with the same exponents (and angular momentum)
+        :math:`M_1` is the number of segmented contractions with the same exponents (and angular
+        momentum) associated with the first index.
+        :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
         associated with the first index.
-        `L_cart_1` is the number of Cartesian contractions for the given angular momentum associated
-        with the first index.
-        `M_2` is the number of segmented contractions with the same exponents (and angular momentum)
+        :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+        momentum) associated with the second index.
+        :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
         associated with the second index.
-        `L_cart_2` is the number of Cartesian contractions for the given angular momentum associated
-        with the second index.
     construct_array_cartesian(self, **kwargs) : np.ndarray(K_cart, K_cart, ...)
         Return the array associated with Cartesian Gaussians.
-        `K_cart` is the total number of Cartesian contractions within the instance.
+        :math:`K_cart` is the total number of Cartesian contractions within the instance.
     construct_array_spherical(self, **kwargs) : np.ndarray(K_sph, K_sph, ...)
         Return the array associated with spherical Gaussians (atomic orbitals).
-        `K_sph` is the total number of spherical contractions within the instance.
+        :math:`K_sph` is the total number of spherical contractions within the instance.
     construct_array_lincomb(self, transform, coord_type) : np.ndarray(K_orbs, K_orbs, ...)
         Return the array associated with linear combinations of contractions in the given coordinate
         system.
-        `K_orbs` is the number of basis functions produced after the linear combinations.
+        :math:`K_orbs` is the number of basis functions produced after the linear combinations.
 
     """
 
@@ -64,12 +62,12 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
 
     @property
     def contractions(self):
-        """Contractions that are associated with the first index of the array.
+        """Contractions that are associated with the first two indices of the array.
 
         Returns
         -------
         contractions : tuple of GeneralizedContractionShell
-            Contractions that are associated with the first index of the array.
+            Contractions that are associated with the first two indices of the array.
 
         """
         return self._axes_contractions[0]
@@ -94,17 +92,17 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
         -------
         array_contraction : np.ndarray(M_1, L_cart_1, M_2, L_cart_2, ...)
             Array associated with the given instances of GeneralizedContractionShell.
-            First axis corresponds to the segmented contraction within `contractions_one`. `M_1` is
-            the number of segmented contractions with the same exponents (and angular momentum)
+            Dimension 0 corresponds to the segmented contraction within `contractions_one`.
+            :math:`M_1` is the number of segmented contractions with the same exponents (and angular
+            momentum) associated with the first index.
+            Dimension 1 corresponds to the angular momentum vector of the `contractions_one`.
+            :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
             associated with the first index.
-            Second axis corresponds to the angular momentum vector of the `contractions_one`.
-            `L_cart_1` is the number of Cartesian contractions for the given angular momentum
-            associated with the first index.
-            Third axis corresponds to the segmented contraction within `contractions_two`. `M_2` is
-            the number of segmented contractions with the same exponents (and angular momentum)
-            associated with the second index.
-            Fourth axis corresponds to the angular momentum vector of the `contractions_two`.
-            `L_cart_2` is the number of Cartesian contractions for the given angular momentum
+            Dimension 2 corresponds to the segmented contraction within `contractions_two`.
+            :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+            momentum) associated with the second index.
+            Dimension 3 corresponds to the angular momentum vector of the `contractions_two`.
+            :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
             associated with the second index.
 
         Notes
@@ -115,14 +113,14 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
         than the arbitrary number of keywords (as is done here).
 
         The methods `construct_array_cartesian`, `construct_array_spherical`, and
-        `construct_array_lincomb` depend on this function to produce an array whose first
-        and second indices correspond to the contraction (within a generalized contraction) and
-        the angular momentum vector of `contractions_one`, and third and fourth indices correspond
-        to the contraction (within a generalized contraction) and the angular momentum vector of
-        `contractions_two`,. These other methods **will** fail with little warning if the shape of
+        `construct_array_lincomb` depend on this function to produce an array with dimensions 0, 1
+        corresponding to the contraction (within a generalized contraction) and the angular momentum
+        vector of `contractions_one`, and dimensions 2, 3 corresponding to the contraction (within a
+        generalized contraction) and the angular momentum vector of `contractions_two`,.
+        These other methods **will** fail with little warning if the shape of
         the output is different. Even if both `contractions_one` and `contractions_two` are
-        segmented contractions, the first and third indices must correspond to the contraction.
-        In other words, the shape must still be (1, L_1, 1, L_2).
+        segmented contractions, the dimensions 0 and 2 must correspond to the contraction.
+        In other words, the shape must still be :math:`(1, L_1, 1, L_2)`.
 
         """
 
@@ -140,15 +138,15 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
         -------
         array : np.ndarray(K_cart, K_cart, ...)
             Array associated with the given set of contracted Cartesian Gaussians.
-            First and second indices of the array are associated with the contracted Cartesian
-            Gaussians. `K_cart` is the total number of Cartesian contractions within the instance.
+            Dimensions 0 and 1 of the array are associated with the contracted Cartesian Gaussians.
+            :math:`K_cart` is the total number of Cartesian contractions within the instance.
 
         Notes
         -----
         The blocks along the diagonal, i.e. blocks where the first two axes belong to the same
         set of contractions, are transposed in the process of constructing the whole array.
         It is assumed that the array returned from `construct_array_contraction` is symmetric with
-        respect to the swapping of the first and second axes.
+        respect to the swapping of the first two axes.
 
         """
         triu_blocks = []
@@ -195,16 +193,16 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
         array : np.ndarray(K_sph, K_sph, ...)
             Array associated with the atomic orbitals associated with the given set(s) of contracted
             Cartesian Gaussians.
-            First and second indices of the array are associated with two contracted spherical
-            Gaussians (atomic orbitals). `K_sph` is the total number of spherical contractions
-            within the instance.
+            Dimensions 0 and 1 are associated with two contracted spherical Gaussians (atomic
+            orbitals). :math:`K_sph` is the total number of spherical contractions within the
+            instance.
 
         Notes
         -----
         The blocks along the diagonal, i.e. blocks where the first two axes belong to the same
         set of contractions, are transposed in the process of constructing the whole array.
         It is assumed that the array returned from `construct_array_contraction` is symmetric with
-        respect to the swapping of the first and second axes.
+        respect to the swapping of the first two axes.
 
         """
         triu_blocks = []
@@ -257,12 +255,12 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
         )
 
     def construct_array_mix(self, coord_types, **kwargs):
-        """Return the array associated with set of Gaussians of the given coordinate systems.
+        """Return the array associated with a set of Gaussians of the given coordinate systems.
 
         Parameters
         ----------
         coord_types : list/tuple of str
-            Types of the coordinate system for each GeneralizedContractionShell.
+            Types of the coordinate system for each `GeneralizedContractionShell`.
             Each entry must be one of "cartesian" or "spherical".
         kwargs : dict
             Other keyword arguments that will be used to construct the array.
@@ -272,8 +270,8 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
         array : np.ndarray(K_cont, K_cont, ...)
             Array associated with the atomic orbitals associated with the given set of contracted
             Cartesian Gaussians.
-            First and second indices of the array are associated with two contractions in the given
-            coordinate system. `K_cont` is the total number of contractions within the instance.
+            Dimensions 0 and 1 are associated with two contractions in the given coordinate system.
+            :math:`K_cont` is the total number of contractions within the instance.
 
         Raises
         ------
@@ -282,7 +280,7 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
         ValueError
             If `coord_types` has an entry that is not "cartesian" or "spherical".
             If `coord_types` has different number of entries as the number of
-            GeneralizedContractionShell (`contractions`) in instance.
+            `GeneralizedContractionShell` (`contractions`) in instance.
 
         """
         if not isinstance(coord_types, (list, tuple)):
@@ -294,7 +292,7 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
         if len(coord_types) != len(self.contractions):
             raise ValueError(
                 "`coord_types` must have the same number of entries as the number of "
-                "GeneralizedContractionShell in the instance."
+                "`GeneralizedContractionShell` in the instance."
             )
 
         triu_blocks = []
@@ -362,14 +360,14 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
             Transformation matrix from contractions in the given coordinate system (e.g. AO) to
             linear combinations of contractions (e.g. MO).
             Transformation is applied to the left.
-            Rows correspond to the linear combinationes (i.e. MO) and the columns correspond to the
+            Rows correspond to the linear combinations (i.e. MO) and the columns correspond to the
             contractions (i.e. AO).
         coord_type : {"cartesian", "spherical", list/tuple of "cartesian" or "spherical}
             Types of the coordinate system for the contractions.
             If "cartesian", then all of the contractions are treated as Cartesian contractions.
             If "spherical", then all of the contractions are treated as spherical contractions.
             If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-            coordinate type of each GeneralizedContractionShell instance.
+            coordinate type of each `GeneralizedContractionShell` instance.
         kwargs : dict
             Other keyword arguments that will be used to construct the array.
             These keyword arguments are passed directly to `construct_array_spherical`, which will
@@ -379,10 +377,10 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
         Returns
         -------
         array : np.ndarray(K_orbs, K_orbs, ...)
-            Array whose first and second indices are associated with the linear combinations of the
+            Array whose first two indices are associated with the linear combinations of the
             contractions.
-            First and second indices of the array correspond to the linear combination of contracted
-            spherical Gaussians. `K_orbs` is the number of basis functions produced after the linear
+            Dimensions 0 and 1 correspond to the linear combination of contracted spherical
+            Gaussians. :math:`K_orbs` is the number of basis functions produced after the linear
             combinations.
 
         Raises

--- a/gbasis/contractions.py
+++ b/gbasis/contractions.py
@@ -335,8 +335,8 @@ class GeneralizedContractionShell:
         return np.array(
             [
                 (x, y, self.angmom - x - y)
-                for x in range(self.angmom + 1)[::-1]
-                for y in range(self.angmom - x + 1)[::-1]
+                for x in range(self.angmom, -1, -1)
+                for y in range(self.angmom - x, -1, -1)
             ]
         )
 

--- a/gbasis/contractions.py
+++ b/gbasis/contractions.py
@@ -77,7 +77,7 @@ class GeneralizedContractionShell:
         The x, y, and z components of the angular momentum vectors
         (:math:`\vec{a} = (a_x, a_y, a_z)` where :math:`a_x + a_y + a_z = \ell`).
         `L` is the number of Cartesian contracted Gaussian functions for the given angular
-        momentum, i.e. :math:`(angmom + 1) * (angmom + 2) / 2`.
+        momentum, i.e. :math:`(\ell + 1) * (\ell + 2) / 2`.
         Property of `GeneralizedContractionShell`.
     angmom_components_sph : tuple of int
         Tuple of magnetic quantum numbers of the contractions that specifies the ordering after
@@ -97,13 +97,13 @@ class GeneralizedContractionShell:
     norm_prim_cart : np.ndarray(L, K)
         The normalization constants of the Cartesian Gaussian primitives.
         `L` is the number of contracted Cartesian Gaussian functions for the given angular
-        momentum, i.e. :math:`(angmom + 1) * (angmom + 2) / 2`.
+        momentum, i.e. :math:`(\ell + 1) * (\ell + 2) / 2`.
         Property of `GeneralizedContractionShell`.
     num_cart : int
-        Number of Cartesian contractions of angular momentum, `angmom`.
+        Number of Cartesian contractions of angular momentum, :math:`\ell`.
         Property of `GeneralizedContractionShell`.
     num_sph : int
-        Number of spherical contractions of angular momentum, `angmom`.
+        Number of spherical contractions of angular momentum, :math:`\ell`.
         Property of `GeneralizedContractionShell`.
 
     Methods
@@ -329,7 +329,7 @@ class GeneralizedContractionShell:
             The x, y, and z components of the angular momentum vectors
             (:math:`\vec{a} = (a_x, a_y, a_z)` where :math:`a_x + a_y + a_z = \ell`).
             `L` is the number of Cartesian contracted Gaussian functions for the given
-            angular momentum, i.e. :math:`(angmom + 1) * (angmom + 2) / 2`
+            angular momentum, i.e. :math:`(\ell + 1) * (\ell + 2) / 2`
 
         """
         return np.array(
@@ -369,7 +369,7 @@ class GeneralizedContractionShell:
         norm_prim_cart : np.ndarray(L, K)
             The normalization constants of the Cartesian Gaussian primitives.
             `L` is the number of contracted Cartesian Gaussian functions for the given angular
-            momentum, i.e. :math:`(angmom + 1) * (angmom + 2) / 2`
+            momentum, i.e. :math:`(\ell + 1) * (\ell + 2) / 2`
             `K` is the number of exponents (i.e. primitives).
 
         """

--- a/gbasis/contractions.py
+++ b/gbasis/contractions.py
@@ -426,14 +426,12 @@ class GeneralizedContractionShell:
         r"""Store the normalization constants of the contractions.
 
         .. math::
-
             \int \phi_i(\mathbf{r}) \phi_i(\mathbf{r}) d\mathbf{r} &= N\\
             \frac{1}{N} \int \phi_i(\mathbf{r}) \phi_i(\mathbf{r}) d\mathbf{r} &= 1\\
-            \int (\frac{1}{\sqrt{N}} \phi_i(\mathbf{r}))
-            (\frac{1}{\sqrt{N}} \phi_i(\mathbf{r})) d\mathbf{r} &= 1\\
+            \int \left(\frac{1}{\sqrt{N}} \phi_i(\mathbf{r})\right)
+            \left(\frac{1}{\sqrt{N}} \phi_i(\mathbf{r})\right) d\mathbf{r} &= 1\\
 
-        where :math:`\phi_i` is a contraction and :math:`N` is the norm of the contraction (without
-        normalization).
+        where :math:`N` is the norm of contraction :math:`\phi_i`.
 
         Notes
         -----

--- a/gbasis/contractions.py
+++ b/gbasis/contractions.py
@@ -383,7 +383,9 @@ class GeneralizedContractionShell:
 
     @property
     def num_cart(self):
-        """Return the number of Cartesian contractions of the given angular momentum.
+        r"""Return the number of Cartesian contractions of the given angular momentum.
+
+        .. math:: \frac{(\ell + 1)(\ell + 2)}{2}
 
         Returns
         -------
@@ -395,7 +397,9 @@ class GeneralizedContractionShell:
 
     @property
     def num_sph(self):
-        """Return the number of spherical contractions of the given angular momentum.
+        r"""Return the number of spherical contractions of the given angular momentum.
+
+        .. math:: 1 + 2\ell
 
         Returns
         -------

--- a/gbasis/contractions.py
+++ b/gbasis/contractions.py
@@ -20,8 +20,8 @@ class GeneralizedContractionShell:
         (x - X_A)^{a_x} (y - Y_A)^{a_y} (z - Z_A)^{a_z}
         \exp{-\alpha_i |\vec{r} - \vec{R}_A|^2}
 
-    where :math:`\vec{a} = (a_x, a_y, az)` is the angular momentum components in the Cartesian
-    coordinate, :math:`\vec{R}_A` is the coordinate of the center :math:`A`, :math:`N_g` is the
+    where :math:`\vec{a} = (a_x, a_y, az)` is the angular momentum components in Cartesian
+    coordinates, :math:`\vec{R}_A` is the coordinate of the center :math:`A`, :math:`N_g` is the
     normalization constant of the primitive, and :math:`\alpha_i` is the exponent of the primitive.
 
     A **Cartesian contraction** is a linear combination of Cartesian primitives:
@@ -41,19 +41,19 @@ class GeneralizedContractionShell:
     the contractions in one coordinate system to another, we use the term **contraction** to
     describe both cases, unless otherwise stated.
 
-    In order to obtain the spherical contractions, we need the contractions at different angular
-    momentum components. We will denote the collection of these contractions as
-    **segmented contraction shell**. Note that contractions within segmented contraction shell all
-    have the same angular momentum, center, and the same set of exponents and contraction
-    coefficients.
+    In order to obtain the spherical contractions for a given angular momentum, we need all of the
+    contractions at that angular momentum (each with a different combination of angular momentum
+    components. We will denote the collection of these contractions as a **segmented contraction
+    shell**. Note that contractions within segmented contraction shell all have the same angular
+    momentum, center, and the same set of exponents and contraction coefficients.
 
-    Now, some basis sets, e.g. ANO-RCC, group together multiple segmented contractions that only
+    Some basis sets, e.g. ANO-RCC, group together multiple segmented contractions that only
     differ by the contraction coefficients and angular momentums. Here, we denote a collection of
-    contractions with the same angular momentum, center, and the same set of exponents as
-    **generalized contraction shell**. Note that **we do not support generalized contraction with
+    contractions with the same angular momentum, center, and the same set of exponents as a
+    **generalized contraction shell**. Note that **we do not support generalized contractions with
     different angular momentum**.
 
-    We can think of generalized contraction shell as a union of segmented contraction shells with
+    We can think of a generalized contraction shell as a union of segmented contraction shells with
     the same angular momentum, center, and the same set of exponents. Now, the contraction
     coefficients depend on the specific segmented contraction shell, :math:`j`, to which the
     contraction belongs:
@@ -74,7 +74,15 @@ class GeneralizedContractionShell:
             \ell = \sum_i (\vec{a})_i = a_x + a_y + a_z
 
     angmom_components_cart : np.ndarray(L, 3)
-        Components of the angular momentum.
+        The x, y, and z components of the angular momentum vectors
+        (:math:`\vec{a} = (a_x, a_y, a_z)` where :math:`a_x + a_y + a_z = \ell`).
+        :math:`L` is the number of Cartesian contracted Gaussian functions for the given angular
+        momentum, i.e. :math:`(angmom + 1) * (angmom + 2) / 2`.
+        Property of `GeneralizedContractionShell`.
+    angmom_components_sph : tuple of int
+        Tuple of magnetic quantum numbers of the contractions that specifies the ordering after
+        transforming the contractions from the Cartesian to spherical coordinate system.
+        Property of `GeneralizedContractionShell`.
     charge : float
         Charge at the center of the Gaussian primitives.
     exps : np.ndarray(K,)
@@ -86,30 +94,20 @@ class GeneralizedContractionShell:
     norm_cont : np.ndarray(M, L)
         Normalization constants of the Cartesian contractions of different angular momentum
         components and segmented contraction shells.
-
-    Properties
-    ----------
-    angmom_components_cart : np.ndarray(L, 3)
-        The x, y, and z components of the angular momentum vectors
-        (:math:`\vec{a} = (a_x, a_y, a_z)` where :math:`a_x + a_y + a_z = \ell`).
-        :math:`L` is the number of Cartesian contracted Gaussian functions for the given
-        angular momentum, i.e. :math:`(angmom + 1) * (angmom + 2) / 2`
-    angmom_components_sph : tuple of int
-        Tuple of magnetic quantum numbers of the contractions that specifies the ordering after
-        transforming the contractions from the Cartesian to spherical coordinate system.
     norm_prim_cart : np.ndarray(L, K)
         The normalization constants of the Cartesian Gaussian primitives.
         :math:`L` is the number of contracted Cartesian Gaussian functions for the given angular
-        momentum, i.e. :math:`(angmom + 1) * (angmom + 2) / 2`
+        momentum, i.e. :math:`(angmom + 1) * (angmom + 2) / 2`.
+        Property of `GeneralizedContractionShell`.
     num_cart : int
         Number of Cartesian contractions of angular momentum, `angmom`.
+        Property of `GeneralizedContractionShell`.
     num_sph : int
         Number of spherical contractions of angular momentum, `angmom`.
+        Property of `GeneralizedContractionShell`.
 
     Methods
     -------
-    __init__(self, angmom, coord, coeffs, exps)
-        Initialize.
     assign_norm_contr(self)
         Assign normalization constants for the contractions.
 
@@ -119,7 +117,7 @@ class GeneralizedContractionShell:
     def __init__(self, angmom, coord, coeffs, exps):
         r"""Initialize a GeneralizedContractionShell instance.
 
-        Attributes
+        Parameters
         ----------
         angmom : int
             Angular momentum of the set of contractions.
@@ -133,7 +131,8 @@ class GeneralizedContractionShell:
             Contraction coefficients, :math:`\{d_{ij}\}`, of the primitives.
             If a two-dimensional array is given, the first axis corresponds to the primitive and the
             second axis corresponds to the segmented contraction shell.
-            If a one-dimensional array is given, a newaxis will be inserted in the second dimension.
+            If a one-dimensional array is given, a `newaxis` will be inserted in the second
+            dimension.
         exps : np.ndarray(K,)
             Exponents of the primitives, :math:`\{\alpha_i\}`.
 
@@ -168,12 +167,12 @@ class GeneralizedContractionShell:
         Raises
         ------
         TypeError
-            If coord is not a numpy array of dimension 3.
-            If coord does not have data type of int or float.
+            If `coord` is not a `numpy` array of dimension 3.
+            If `coord` does not have data type of int or float.
 
         """
         if not (isinstance(coord, np.ndarray) and coord.size == 3):
-            raise TypeError("Coordinate must be given as a numpy array of dimension 3.")
+            raise TypeError("Coordinate must be given as a `numpy` array of dimension 3.")
         if coord.dtype == int:
             coord = coord.astype(float)
         if coord.dtype != float:
@@ -245,13 +244,13 @@ class GeneralizedContractionShell:
         Raises
         ------
         TypeError
-            If exps does not have data type of float.
+            If `exps` does not have data type of float.
         ValueError
-            If exps and coeffs are not arrays of the same size.
+            If `exps` and `coeffs` are not arrays of the same size.
 
         """
         if not (isinstance(exps, np.ndarray) and exps.dtype == float):
-            raise TypeError("Exponents must be given as a numpy array of data type float.")
+            raise TypeError("Exponents must be given as a `numpy` array of data type float.")
         if hasattr(self, "_coeffs") and self.coeffs.shape[0] != exps.size:
             raise ValueError(
                 "Exponents array must have the same number of elements as the number of rows "
@@ -268,8 +267,8 @@ class GeneralizedContractionShell:
         -------
         coeffs : np.ndarray(K, M)
             Contraction coefficients, :math:`\{d_{ij}\}`, of the primitives.
-            First axis corresponds to the primitive and the second axis corresponds to the segmented
-            contraction shell.
+            Dimension 0 corresponds to the primitive and the dimension 1 corresponds to the
+            segmented contraction shell.
 
         """
         return self._coeffs
@@ -282,24 +281,25 @@ class GeneralizedContractionShell:
         ----------
         coeffs : {np.ndarray(K,), np.ndarray(K, M)}
             Contraction coefficients, :math:`\{d_{ij}\}`, of the primitives.
-            If a two-dimensional array is given, the first axis corresponds to the primitive and the
-            second axis corresponds to the segmented contraction shell.
-            If a one-dimensional array is given, a newaxis will be inserted in the second dimension.
+            If a two-dimensional array is given, the dimension 0 corresponds to the primitive and
+            dimension 1 corresponds to the segmented contraction shell.
+            If a one-dimensional array is given, a `newaxis` will be inserted in the second
+            dimension.
 
         Raises
         ------
         TypeError
-            If `coeffs` is not a numpy array of data type of float.
+            If `coeffs` is not a `numpy` array of data type of float.
         ValueError
             If `coeffs` is not a one or two dimensional array.
-            If `coeffs` refers to generalized contraction (i.e. two dimensional array) and does not
-            have the same number of rows as there are exponents (i.e. primitives).
+            If `coeffs` refers to a generalized contraction (i.e. two dimensional array) and does
+            not have the same number of rows as there are exponents (i.e. primitives).
             If `coeffs` refers to segmented contraction (i.e. one dimensional array) and does not
             have the same number of elements as there are exponents (i.e. primitives).
 
         """
         if not (isinstance(coeffs, np.ndarray) and coeffs.dtype == float):
-            raise TypeError("Contraction coefficients must be a numpy array of data type float.")
+            raise TypeError("Contraction coefficients must be a `numpy` array of data type float.")
         if coeffs.ndim not in [1, 2]:
             raise ValueError("Coefficients array must be given as a one- or two-dimensional array.")
         if hasattr(self, "_exps"):

--- a/gbasis/contractions.py
+++ b/gbasis/contractions.py
@@ -86,7 +86,7 @@ class GeneralizedContractionShell:
     charge : float
         Charge at the center of the Gaussian primitives.
     exps : np.ndarray(K,)
-        Exponents of the primitives, :math:`\{\alpha_i\}`.
+        Exponents of the primitives, :math:`\{\alpha_i\}_{i=1}^K`.
     coeffs : np.ndarray(K, M)
         Contraction coefficients, :math:`\{d_{ij}\}`, of the primitives.
         First axis corresponds to the primitive and the second axis corresponds to the segmented
@@ -134,7 +134,7 @@ class GeneralizedContractionShell:
             If a one-dimensional array is given, a `newaxis` will be inserted in the second
             dimension.
         exps : np.ndarray(K,)
-            Exponents of the primitives, :math:`\{\alpha_i\}`.
+            Exponents of the primitives, :math:`\{\alpha_i\}_{i=1}^K`.
 
         """
         self.angmom = angmom
@@ -227,7 +227,7 @@ class GeneralizedContractionShell:
         Returns
         -------
         exps : np.ndarray(K,)
-            Exponents of the primitives, :math:`\{\alpha_i\}`.
+            Exponents of the primitives, :math:`\{\alpha_i\}_{i=1}^K`.
 
         """
         return self._exps
@@ -239,7 +239,7 @@ class GeneralizedContractionShell:
         Parameters
         ----------
         exps : np.ndarray(K,)
-            Exponents of the primitives, :math:`\{\alpha_i\}`.
+            Exponents of the primitives, :math:`\{\alpha_i\}_{i=1}^K`.
 
         Raises
         ------

--- a/gbasis/contractions.py
+++ b/gbasis/contractions.py
@@ -357,11 +357,12 @@ class GeneralizedContractionShell:
     def norm_prim_cart(self):
         r"""Return the normalization constants of the Cartesian Gaussian primitives.
 
-            .. math::
+        For a Cartesian primitive with exponent :math:`\alpha_i`, the normalization constant is:
 
-                N(\vec{a}, \alpha) = (2 * \alpha / \pi)^{3/4} *
-                (4 * \alpha)^{(a_x + a_y + a_z)/2} /
-                ((2 * a_x - 1)!! * (2 * a_y - 1)!! * (2 * a_z - 1)!!)^{1/2}
+        .. math::
+           N(\alpha_i, \vec{a}) = \sqrt {
+           \left(\frac{2\alpha_i}{\pi}\right)^\frac{3}{2}
+           \frac{(4\alpha_i)^{a_x + a_y + a_z}}{(2a_x - 1)!! (2a_y - 1)!! (2a_z - 1)!!}}
 
         Returns
         -------

--- a/gbasis/contractions.py
+++ b/gbasis/contractions.py
@@ -76,7 +76,7 @@ class GeneralizedContractionShell:
     angmom_components_cart : np.ndarray(L, 3)
         The x, y, and z components of the angular momentum vectors
         (:math:`\vec{a} = (a_x, a_y, a_z)` where :math:`a_x + a_y + a_z = \ell`).
-        :math:`L` is the number of Cartesian contracted Gaussian functions for the given angular
+        `L` is the number of Cartesian contracted Gaussian functions for the given angular
         momentum, i.e. :math:`(angmom + 1) * (angmom + 2) / 2`.
         Property of `GeneralizedContractionShell`.
     angmom_components_sph : tuple of int
@@ -96,7 +96,7 @@ class GeneralizedContractionShell:
         components and segmented contraction shells.
     norm_prim_cart : np.ndarray(L, K)
         The normalization constants of the Cartesian Gaussian primitives.
-        :math:`L` is the number of contracted Cartesian Gaussian functions for the given angular
+        `L` is the number of contracted Cartesian Gaussian functions for the given angular
         momentum, i.e. :math:`(angmom + 1) * (angmom + 2) / 2`.
         Property of `GeneralizedContractionShell`.
     num_cart : int
@@ -328,7 +328,7 @@ class GeneralizedContractionShell:
         angmom_components_cart : np.ndarray(L, 3)
             The x, y, and z components of the angular momentum vectors
             (:math:`\vec{a} = (a_x, a_y, a_z)` where :math:`a_x + a_y + a_z = \ell`).
-            :math:`L` is the number of Cartesian contracted Gaussian functions for the given
+            `L` is the number of Cartesian contracted Gaussian functions for the given
             angular momentum, i.e. :math:`(angmom + 1) * (angmom + 2) / 2`
 
         """
@@ -368,9 +368,9 @@ class GeneralizedContractionShell:
         -------
         norm_prim_cart : np.ndarray(L, K)
             The normalization constants of the Cartesian Gaussian primitives.
-            :math:`L` is the number of contracted Cartesian Gaussian functions for the given angular
+            `L` is the number of contracted Cartesian Gaussian functions for the given angular
             momentum, i.e. :math:`(angmom + 1) * (angmom + 2) / 2`
-            :math:`K` is the number of exponents (i.e. primitives).
+            `K` is the number of exponents (i.e. primitives).
 
         """
         exponents = self.exps[np.newaxis, :]

--- a/gbasis/evals/_deriv.py
+++ b/gbasis/evals/_deriv.py
@@ -81,22 +81,21 @@ def _eval_deriv_contractions(coords, orders, center, angmom_comps, alphas, prim_
 
     # zeroth order (i.e. no derivatization)
     indices_noderiv = orders <= 0
-    zero_rel_coords, zero_angmom_comps, zero_gauss = (
-        rel_coords[:, :, indices_noderiv],
-        angmom_comps[:, :, indices_noderiv],
-        gauss[:, :, indices_noderiv],
-    )
+
+    zero_rel_coords = rel_coords[:, :, indices_noderiv]
+    zero_angmom_comps = angmom_comps[:, :, indices_noderiv]
+    zero_gauss = gauss[:, :, indices_noderiv]
+
     zeroth_part = np.prod(zero_rel_coords ** zero_angmom_comps * zero_gauss, axis=(0, 2))
     # NOTE: `zeroth_part` now has axis 0 for primitives, axis 1 for angular momentum vector, and
     # axis 2 for coordinate
 
     deriv_part = 1
-    nonzero_rel_coords, nonzero_orders, nonzero_angmom_comps, nonzero_gauss = (
-        rel_coords[:, :, ~indices_noderiv],
-        orders[~indices_noderiv],
-        angmom_comps[:, :, ~indices_noderiv],
-        gauss[:, :, ~indices_noderiv],
-    )
+    nonzero_rel_coords = rel_coords[:, :, ~indices_noderiv]
+    nonzero_orders = orders[~indices_noderiv]
+    nonzero_angmom_comps = angmom_comps[:, :, ~indices_noderiv]
+    nonzero_gauss = gauss[:, :, ~indices_noderiv]
+
     nonzero_orders = nonzero_orders[np.newaxis, np.newaxis, :, np.newaxis, np.newaxis]
 
     # derivatization part

--- a/gbasis/evals/_deriv.py
+++ b/gbasis/evals/_deriv.py
@@ -101,7 +101,7 @@ def _eval_deriv_contractions(coords, orders, center, angmom_comps, alphas, prim_
 
     # derivatization part
     if nonzero_orders.size != 0:
-        # General approach: compute the whole coefficents, zero out the irrelevant parts
+        # General approach: compute the whole coefficients, zero out the irrelevant parts
         # NOTE: The following step assumes that there is only one set (nx, ny, nz) of derivatization
         # orders i.e. we assume that only one axis (axis 2) of `nonzero_orders` has a dimension
         # greater than 1

--- a/gbasis/evals/_deriv.py
+++ b/gbasis/evals/_deriv.py
@@ -15,16 +15,16 @@ def _eval_deriv_contractions(coords, orders, center, angmom_comps, alphas, prim_
     ----------
     coords : np.ndarray(N, 3)
         Point in space where the derivative of the Gaussian primitive is evaluated.
-        Coordinates must be given as a two dimensional array, even if one coordinate is given.
+        Coordinates must be given as a two dimensional array, even if only one point is given.
     orders : np.ndarray(3,)
         Orders of the derivative.
         Negative orders are treated as zero orders.
     center : np.ndarray(3,)
         Center of the Gaussian primitive.
     angmom_comps : np.ndarray(L, 3)
-        Component of the angular momentum that corresponds to this dimension.
+        Components of the angular momentum, :math:`(a_x, a_y, a_z)`.
         Angular momentum components must be given as a two dimensional array, even if only one
-        is given.
+        set of components is given.
     alphas : np.ndarray(K,)
         Values of the (square root of the) precisions of the primitives.
     prim_coeffs : np.ndarray(K, M)
@@ -39,14 +39,15 @@ def _eval_deriv_contractions(coords, orders, center, angmom_comps, alphas, prim_
     -------
     derivative : np.ndarray(M, L, N)
         Evaluation of the derivative at each given coordinate.
-        Array is three dimensional, where the first index corresponds to the contraction, second
-        index corresponds to the angular momentum vector, and the third index corresponds to the
-        coordinate for the evaluation.
+        Dimension 0 corresponds to the contraction, with `M` as the number of given contractions.
+        Dimension 1 corresponds to the angular momentum vector, ordered as in `angmom_comps`.
+        Dimension 2 corresponds to the point at which the derivative is evaluated, ordered as in
+        `coords`.
 
     Notes
     -----
     The input is not checked. This means that you must provide the parameters as they are specified
-    in the docstring. They must all be numpy arrays with the **correct shape**.
+    in the docstring. They must all be `numpy` arrays with the **correct shape**.
 
     Pople style basis sets are not supported. If multiple angular momentum vectors (with different
     angular momentum) and multiple contraction coefficients are provided, it is **not assumed** that

--- a/gbasis/evals/_deriv.py
+++ b/gbasis/evals/_deriv.py
@@ -75,23 +75,24 @@ def _eval_deriv_contractions(coords, orders, center, angmom_comps, alphas, prim_
     alphas = alphas[np.newaxis, :, np.newaxis, np.newaxis, np.newaxis]
     # NOTE: `prim_coeffs` will be used as a 1D array
 
+    # shift coordinates
+    coords = coords - center
     # useful variables
-    rel_coords = coords - center
-    gauss = np.exp(-alphas * rel_coords ** 2)
+    gauss = np.exp(-alphas * coords ** 2)
 
     # zeroth order (i.e. no derivatization)
     indices_noderiv = orders <= 0
 
-    zero_rel_coords = rel_coords[:, :, indices_noderiv]
+    zero_coords = coords[:, :, indices_noderiv]
     zero_angmom_comps = angmom_comps[:, :, indices_noderiv]
     zero_gauss = gauss[:, :, indices_noderiv]
 
-    zeroth_part = np.prod(zero_rel_coords ** zero_angmom_comps * zero_gauss, axis=(0, 2))
+    zeroth_part = np.prod(zero_coords ** zero_angmom_comps * zero_gauss, axis=(0, 2))
     # NOTE: `zeroth_part` now has axis 0 for primitives, axis 1 for angular momentum vector, and
     # axis 2 for coordinate
 
     deriv_part = 1
-    nonzero_rel_coords = rel_coords[:, :, ~indices_noderiv]
+    nonzero_coords = coords[:, :, ~indices_noderiv]
     nonzero_orders = orders[~indices_noderiv]
     nonzero_angmom_comps = angmom_comps[:, :, ~indices_noderiv]
     nonzero_gauss = gauss[:, :, ~indices_noderiv]
@@ -116,7 +117,7 @@ def _eval_deriv_contractions(coords, orders, center, angmom_comps, alphas, prim_
             comb(nonzero_orders, indices_herm)
             * perm(nonzero_angmom_comps, nonzero_orders - indices_herm)
             * (-alphas ** 0.5) ** indices_herm
-            * nonzero_rel_coords ** indices_angmom
+            * nonzero_coords ** indices_angmom
         )
         # zero out the appropriate terms
         indices_zero = np.where(indices_herm < np.maximum(0, nonzero_orders - nonzero_angmom_comps))
@@ -129,7 +130,7 @@ def _eval_deriv_contractions(coords, orders, center, angmom_comps, alphas, prim_
         # evaluating the hermite polynomial at different orders (in sequence) may be nice in the
         # future.
         hermite = np.sum(
-            coeffs * eval_hermite(indices_herm, alphas ** 0.5 * nonzero_rel_coords), axis=0
+            coeffs * eval_hermite(indices_herm, alphas ** 0.5 * nonzero_coords), axis=0
         )
         hermite = np.prod(hermite, axis=1)
 

--- a/gbasis/evals/_deriv.py
+++ b/gbasis/evals/_deriv.py
@@ -92,15 +92,15 @@ def _eval_deriv_contractions(coords, orders, center, angmom_comps, alphas, prim_
     # axis 2 for coordinate
 
     deriv_part = 1
-    nonzero_coords = coords[:, :, ~indices_noderiv]
     nonzero_orders = orders[~indices_noderiv]
-    nonzero_angmom_comps = angmom_comps[:, :, ~indices_noderiv]
-    nonzero_gauss = gauss[:, :, ~indices_noderiv]
-
     nonzero_orders = nonzero_orders[np.newaxis, np.newaxis, :, np.newaxis, np.newaxis]
 
     # derivatization part
     if nonzero_orders.size != 0:
+        # get nonzero arrays
+        nonzero_coords = coords[:, :, ~indices_noderiv]
+        nonzero_angmom_comps = angmom_comps[:, :, ~indices_noderiv]
+        nonzero_gauss = gauss[:, :, ~indices_noderiv]
         # General approach: compute the whole coefficients, zero out the irrelevant parts
         # NOTE: The following step assumes that there is only one set (nx, ny, nz) of derivatization
         # orders i.e. we assume that only one axis (axis 2) of `nonzero_orders` has a dimension

--- a/gbasis/evals/density.py
+++ b/gbasis/evals/density.py
@@ -13,14 +13,14 @@ def evaluate_density_using_evaluated_orbs(one_density_matrix, orb_eval):
     one_density_matrix : np.ndarray(K_orb, K_orb)
         One-electron density matrix in terms of the given orbitals.
     orb_eval : np.ndarray(K_orb, N)
-        Orbitals evaluated at different grid points.
+        Orbitals evaluated at :math:`N` grid points.
         The set of orbitals must be the same basis set used to build the one-electron density
         matrix.
 
     Returns
     -------
     density : np.ndarray(N,)
-        Density evaluated at different grid points.
+        Density evaluated at :math:`N` grid points.
 
     Raises
     ------
@@ -95,7 +95,7 @@ def evaluate_density(one_density_matrix, basis, points, transform=None, coord_ty
     Returns
     -------
     density : np.ndarray(N,)
-        Density evaluated at the given points.
+        Density evaluated at :math:`N` grid points.
 
     """
     orb_eval = evaluate_basis(basis, points, transform=transform, coord_type=coord_type)
@@ -167,7 +167,7 @@ def evaluate_deriv_reduced_density_matrix(
     Returns
     -------
     deriv_reduced_density_matrix : np.ndarray(N,)
-        Derivative of the first-order reduced density matrix evaluated at the given points.
+        Derivative of the first-order reduced density matrix evaluated at :math:`N` grid points.
 
     """
     deriv_orb_eval_one = evaluate_deriv_basis(
@@ -222,7 +222,7 @@ def evaluate_deriv_density(
     Returns
     -------
     density_deriv : np.ndarray(N,)
-        Derivative of the density evaluated at the given points.
+        Derivative of the density evaluated at :math:`N` grid points.
 
     """
     # pylint: disable=R0914
@@ -291,7 +291,7 @@ def evaluate_density_gradient(
     Returns
     -------
     density_gradient : np.ndarray(N, 3)
-        Gradient of the density evaluated at the given points.
+        Gradient of the density evaluated at :math:`N` grid points.
 
     """
     return np.array(
@@ -359,7 +359,7 @@ def evaluate_density_laplacian(
     Returns
     -------
     density_laplacian : np.ndarray(N)
-        Laplacian of the density evaluated at the given points.
+        Laplacian of the density evaluated at :math:`N` grid points.
 
     """
     output = evaluate_deriv_density(
@@ -424,7 +424,7 @@ def evaluate_density_hessian(
     Returns
     -------
     density_hessian : np.ndarray(N, 3, 3)
-        Hessian of the density evaluated at the given points.
+        Hessian of the density evaluated at :math:`N` grid points.
         Dimension 0 corresponds to the point, ordered as in `points`.
         Dimensions 1, 2 correspond to the dimensions `(x, y, z)` in which the derivative of density
         was calculated.
@@ -495,9 +495,8 @@ def evaluate_posdef_kinetic_energy_density(
     Returns
     -------
     posdef_kindetic_energy_density : np.ndarray(N,)
-        Positive definite kinetic energy density of the given transformed basis set evaluated at the
-        given points.
-
+        Positive definite kinetic energy density of the given transformed basis set evaluated at
+        :math:`N` grid points.
     """
     output = np.zeros(points.shape[0])
     for orders in np.identity(3, dtype=int):
@@ -557,8 +556,8 @@ def evaluate_general_kinetic_energy_density(
     Returns
     -------
     general_kinetic_energy_density : np.ndarray(N,)
-        General kinetic energy density of the given transformed basis set evaluated at the given
-        points.
+        General kinetic energy density of the given transformed basis set evaluated at :math:`N`
+        grid points.
 
     Raises
     ------

--- a/gbasis/evals/density.py
+++ b/gbasis/evals/density.py
@@ -497,6 +497,7 @@ def evaluate_posdef_kinetic_energy_density(
     posdef_kindetic_energy_density : np.ndarray(N,)
         Positive definite kinetic energy density of the given transformed basis set evaluated at
         :math:`N` grid points.
+
     """
     output = np.zeros(points.shape[0])
     for orders in np.identity(3, dtype=int):

--- a/gbasis/evals/density.py
+++ b/gbasis/evals/density.py
@@ -25,12 +25,12 @@ def evaluate_density_using_evaluated_orbs(one_density_matrix, orb_eval):
     Raises
     ------
     TypeError
-        If orb_eval is not a 2-dimensional numpy array with dtype float.
-        If density_matrix is not a 2-dimensional numpy array with dtype float.
+        If `orb_eval` is not a 2-dimensional `numpy` array with `dtype` float.
+        If `one_density_matrix` is not a 2-dimensional `numpy` array with `dtype` float.
     ValueError
-        If one-electron density matrix is not square.
-        If the number of columns (or rows) of the one-electron density matrix is not equal to the
-        number of rows of the orbital evaluations.
+        If `one_density_matrix` is not square.
+        If the number of columns (or rows) of `one_density_matrix` is not equal to the number of
+        rows of the orbital evaluations.
 
     """
     # test that inputs have the correct shape and type
@@ -40,11 +40,12 @@ def evaluate_density_using_evaluated_orbs(one_density_matrix, orb_eval):
         and one_density_matrix.dtype == float
     ):
         raise TypeError(
-            "One-electron density matrix must be a two-dimensional numpy array with dtype float."
+            "One-electron density matrix must be a two-dimensional `numpy` array with `dtype`"
+            " float."
         )
     if not (isinstance(orb_eval, np.ndarray) and orb_eval.ndim == 2 and orb_eval.dtype == float):
         raise TypeError(
-            "Evaluation of orbitals must be a two-dimensional numpy array with dtype float."
+            "Evaluation of orbitals must be a two-dimensional `numpy` array with `dtype` float."
         )
     if one_density_matrix.shape[0] != one_density_matrix.shape[1]:
         raise ValueError("One-electron density matrix must be a square matrix.")
@@ -62,7 +63,7 @@ def evaluate_density_using_evaluated_orbs(one_density_matrix, orb_eval):
 
 
 def evaluate_density(one_density_matrix, basis, points, transform=None, coord_type="spherical"):
-    """Return the density of the given basis set at the given coordinates.
+    r"""Return the density of the given basis set at the given points.
 
     Parameters
     ----------
@@ -73,9 +74,10 @@ def evaluate_density(one_density_matrix, basis, points, transform=None, coord_ty
     basis : list/tuple of GeneralizedContractionShell
         Shells of generalized contractions.
     points : np.ndarray(N, 3)
-        Coordinates of the points in space (in atomic units) where the basis functions are
-        evaluated.
-        Rows correspond to the points and columns correspond to the x, y, and z components.
+        Cartesian coordinates of the points in space (in atomic units) where the basis functions
+        are evaluated.
+        Rows correspond to the points and columns correspond to the :math:`x, y, \text{and} z`
+        components.
     transform : np.ndarray(K_orbs, K_cont)
         Transformation matrix from the basis set in the given coordinate system (e.g. AO) to linear
         combinations of contractions (e.g. MO).
@@ -87,7 +89,7 @@ def evaluate_density(one_density_matrix, basis, points, transform=None, coord_ty
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each GeneralizedContractionShell instance.
+        coordinate type of each `GeneralizedContractionShell` instance.
         Default value is "spherical".
 
     Returns
@@ -109,7 +111,7 @@ def evaluate_deriv_reduced_density_matrix(
     transform=None,
     coord_type="spherical",
 ):
-    r"""Return the derivative of the first-order reduced density matrix evaluated at the same point.
+    r"""Return the derivative of the first-order reduced density matrix at the given points.
 
     ..math::
 
@@ -126,17 +128,17 @@ def evaluate_deriv_reduced_density_matrix(
         \left.
         \frac{\partial^{q_x + q_y + q_z}}{\partial x_2^{q_x} \partial y_2^{q_y} \partial z_2^{q_z}}
         \phi_j(\mathbf{r}_2)
-        \right|_{\mathbf{r}_1 = \mathbf{r}_n}
+        \right|_{\mathbf{r}_2 = \mathbf{r}_n}
 
-    where :math:`\mathbf{r}_1` is the first coordinate, :math:`\mathbf{r}_2` is the second
-    coordinate, and :math:`\mathbf{r}_n` is the coordinate at which the derivative is evaluated.
+    where :math:`\mathbf{r}_1` is the first point, :math:`\mathbf{r}_2` is the second point, and
+    :math:`\mathbf{r}_n` is the point at which the derivative is evaluated.
 
     Parameters
     ----------
     orders_one : np.ndarray(3,)
-        Orders of the derivative for the first coordinate.
+        Orders of the derivative for the first point, :math:`mathbf{r}_1`.
     orders_two : np.ndarray(3,)
-        Orders of the derivative for the second coordinate.
+        Orders of the derivative for the second point, :math:`mathbf{r}_1`.
     one_density_matrix : np.ndarray(K_orbs, K_orbs)
         One-electron density matrix in terms of the given basis set.
         If the basis is transformed using `transform` keyword, then the density matrix is assumed to
@@ -144,9 +146,10 @@ def evaluate_deriv_reduced_density_matrix(
     basis : list/tuple of GeneralizedContractionShell
         Shells of generalized contractions.
     points : np.ndarray(N, 3)
-        Coordinates of the points in space (in atomic units) where the basis functions are
-        evaluated.
-        Rows correspond to the points and columns correspond to the x, y, and z components.
+        Cartesian coordinates of the points in space (in atomic units) where the basis functions
+        are evaluated.
+        Rows correspond to the points and columns correspond to the :math:`x, y, \text{and} z`
+        components.
     transform : np.ndarray(K_orbs, K_cont)
         Transformation matrix from the basis set in the given coordinate system (e.g. AO) to linear
         combinations of contractions (e.g. MO).
@@ -158,7 +161,7 @@ def evaluate_deriv_reduced_density_matrix(
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each GeneralizedContractionShell instance.
+        coordinate type of each `GeneralizedContractionShell` instance.
         Default value is "spherical".
 
     Returns
@@ -185,7 +188,7 @@ def evaluate_deriv_reduced_density_matrix(
 def evaluate_deriv_density(
     orders, one_density_matrix, basis, points, transform=None, coord_type="spherical"
 ):
-    """Return the derivative of density of the given transformed basis set at the given coordinates.
+    r"""Return the derivative of density of the given transformed basis set at the given points.
 
     Parameters
     ----------
@@ -198,9 +201,10 @@ def evaluate_deriv_density(
     basis : list/tuple of GeneralizedContractionShell
         Shells of generalized contractions.
     points : np.ndarray(N, 3)
-        Coordinates of the points in space (in atomic units) where the basis functions are
-        evaluated.
-        Rows correspond to the points and columns correspond to the x, y, and z components.
+        Cartesian coordinates of the points in space (in atomic units) where the basis functions
+        are evaluated.
+        Rows correspond to the points and columns correspond to the :math:`x, y, \text{and} z`
+        components.
     transform : np.ndarray(K_orbs, K_cont)
         Transformation matrix from the basis set in the given coordinate system (e.g. AO) to linear
         combinations of contractions (e.g. MO).
@@ -212,7 +216,7 @@ def evaluate_deriv_density(
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each GeneralizedContractionShell instance.
+        coordinate type of each `GeneralizedContractionShell` instance.
         Default value is "spherical".
 
     Returns
@@ -255,7 +259,7 @@ def evaluate_deriv_density(
 def evaluate_density_gradient(
     one_density_matrix, basis, points, transform=None, coord_type="spherical"
 ):
-    """Return the gradient of the density evaluated at the given coordinates.
+    r"""Return the gradient of the density evaluated at the given points.
 
     Parameters
     ----------
@@ -266,9 +270,10 @@ def evaluate_density_gradient(
     basis : list/tuple of GeneralizedContractionShell
         Shells of generalized contractions.
     points : np.ndarray(N, 3)
-        Coordinates of the points in space (in atomic units) where the basis functions are
-        evaluated.
-        Rows correspond to the points and columns correspond to the x, y, and z components.
+        Cartesian coordinates of the points in space (in atomic units) where the basis functions
+        are evaluated.
+        Rows correspond to the points and columns correspond to the :math:`x, y, \text{and} z`
+        components.
     transform : np.ndarray(K_orbs, K_cont)
         Transformation matrix from the basis set in the given coordinate system (e.g. AO) to linear
         combinations of contractions (e.g. MO).
@@ -280,13 +285,13 @@ def evaluate_density_gradient(
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each GeneralizedContractionShell instance.
+        coordinate type of each `GeneralizedContractionShell` instance.
         Default value is "spherical".
 
     Returns
     -------
     density_gradient : np.ndarray(N, 3)
-        Gradient of the density evaluated at the given coordinates.
+        Gradient of the density evaluated at the given points.
 
     """
     return np.array(
@@ -322,7 +327,7 @@ def evaluate_density_gradient(
 def evaluate_density_laplacian(
     one_density_matrix, basis, points, transform=None, coord_type="spherical"
 ):
-    """Return the Laplacian of the density evaluated at the given coordinates.
+    r"""Return the Laplacian of the density evaluated at the given points.
 
     Parameters
     ----------
@@ -333,9 +338,10 @@ def evaluate_density_laplacian(
     basis : list/tuple of GeneralizedContractionShell
         Shells of generalized contractions.
     points : np.ndarray(N, 3)
-        Coordinates of the points in space (in atomic units) where the basis functions are
-        evaluated.
-        Rows correspond to the points and columns correspond to the x, y, and z components.
+        Cartesian coordinates of the points in space (in atomic units) where the basis functions
+        are evaluated.
+        Rows correspond to the points and columns correspond to the :math:`x, y, \text{and} z`
+        components.
     transform : np.ndarray(K_orbs, K_cont)
         Transformation matrix from the basis set in the given coordinate system (e.g. AO) to linear
         combinations of contractions (e.g. MO).
@@ -347,13 +353,13 @@ def evaluate_density_laplacian(
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each GeneralizedContractionShell instance.
+        coordinate type of each `GeneralizedContractionShell` instance.
         Default value is "spherical".
 
     Returns
     -------
     density_laplacian : np.ndarray(N)
-        Laplacian of the density evaluated at the given coordinates.
+        Laplacian of the density evaluated at the given points.
 
     """
     output = evaluate_deriv_density(
@@ -386,7 +392,7 @@ def evaluate_density_laplacian(
 def evaluate_density_hessian(
     one_density_matrix, basis, points, transform=None, coord_type="spherical"
 ):
-    """Return the Hessian of the density evaluated at the given coordinates.
+    r"""Return the Hessian of the density evaluated at the given points.
 
     Parameters
     ----------
@@ -397,9 +403,10 @@ def evaluate_density_hessian(
     basis : list/tuple of GeneralizedContractionShell
         Shells of generalized contractions.
     points : np.ndarray(N, 3)
-        Coordinates of the points in space (in atomic units) where the basis functions are
-        evaluated.
-        Rows correspond to the points and columns correspond to the x, y, and z components.
+        Cartesian coordinates of the points in space (in atomic units) where the basis functions
+        are evaluated.
+        Rows correspond to the points and columns correspond to the :math:`x, y, \text{and} z`
+        components.
     transform : np.ndarray(K_orbs, K_cont)
         Transformation matrix from the basis set in the given coordinate system (e.g. AO) to linear
         combinations of contractions (e.g. MO).
@@ -411,15 +418,16 @@ def evaluate_density_hessian(
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each GeneralizedContractionShell instance.
+        coordinate type of each `GeneralizedContractionShell` instance.
         Default value is "spherical".
 
     Returns
     -------
     density_hessian : np.ndarray(N, 3, 3)
-        Hessian of the density evaluated at the given coordinates.
-        First index corresponds to the coordinate. Second and third indices correspond to the
-        dimension (x, y, z) with respect to which the density is derivatized.
+        Hessian of the density evaluated at the given points.
+        Dimension 0 corresponds to the point, ordered as in `points`.
+        Dimensions 1, 2 correspond to the dimensions `(x, y, z)` in which the derivative of density
+        was calculated.
 
     """
     return np.array(
@@ -443,7 +451,7 @@ def evaluate_density_hessian(
 def evaluate_posdef_kinetic_energy_density(
     one_density_matrix, basis, points, transform=None, coord_type="spherical"
 ):
-    r"""Return evaluations of positive definite kinetic energy density.
+    r"""Return evaluations of positive definite kinetic energy density at the given points.
 
     ..math::
 
@@ -466,9 +474,10 @@ def evaluate_posdef_kinetic_energy_density(
     basis : list/tuple of GeneralizedContractionShell
         Shells of generalized contractions.
     points : np.ndarray(N, 3)
-        Coordinates of the points in space (in atomic units) where the basis functions are
-        evaluated.
-        Rows correspond to the points and columns correspond to the x, y, and z components.
+        Cartesian coordinates of the points in space (in atomic units) where the basis functions
+        are evaluated.
+        Rows correspond to the points and columns correspond to the :math:`x, y, \text{and} z`
+        components.
     transform : np.ndarray(K_orbs, K_cont)
         Transformation matrix from the basis set in the given coordinate system (e.g. AO) to linear
         combinations of contractions (e.g. MO).
@@ -480,14 +489,14 @@ def evaluate_posdef_kinetic_energy_density(
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each GeneralizedContractionShell instance.
+        coordinate type of each `GeneralizedContractionShell` instance.
         Default value is "spherical".
 
     Returns
     -------
     posdef_kindetic_energy_density : np.ndarray(N,)
-        Positive definite kintic energy density of the given transformed basis set evaluated at the
-        given coordinates.
+        Positive definite kinetic energy density of the given transformed basis set evaluated at the
+        given points.
 
     """
     output = np.zeros(points.shape[0])
@@ -508,7 +517,7 @@ def evaluate_posdef_kinetic_energy_density(
 def evaluate_general_kinetic_energy_density(
     one_density_matrix, basis, points, alpha, transform=None, coord_type="spherical"
 ):
-    r"""Return evaluations of general form of the kinetic energy density.
+    r"""Return evaluations of general form of the kinetic energy density at the given points.
 
     .. math::
 
@@ -525,9 +534,10 @@ def evaluate_general_kinetic_energy_density(
     basis : list/tuple of GeneralizedContractionShell
         Shells of generalized contractions.
     points : np.ndarray(N, 3)
-        Coordinates of the points in space (in atomic units) where the basis functions are
-        evaluated.
-        Rows correspond to the points and columns correspond to the x, y, and z components.
+        Cartesian coordinates of the points in space (in atomic units) where the basis functions
+        are evaluated.
+        Rows correspond to the points and columns correspond to the :math:`x, y, \text{and} z`
+        components.
     alpha : float
         Parameter of the general form of the kinetic energy density.
     transform : np.ndarray(K_orbs, K_cont)
@@ -541,14 +551,14 @@ def evaluate_general_kinetic_energy_density(
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each GeneralizedContractionShell instance.
+        coordinate type of each `GeneralizedContractionShell` instance.
         Default value is "spherical".
 
     Returns
     -------
-    general_kindetic_energy_density : np.ndarray(N,)
-        General kintic energy density of the given transformed basis set evaluated at the given
-        coordinates.
+    general_kinetic_energy_density : np.ndarray(N,)
+        General kinetic energy density of the given transformed basis set evaluated at the given
+        points.
 
     Raises
     ------

--- a/gbasis/evals/density.py
+++ b/gbasis/evals/density.py
@@ -20,7 +20,7 @@ def evaluate_density_using_evaluated_orbs(one_density_matrix, orb_eval):
     Returns
     -------
     density : np.ndarray(N,)
-        Density evaluated at :math:`N` grid points.
+        Density evaluated at `N` grid points.
 
     Raises
     ------
@@ -95,7 +95,7 @@ def evaluate_density(one_density_matrix, basis, points, transform=None, coord_ty
     Returns
     -------
     density : np.ndarray(N,)
-        Density evaluated at :math:`N` grid points.
+        Density evaluated at `N` grid points.
 
     """
     orb_eval = evaluate_basis(basis, points, transform=transform, coord_type=coord_type)
@@ -167,7 +167,7 @@ def evaluate_deriv_reduced_density_matrix(
     Returns
     -------
     deriv_reduced_density_matrix : np.ndarray(N,)
-        Derivative of the first-order reduced density matrix evaluated at :math:`N` grid points.
+        Derivative of the first-order reduced density matrix evaluated at `N` grid points.
 
     """
     deriv_orb_eval_one = evaluate_deriv_basis(
@@ -222,7 +222,7 @@ def evaluate_deriv_density(
     Returns
     -------
     density_deriv : np.ndarray(N,)
-        Derivative of the density evaluated at :math:`N` grid points.
+        Derivative of the density evaluated at `N` grid points.
 
     """
     # pylint: disable=R0914
@@ -291,7 +291,7 @@ def evaluate_density_gradient(
     Returns
     -------
     density_gradient : np.ndarray(N, 3)
-        Gradient of the density evaluated at :math:`N` grid points.
+        Gradient of the density evaluated at `N` grid points.
 
     """
     return np.array(
@@ -359,7 +359,7 @@ def evaluate_density_laplacian(
     Returns
     -------
     density_laplacian : np.ndarray(N)
-        Laplacian of the density evaluated at :math:`N` grid points.
+        Laplacian of the density evaluated at `N` grid points.
 
     """
     output = evaluate_deriv_density(
@@ -424,7 +424,7 @@ def evaluate_density_hessian(
     Returns
     -------
     density_hessian : np.ndarray(N, 3, 3)
-        Hessian of the density evaluated at :math:`N` grid points.
+        Hessian of the density evaluated at `N` grid points.
         Dimension 0 corresponds to the point, ordered as in `points`.
         Dimensions 1, 2 correspond to the dimensions `(x, y, z)` in which the derivative of density
         was calculated.
@@ -496,7 +496,7 @@ def evaluate_posdef_kinetic_energy_density(
     -------
     posdef_kindetic_energy_density : np.ndarray(N,)
         Positive definite kinetic energy density of the given transformed basis set evaluated at
-        :math:`N` grid points.
+        `N` grid points.
 
     """
     output = np.zeros(points.shape[0])
@@ -557,7 +557,7 @@ def evaluate_general_kinetic_energy_density(
     Returns
     -------
     general_kinetic_energy_density : np.ndarray(N,)
-        General kinetic energy density of the given transformed basis set evaluated at :math:`N`
+        General kinetic energy density of the given transformed basis set evaluated at `N`
         grid points.
 
     Raises

--- a/gbasis/evals/electrostatic_potential.py
+++ b/gbasis/evals/electrostatic_potential.py
@@ -1,4 +1,4 @@
-"""Module for computing the electrostatic potential integrals."""
+"""Module for computing electrostatic potential integrals."""
 from gbasis.integrals.point_charge import point_charge_integral
 import numpy as np
 
@@ -13,7 +13,7 @@ def electrostatic_potential(
     coord_type="spherical",
     threshold_dist=0.0,
 ):
-    """Return the electrostatic potentials of the basis set in the Cartesian form.
+    r"""Return the electrostatic potentials of the basis set in the Cartesian form.
 
     Parameters
     ----------
@@ -21,15 +21,17 @@ def electrostatic_potential(
         Shells of generalized contractions.
     one_density_matrix : np.ndarray(K_orbs, K_orbs)
         One-electron density matrix in terms of the given basis set.
-        If the basis is transformed using `transform` keyword, then the density matrix is assumed to
-        be expressed with respect to the transformed basis set.
+        If the basis is transformed using `transform` keyword, then the density matrix is assumed
+        to be expressed with respect to the transformed basis set.
     points : np.ndarray(N, 3)
-        Coordinates of the points in space (in atomic units) where the basis functions are
-        evaluated.
-        Rows correspond to the points and columns correspond to the x, y, and z components.
+        Cartesian coordinates of the points in space (in atomic units) where the basis functions
+        are evaluated.
+        Rows correspond to the points and columns correspond to the :math:`x, y, \text{and} z`
+        components.
     nuclear_coords : np.ndarray(N_nuc, 3)
-        Coordinates of each atom.
-        Rows correspond to the atoms and columns correspond to the x, y, and z components.
+        Cartesian coordinates of each atom.
+        Rows correspond to the atoms and columns correspond to the :math:`x, y, \text{and} z`
+        components.
     nuclear_charges : np.ndarray(N_nuc)
         Charges of each atom.
     transform : np.ndarray(K_orbs, K_cont)
@@ -43,7 +45,7 @@ def electrostatic_potential(
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each GeneralizedContractionShell instance.
+        coordinate type of each `GeneralizedContractionShell` instance.
     threshold_dist : {float, 0.0}
         Threshold for rejecting nuclei whose distances to the points are less than the provided
         value. i.e. nuclei that are closer to the point than the threshold are discarded when
@@ -53,33 +55,35 @@ def electrostatic_potential(
     Returns
     -------
     array : np.ndarray(N)
-        Electrostatic potential evaluated at the given coordinates.
+        Electrostatic potential evaluated at the given points.
 
     Raises
     ------
     TypeError
-        If `one_density_matrix` is not a two-dimensional numpy array.
-        If `nuclear_coords` is not a two-dimensional numpy array with 3 columns.
-        If `nuclear_charges` is not a one-dimensional numpy array.
-        If `threshold_dist` is not a int/float.
+        If `one_density_matrix` is not a two-dimensional `numpy` array.
+        If `nuclear_coords` is not a two-dimensional `numpy` array with 3 columns.
+        If `nuclear_charges` is not a one-dimensional `numpy` array.
+        If `threshold_dist` is not an integer or float.
     ValueError
-        If `one_density_matrix` must be a symmetric (square) matrix.
-        If bumber of rows in `nuclear_coords` is not equal to the number of elements in
+        If `one_density_matrix` is not a symmetric (square) matrix.
+        If number of rows in `nuclear_coords` is not equal to the number of elements in
         `nuclear_charges`.
         If `threshold_dist` is less than 0.
 
     """
     # pylint: disable=R0912
     if not (isinstance(one_density_matrix, np.ndarray) and one_density_matrix.ndim == 2):
-        raise TypeError("`one_density_matrix_cart` must be given as a two-dimensional numpy array.")
+        raise TypeError(
+            "`one_density_matrix_cart` must be given as a two-dimensional `numpy` array."
+        )
     if not (
         isinstance(nuclear_coords, np.ndarray)
         and nuclear_coords.ndim == 2
         and nuclear_coords.shape[1] == 3
     ):
-        raise TypeError("`nuclear_coords` must be a two-dimensional numpy array with 3 columns.")
+        raise TypeError("`nuclear_coords` must be a two-dimensional `numpy` array with 3 columns.")
     if not (isinstance(nuclear_charges, np.ndarray) and nuclear_charges.ndim == 1):
-        raise TypeError("`nuclear_charges` must be a one-dimensional numpy array.")
+        raise TypeError("`nuclear_charges` must be a one-dimensional `numpy` array.")
 
     if not (
         one_density_matrix.shape[0] == one_density_matrix.shape[1]
@@ -92,7 +96,7 @@ def electrostatic_potential(
             "`nuclear_charges`."
         )
     if not isinstance(threshold_dist, (int, float)):
-        raise TypeError("`threshold_dist` must be a int/float.")
+        raise TypeError("`threshold_dist` must be an integer or float.")
     if threshold_dist < 0:
         raise ValueError("`threshold_dist` must be greater than or equal to zero.")
 

--- a/gbasis/evals/eval.py
+++ b/gbasis/evals/eval.py
@@ -6,9 +6,9 @@ import numpy as np
 
 
 class Eval(BaseOneIndex):
-    """Class for evaluating the Gaussian contractions and their linear combinations.
+    """Class for evaluating Gaussian contractions and their linear combinations.
 
-    The first dimension (axis 0) of the returned array is associated with a contracted Gaussian (or
+    Dimension 0 of the returned array is associated with a contracted Gaussian (or
     a linear combination of a set of Gaussians).
 
     Attributes
@@ -16,11 +16,9 @@ class Eval(BaseOneIndex):
     _axes_contractions : tuple of tuple of GeneralizedContractionShell
         Contractions that are associated with each index of the array.
         Each tuple of GeneralizedContractionShell corresponds to an index of the array.
-
-    Properties
-    ----------
     contractions : tuple of GeneralizedContractionShell
         Contractions that are associated with the first index of the array.
+        Property of `Eval`.
 
     Methods
     -------
@@ -28,34 +26,35 @@ class Eval(BaseOneIndex):
         Initialize.
     construct_array_contraction(contraction, points) : np.ndarray(M, L_cart, N)
         Return the evaluations of the given Cartesian contractions at the given coordinates.
-        `M` is the number of segmented contractions with the same exponents (and angular momentum).
-        `L_cart` is the number of Cartesian contractions for the given angular momentum.
-        `N` is the number of coordinates at which the contractions are evaluated.
+        :math:`M` is the number of segmented contractions with the same exponents (and angular
+        momentum).
+        :math:`L_cart` is the number of Cartesian contractions for the given angular momentum.
+        :math:`N` is the number of coordinates at which the contractions are evaluated.
     construct_array_cartesian(self, points) : np.ndarray(K_cart, N)
         Return the evaluations of the Cartesian contractions of the instance at the given
         coordinates.
-        `K_cart` is the total number of Cartesian contractions within the instance.
-        `N` is the number of coordinates at which the contractions are evaluated.
+        :math:`K_cart` is the total number of Cartesian contractions within the instance.
+        :math:`N` is the number of coordinates at which the contractions are evaluated.
     construct_array_spherical(self, points) : np.ndarray(K_sph, N)
         Return the evaluations of the spherical contractions of the instance at the given
         coordinates.
-        `K_sph` is the total number of spherical contractions within the instance.
-        `N` is the number of coordinates at which the contractions are evaluated.
+        :math:`K_sph` is the total number of spherical contractions within the instance.
+        :math:`N` is the number of coordinates at which the contractions are evaluated.
     construct_array_mix(self, coord_types, points) : np.ndarray(K_cont, N)
         Return the evaluatations of the contraction in the given coordinate system.
-        `K_cont` is the total number of contractions within the given basis set.
-        `N` is the number of coordinates at which the contractions are evaluated.
+        :math:`K_cont` is the total number of contractions within the given basis set.
+        :math:`N` is the number of coordinates at which the contractions are evaluated.
     construct_array_lincomb(self, transform, coord_type, points) : np.ndarray(K_orbs, N)
         Return the evaluations of the linear combinations of contractions in the given coordinate
         system.
-        `K_orbs` is the number of basis functions produced after the linear combinations.
-        `N` is the number of coordinates at which the contractions are evaluated.
+        :math:`K_orbs` is the number of basis functions produced after the linear combinations.
+        :math:`N` is the number of coordinates at which the contractions are evaluated.
 
     """
 
     @staticmethod
     def construct_array_contraction(contractions, points):
-        """Return the evaluations of the given contractions at the given coordinates.
+        r"""Return the evaluations of the given contractions at the given coordinates.
 
         Parameters
         ----------
@@ -63,27 +62,28 @@ class Eval(BaseOneIndex):
             Contracted Cartesian Gaussians (of the same shell) that will be used to construct an
             array.
         points : np.ndarray(N, 3)
-            Coordinates of the points in space (in atomic units) where the basis functions are
-            evaluated.
-            Rows correspond to the points and columns correspond to the x, y, and z components.
+            Cartesian coordinates of the points in space (in atomic units) where the basis
+            functions are evaluated.
+            Rows correspond to the points and columns correspond to the :math:`x, y, \text{and} z`
+            components.
 
         Returns
         -------
         array_contraction : np.ndarray(M, L_cart, N)
-            Evaluations of the given Cartesian contractions at the given coordinates.
-            First index corresponds to segmented contractions within the given generalized
+            Evaluations of the given Cartesian contractions at the given points.
+            Dimension 0 corresponds to segmented contractions within the given generalized
             contraction (same exponents and angular momentum, but different coefficients). `M` is
             the number of segmented contractions with the same exponents (and angular momentum).
-            Second index corresponds to angular momentum vector. `L_cart` is the number of Cartesian
+            Dimension 1 corresponds to angular momentum vector. `L_cart` is the number of Cartesian
             contractions for the given angular momentum.
-            Third index corresponds to coordinates at which the contractions are evaluated. `N` is
+            Dimension 2 corresponds to coordinates at which the contractions are evaluated. `N` is
             the number of coordinates at which the contractions are evaluated.
 
         Raises
         ------
         TypeError
-            If contractions is not a GeneralizedContractionShell instance.
-            If points is not a two-dimensional numpy array with 3 columns.
+            If contractions is not a `GeneralizedContractionShell` instance.
+            If points is not a two-dimensional `numpy` array with 3 columns.
 
         Note
         ----
@@ -94,10 +94,10 @@ class Eval(BaseOneIndex):
 
         """
         if not isinstance(contractions, GeneralizedContractionShell):
-            raise TypeError("`contractions` must be a GeneralizedContractionShell instance.")
+            raise TypeError("`contractions` must be a `GeneralizedContractionShell` instance.")
         if not (isinstance(points, np.ndarray) and points.ndim == 2 and points.shape[1] == 3):
             raise TypeError(
-                "`points` must be given as a two-dimensional numpy array with 3 columnms."
+                "`points` must be given as a two-dimensional `numpy` array with 3 columnms."
             )
 
         alphas = contractions.exps
@@ -112,16 +112,17 @@ class Eval(BaseOneIndex):
 
 
 def evaluate_basis(basis, points, transform=None, coord_type="spherical"):
-    """Evaluate the basis set in the given coordinate system at the given coordinates.
+    r"""Evaluate the basis set in the given coordinate system at the given points.
 
     Parameters
     ----------
     basis : list/tuple of GeneralizedContractionShell
         Shells of generalized contractions.
     points : np.ndarray(N, 3)
-        Coordinates of the points in space (in atomic units) where the basis functions are
-        evaluated.
-        Rows correspond to the points and columns correspond to the x, y, and z components.
+        Cartesian coordinates of the points in space (in atomic units) where the basis
+        functions are evaluated.
+        Rows correspond to the points and columns correspond to the :math:`x, y, \text{and} z`
+        components.
     transform : np.ndarray(K, K_cont)
         Transformation matrix from the basis set in the given coordinate system (e.g. AO) to linear
         combinations of contractions (e.g. MO).
@@ -133,17 +134,17 @@ def evaluate_basis(basis, points, transform=None, coord_type="spherical"):
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each GeneralizedContractionShell instance.
+        coordinate type of each `GeneralizedContractionShell` instance.
         Default value is "spherical".
 
     Returns
     -------
     eval_array : np.ndarray(K, N)
-        Evaluations of the basis functions at the given coordinates.
+        Evaluations of the basis functions at the given points.
         If keyword argument `transform` is provided, then the transformed basis functions will be
-        evaluted at the given points.
-        `K` is the total number of basis functions within the given basis set.
-        `N` is the number of coordinates at which the contractions are evaluated.
+        evaluated at the given points.
+        :math:`K` is the total number of basis functions within the given basis set.
+        :math:`N` is the number of coordinates at which the contractions are evaluated.
 
     """
     if transform is not None:

--- a/gbasis/evals/eval.py
+++ b/gbasis/evals/eval.py
@@ -26,29 +26,29 @@ class Eval(BaseOneIndex):
         Initialize.
     construct_array_contraction(contraction, points) : np.ndarray(M, L_cart, N)
         Return the evaluations of the given Cartesian contractions at the given coordinates.
-        :math:`M` is the number of segmented contractions with the same exponents (and angular
+        `M` is the number of segmented contractions with the same exponents (and angular
         momentum).
-        :math:`L_cart` is the number of Cartesian contractions for the given angular momentum.
-        :math:`N` is the number of coordinates at which the contractions are evaluated.
+        `L_cart` is the number of Cartesian contractions for the given angular momentum.
+        `N` is the number of coordinates at which the contractions are evaluated.
     construct_array_cartesian(self, points) : np.ndarray(K_cart, N)
         Return the evaluations of the Cartesian contractions of the instance at the given
         coordinates.
-        :math:`K_cart` is the total number of Cartesian contractions within the instance.
-        :math:`N` is the number of coordinates at which the contractions are evaluated.
+        `K_cart` is the total number of Cartesian contractions within the instance.
+        `N` is the number of coordinates at which the contractions are evaluated.
     construct_array_spherical(self, points) : np.ndarray(K_sph, N)
         Return the evaluations of the spherical contractions of the instance at the given
         coordinates.
-        :math:`K_sph` is the total number of spherical contractions within the instance.
-        :math:`N` is the number of coordinates at which the contractions are evaluated.
+        `K_sph` is the total number of spherical contractions within the instance.
+        `N` is the number of coordinates at which the contractions are evaluated.
     construct_array_mix(self, coord_types, points) : np.ndarray(K_cont, N)
         Return the evaluatations of the contraction in the given coordinate system.
-        :math:`K_cont` is the total number of contractions within the given basis set.
-        :math:`N` is the number of coordinates at which the contractions are evaluated.
+        `K_cont` is the total number of contractions within the given basis set.
+        `N` is the number of coordinates at which the contractions are evaluated.
     construct_array_lincomb(self, transform, coord_type, points) : np.ndarray(K_orbs, N)
         Return the evaluations of the linear combinations of contractions in the given coordinate
         system.
-        :math:`K_orbs` is the number of basis functions produced after the linear combinations.
-        :math:`N` is the number of coordinates at which the contractions are evaluated.
+        `K_orbs` is the number of basis functions produced after the linear combinations.
+        `N` is the number of coordinates at which the contractions are evaluated.
 
     """
 
@@ -143,8 +143,8 @@ def evaluate_basis(basis, points, transform=None, coord_type="spherical"):
         Evaluations of the basis functions at the given points.
         If keyword argument `transform` is provided, then the transformed basis functions will be
         evaluated at the given points.
-        :math:`K` is the total number of basis functions within the given basis set.
-        :math:`N` is the number of coordinates at which the contractions are evaluated.
+        `K` is the total number of basis functions within the given basis set.
+        `N` is the number of coordinates at which the contractions are evaluated.
 
     """
     if transform is not None:

--- a/gbasis/evals/eval.py
+++ b/gbasis/evals/eval.py
@@ -97,7 +97,7 @@ class Eval(BaseOneIndex):
             raise TypeError("`contractions` must be a `GeneralizedContractionShell` instance.")
         if not (isinstance(points, np.ndarray) and points.ndim == 2 and points.shape[1] == 3):
             raise TypeError(
-                "`points` must be given as a two-dimensional `numpy` array with 3 columnms."
+                "`points` must be given as a two-dimensional `numpy` array with 3 columns."
             )
 
         alphas = contractions.exps

--- a/gbasis/evals/eval_deriv.py
+++ b/gbasis/evals/eval_deriv.py
@@ -27,29 +27,29 @@ class EvalDeriv(BaseOneIndex):
         Initialize.
     construct_array_contraction(contraction, points, orders) : np.ndarray(M, L_cart, N)
         Return the evaluations of the given Cartesian contractions at the given coordinates.
-        :math:`M` is the number of segmented contractions with the same exponents (and angular
+        `M` is the number of segmented contractions with the same exponents (and angular
         momentum).
-        :math:`L_cart` is the number of Cartesian contractions for the given angular momentum.
-        :math:`N` is the number of coordinates at which the contractions are evaluated.
+        `L_cart` is the number of Cartesian contractions for the given angular momentum.
+        `N` is the number of coordinates at which the contractions are evaluated.
     construct_array_cartesian(self, points, orders) : np.ndarray(K_cart, N)
         Return the evaluations of the derivatives of the Cartesian contractions of the instance at
         the given coordinates.
-        :math:`K_cart` is the total number of Cartesian contractions within the instance.
-        :math:`N` is the number of coordinates at which the contractions are evaluated.
+        `K_cart` is the total number of Cartesian contractions within the instance.
+        `N` is the number of coordinates at which the contractions are evaluated.
     construct_array_spherical(self, points, orders) : np.ndarray(K_sph, N)
         Return the evaluations of the derivatives of the spherical contractions of the instance at
         the given coordinates.
-        :math:`K_sph` is the total number of spherical contractions within the instance.
-        :math:`N` is the number of coordinates at which the contractions are evaluated.
+        `K_sph` is the total number of spherical contractions within the instance.
+        `N` is the number of coordinates at which the contractions are evaluated.
     construct_array_mix(self, coord_types, points, orders) : np.ndarray(K_cont, N)
         Return the array associated with all of the contraction in the given coordinate system.
-        :math:`K_cont` is the total number of contractions within the given basis set.
-        :math:`N` is the number of coordinates at which the contractions are evaluated.
+        `K_cont` is the total number of contractions within the given basis set.
+        `N` is the number of coordinates at which the contractions are evaluated.
     construct_array_lincomb(self, transform, coord_type, points, orders) : np.ndarray(K_orbs, N)
         Return the evaluation of derivatives of the  linear combinations of contractions in the
         given coordinate system.
-        :math:`K_orbs` is the number of basis functions produced after the linear combinations.
-        :math:`N` is the number of coordinates at which the contractions are evaluated.
+        `K_orbs` is the number of basis functions produced after the linear combinations.
+        `N` is the number of coordinates at which the contractions are evaluated.
 
     """
 
@@ -163,8 +163,8 @@ def evaluate_deriv_basis(basis, points, orders, transform=None, coord_type="sphe
         Evaluations of the derivative of the basis functions at the given points.
         If keyword argument `transform` is provided, then the transformed basis functions will be
         evaluated at the given points.
-        :math:`K` is the total number of basis functions within the given basis set.
-        :math:`N` is the number of coordinates at which the contractions are evaluated.
+        `K` is the total number of basis functions within the given basis set.
+        `N` is the number of coordinates at which the contractions are evaluated.
 
     """
     if transform is not None:

--- a/gbasis/evals/eval_deriv.py
+++ b/gbasis/evals/eval_deriv.py
@@ -6,21 +6,20 @@ import numpy as np
 
 
 class EvalDeriv(BaseOneIndex):
-    """Class for evaluating the Gaussian contractions and their linear combinations.
+    """Class for evaluating Gaussian contractions and their linear combinations.
 
-    The first dimension (axis 0) of the returned array is associated with a contracted Gaussian (or
+    Dimension 0 of the returned array is associated with a contracted Gaussian (or
     a linear combination of a set of Gaussians).
 
     Attributes
     ----------
     _axes_contractions : tuple of tuple of GeneralizedContractionShell
         Contractions that are associated with each index of the array.
-        Each tuple of GeneralizedContractionShell corresponds to an index of the array.
-
-    Properties
-    ----------
+        Each tuple of `GeneralizedContractionShell` corresponds to an index of the array.
     contractions : tuple of GeneralizedContractionShell
         Contractions that are associated with the first index of the array.
+        Property of `EvalDeriv`.
+
 
     Methods
     -------
@@ -28,34 +27,35 @@ class EvalDeriv(BaseOneIndex):
         Initialize.
     construct_array_contraction(contraction, points, orders) : np.ndarray(M, L_cart, N)
         Return the evaluations of the given Cartesian contractions at the given coordinates.
-        `M` is the number of segmented contractions with the same exponents (and angular momentum).
-        `L_cart` is the number of Cartesian contractions for the given angular momentum.
-        `N` is the number of coordinates at which the contractions are evaluated.
+        :math:`M` is the number of segmented contractions with the same exponents (and angular
+        momentum).
+        :math:`L_cart` is the number of Cartesian contractions for the given angular momentum.
+        :math:`N` is the number of coordinates at which the contractions are evaluated.
     construct_array_cartesian(self, points, orders) : np.ndarray(K_cart, N)
         Return the evaluations of the derivatives of the Cartesian contractions of the instance at
         the given coordinates.
-        `K_cart` is the total number of Cartesian contractions within the instance.
-        `N` is the number of coordinates at which the contractions are evaluated.
+        :math:`K_cart` is the total number of Cartesian contractions within the instance.
+        :math:`N` is the number of coordinates at which the contractions are evaluated.
     construct_array_spherical(self, points, orders) : np.ndarray(K_sph, N)
         Return the evaluations of the derivatives of the spherical contractions of the instance at
         the given coordinates.
-        `K_sph` is the total number of spherical contractions within the instance.
-        `N` is the number of coordinates at which the contractions are evaluated.
+        :math:`K_sph` is the total number of spherical contractions within the instance.
+        :math:`N` is the number of coordinates at which the contractions are evaluated.
     construct_array_mix(self, coord_types, points, orders) : np.ndarray(K_cont, N)
         Return the array associated with all of the contraction in the given coordinate system.
-        `K_cont` is the total number of contractions within the given basis set.
-        `N` is the number of coordinates at which the contractions are evaluated.
+        :math:`K_cont` is the total number of contractions within the given basis set.
+        :math:`N` is the number of coordinates at which the contractions are evaluated.
     construct_array_lincomb(self, transform, coord_type, points, orders) : np.ndarray(K_orbs, N)
-        Return the evaluatiosn of derivatives of the  linear combinations of contractions in the
+        Return the evaluation of derivatives of the  linear combinations of contractions in the
         given coordinate system.
-        `K_orbs` is the number of basis functions produced after the linear combinations.
-        `N` is the number of coordinates at which the contractions are evaluated.
+        :math:`K_orbs` is the number of basis functions produced after the linear combinations.
+        :math:`N` is the number of coordinates at which the contractions are evaluated.
 
     """
 
     @staticmethod
     def construct_array_contraction(contractions, points, orders):
-        """Return the array associated with a set of contracted Cartesian Gaussians.
+        r"""Return the array associated with a set of contracted Cartesian Gaussians.
 
         Parameters
         ----------
@@ -63,9 +63,10 @@ class EvalDeriv(BaseOneIndex):
             Contracted Cartesian Gaussians (of the same shell) that will be used to construct an
             array.
         points : np.ndarray(N, 3)
-            Coordinates of the points in space (in atomic units) where the basis functions are
-            evaluated.
-            Rows correspond to the points and columns correspond to the x, y, and z components.
+            Cartesian coordinates of the points in space (in atomic units) where the basis
+            functions are evaluated.
+            Rows correspond to the points and columns correspond to the :math:`x, y, \text{and} z`
+            components.
         orders : np.ndarray(3,)
             Orders of the derivative.
 
@@ -73,23 +74,23 @@ class EvalDeriv(BaseOneIndex):
         -------
         array_contraction : np.ndarray(M, L_cart, N)
             Array associated with the given instance(s) of GeneralizedContractionShell.
-            First index corresponds to segmented contractions within the given generalized
+            Dimension 0 corresponds to segmented contractions within the given generalized
             contraction (same exponents and angular momentum, but different coefficients). `M` is
             the number of segmented contractions with the same exponents (and angular momentum).
-            Second index corresponds to angular momentum vector. `L_cart` is the number of Cartesian
+            Dimension 1 corresponds to angular momentum vector. `L_cart` is the number of Cartesian
             contractions for the given angular momentum.
-            Third index corresponds to coordinates at which the contractions are evaluated. `N` is
+            Dimension 2 corresponds to coordinates at which the contractions are evaluated. `N` is
             the number of coordinates at which the contractions are evaluated.
 
         Raises
         ------
         TypeError
-            If contractions is not a GeneralizedContractionShell instance.
-            If points is not a two-dimensional numpy array with 3 columns.
-            If orders is not a one-dimensional numpy array with 3 elements.
+            If contractions is not a `GeneralizedContractionShell` instance.
+            If points is not a two-dimensional `numpy` array with 3 columns.
+            If orders is not a one-dimensional `numpy` array with 3 elements.
         ValueError
             If orders has any negative numbers.
-            If orders does not have dtype int.
+            If orders does not have `dtype` int.
 
         Note
         ----
@@ -100,14 +101,14 @@ class EvalDeriv(BaseOneIndex):
 
         """
         if not isinstance(contractions, GeneralizedContractionShell):
-            raise TypeError("`contractions` must be a GeneralizedContractionShell instance.")
+            raise TypeError("`contractions` must be a `GeneralizedContractionShell` instance.")
         if not (isinstance(points, np.ndarray) and points.ndim == 2 and points.shape[1] == 3):
             raise TypeError(
-                "`points` must be given as a two-dimensional numpy array with 3 columnms."
+                "`points` must be given as a two-dimensional `numpy` array with 3 columns."
             )
         if not (isinstance(orders, np.ndarray) and orders.shape == (3,)):
             raise TypeError(
-                "Orders of the derivatives must be a one-dimensional numpy array with 3 elements."
+                "Orders of the derivatives must be a one-dimensional `numpy` array with 3 elements."
             )
         if np.any(orders < 0):
             raise ValueError("Negative order of derivative is not supported.")
@@ -126,16 +127,17 @@ class EvalDeriv(BaseOneIndex):
 
 
 def evaluate_deriv_basis(basis, points, orders, transform=None, coord_type="spherical"):
-    """Evaluate the derivative of basis set in the given coordinate system at the given coordinates.
+    r"""Evaluate the derivative of the basis set in the given coordinate system at the given points.
 
     Parameters
     ----------
     basis : list/tuple of GeneralizedContractionShell
         Shells of generalized contractions.
     points : np.ndarray(N, 3)
-        Coordinates of the points in space (in atomic units) where the basis functions are
-        evaluated.
-        Rows correspond to the points and columns correspond to the x, y, and z components.
+        Cartesian coordinates of the points in space (in atomic units) where the basis functions
+        are evaluated.
+        Rows correspond to the points and columns correspond to the :math:`x, y, \text{and} z`
+        components.
     orders : np.ndarray(3,)
         Orders of the derivative.
         First element corresponds to the order of the derivative with respect to x.
@@ -158,11 +160,11 @@ def evaluate_deriv_basis(basis, points, orders, transform=None, coord_type="sphe
     Returns
     -------
     eval_array : np.ndarray(K, N)
-        Evaluations of the derivative of the basis functions at the given coordinates.
+        Evaluations of the derivative of the basis functions at the given points.
         If keyword argument `transform` is provided, then the transformed basis functions will be
-        evaluted at the given points.
-        `K` is the total number of basis functions within the given basis set.
-        `N` is the number of coordinates at which the contractions are evaluated.
+        evaluated at the given points.
+        :math:`K` is the total number of basis functions within the given basis set.
+        :math:`N` is the number of coordinates at which the contractions are evaluated.
 
     """
     if transform is not None:

--- a/gbasis/evals/stress_tensor.py
+++ b/gbasis/evals/stress_tensor.py
@@ -1,4 +1,4 @@
-"""Module for computing properties related to stress tensor."""
+"""Module for computing properties related to the stress tensor."""
 from gbasis.evals.density import (
     evaluate_density_laplacian,
     evaluate_deriv_density,
@@ -15,6 +15,7 @@ def evaluate_stress_tensor(
 
     Stress tensor is defined here as:
     .. math::
+
         \boldsymbol{\sigma}_{ij}(\mathbf{r}_n | \alpha, \beta)
         =&
         -\frac{1}{2} \alpha
@@ -54,9 +55,10 @@ def evaluate_stress_tensor(
     basis : list/tuple of GeneralizedContractionShell
         Shells of generalized contractions.
     points : np.ndarray(N, 3)
-        Coordinates of the points in space (in atomic units) where the basis functions are
-        evaluated.
-        Rows correspond to the points and columns correspond to the x, y, and z components.
+        Cartesian coordinates of the points in space (in atomic units) where the basis
+        functions are evaluated.
+        Rows correspond to the points and columns correspond to the :math:`x, y, \text{and} z`
+        components.
     transform : np.ndarray(K_orbs, K_cont)
         Transformation matrix from the basis set in the given coordinate system (e.g. AO) to linear
         combinations of contractions (e.g. MO).
@@ -74,13 +76,13 @@ def evaluate_stress_tensor(
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each GeneralizedContractionShell instance.
+        coordinate type of each `GeneralizedContractionShell` instance.
         Default value is "spherical".
 
     Returns
     -------
     stress_tensor : np.ndarray(N, 3, 3)
-        Stress tensor of the given density matrix evaluated at the given coordinates.
+        Stress tensor of the given density matrix evaluated at the given points.
 
     Raises
     ------
@@ -179,9 +181,10 @@ def evaluate_ehrenfest_force(
     basis : list/tuple of GeneralizedContractionShell
         Shells of generalized contractions.
     points : np.ndarray(N, 3)
-        Coordinates of the points in space (in atomic units) where the basis functions are
-        evaluated.
-        Rows correspond to the points and columns correspond to the x, y, and z components.
+        Cartesian coordinates of the points in space (in atomic units) where the basis
+        functions are evaluated.
+        Rows correspond to the points and columns correspond to the :math:`x, y, \text{and} z`
+        components.
     transform : np.ndarray(K_orbs, K_cont)
         Transformation matrix from the basis set in the given coordinate system (e.g. AO) to linear
         combinations of contractions (e.g. MO).
@@ -199,7 +202,7 @@ def evaluate_ehrenfest_force(
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each GeneralizedContractionShell instance.
+        coordinate type of each `GeneralizedContractionShell` instance.
         Default value is "spherical".
 
     Returns
@@ -330,9 +333,10 @@ def evaluate_ehrenfest_hessian(
     basis : list/tuple of GeneralizedContractionShell
         Shells of generalized contractions.
     points : np.ndarray(N, 3)
-        Coordinates of the points in space (in atomic units) where the basis functions are
-        evaluated.
-        Rows correspond to the points and columns correspond to the x, y, and z components.
+        Cartesian coordinates of the points in space (in atomic units) where the basis
+        functions are evaluated.
+        Rows correspond to the points and columns correspond to the :math:`x, y, \text{and} z`
+        components.
     transform : np.ndarray(K_orbs, K_cont)
         Transformation matrix from the basis set in the given coordinate system (e.g. AO) to linear
         combinations of contractions (e.g. MO).
@@ -350,18 +354,18 @@ def evaluate_ehrenfest_hessian(
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each GeneralizedContractionShell instance.
+        coordinate type of each `GeneralizedContractionShell` instance.
         Default value is "spherical".
     symmetric : {True, False}
-        Flag for symmeterizing the Hessian.
-        If True, then the Hessian is symmeterized by averaging it with its transpose.
+        Flag for symmetrizing the Hessian.
+        If True, then the Hessian is symmetrized by averaging it with its transpose.
         Default value is False.
 
     Returns
     -------
     ehrenfest_hessian : np.ndarray(N, 3, 3)
         Ehrenfest Hessian of the given density matrix evaluated at the given coordinates.
-        Hessian is symmeterized if `symmetric` is True.
+        Hessian is symmetrized if `symmetric` is True.
 
     Raises
     ------

--- a/gbasis/integrals/_diff_operator_int.py
+++ b/gbasis/integrals/_diff_operator_int.py
@@ -1,4 +1,4 @@
-"""Integral over differential operator involving Contracted Cartesian Gaussians."""
+"""Integrals over differential operator involving contracted Cartesian Gaussians."""
 from gbasis.integrals._moment_int import (
     _cleanup_intermediate_integrals,
     _compute_multipole_moment_integrals_intermediate,
@@ -10,15 +10,15 @@ import numpy as np
 def _compute_differential_operator_integrals_intermediate(
     order_diff_max, coord_a, angmom_a_max, exps_a, coord_b, angmom_b_max, exps_b
 ):
-    """Return the intermediate integrals over differential operators of two contractions.
+    r"""Return the intermediate integrals over differential operators of two contractions.
 
     # TODO: equation
 
     Parameters
     ----------
     order_diff_max : int
-        Maximum order of differentation at which the recursion will stop.
-        From a set of orders of differentations, it should be the maximum order of differentiation
+        Maximum order of differentiation at which the recursion will stop.
+        From a set of orders of differentiations, it should be the maximum order of differentiation
         along all dimensions.
         Zeroth order differentiation (i.e. overlap) is not supported.
     coord_a : np.ndarray(3,)
@@ -31,7 +31,7 @@ def _compute_differential_operator_integrals_intermediate(
     coeffs_a : np.ndarray(K_a, M_a)
         Contraction coefficients of the primitives on the left side.
         The coefficients always correspond to generalized contractions, i.e. two-dimensional array
-        where the first index corresponds to the primitive and the second index corresponds to the
+        where dimension 0 corresponds to the primitive and dimension 1 corresponds to the
         contraction (with the same exponents and angular momentum).
     norm_a : np.ndarray(L_a, K_a)
         Normalization constants for the primitives in each contraction on the left side.
@@ -45,7 +45,7 @@ def _compute_differential_operator_integrals_intermediate(
     coeffs_b : np.ndarray(K_b, M_b)
         Contraction coefficients of the primitives on the right side.
         The coefficients always correspond to generalized contractions, i.e. two-dimensional array
-        where the first index corresponds to the primitive and the second index corresponds to the
+        where dimension 0 corresponds to the primitive and dimension 1 corresponds to the
         contraction (with the same exponents and angular momentum).
     norm_b : np.ndarray(L_b, K_b)
         Normalization constants for the primitives in each contraction on the right side.
@@ -63,14 +63,14 @@ def _compute_differential_operator_integrals_intermediate(
         Dimension 2 corresponds to the angular momentum component of contraction a in the
         corresponding coordinate. `max_a` is the maximum angular momentum component for the left
         side, i.e. `angmom_a_max`.
-        Dimension 3 corresponds to the coordinate dimension, i.e. x, y, and z.
+        Dimension 3 corresponds to the coordinate dimension, i.e. :math:`x, y, \text{and} z`.
         Dimension 4 corresponds to the index for the primitive in contraction b.
         Dimension 5 corresponds to the index for the primitive in contraction a.
 
     Raises
     ------
     IndexError
-        If the `orders_diff` is all zeros, i.e. `(0, 0, 0)`.
+        If the `orders_diff` is all zeros, i.e. :math:`(0, 0, 0)`.
 
     """
     # pylint: disable=R0914
@@ -139,7 +139,7 @@ def _compute_differential_operator_integrals(
     coeffs_b,
     norm_b,
 ):
-    """Return the integrals over differential operators of two contractions.
+    r"""Return the integrals over differential operators of two contractions.
 
     Parameters
     ----------
@@ -151,7 +151,8 @@ def _compute_differential_operator_integrals(
     coord_a : np.ndarray(3,)
         Center of the contraction on the left side.
     angmoms_a : np.ndarray(L_a, 3)
-        Angular momentum vectors (lx, ly, lz) for the contractions on the left side.
+        Angular momentum vectors :math:`(\ell_x, \ell_y, \ell_z)` for the contractions on the left
+        side.
         Note that a two dimensional array must be given, even if there is only one angular momentum
         vector.
     exps_a : np.ndarray(K_a,)
@@ -159,14 +160,15 @@ def _compute_differential_operator_integrals(
     coeffs_a : np.ndarray(K_a, M_a)
         Contraction coefficients of the primitives on the left side.
         The coefficients always correspond to generalized contractions, i.e. two-dimensional array
-        where the first index corresponds to the primitive and the second index corresponds to the
+        where dimension 0 corresponds to the primitive and dimension 1 corresponds to the
         contraction (with the same exponents and angular momentum).
     norm_a : np.ndarray(L_a, K_a)
         Normalization constants for the primitives in each contraction on the left side.
     coord_b : np.ndarray(3,)
         Center of the contraction on the right side.
     angmoms_b : np.ndarray(L_b, 3)
-        Angular momentum vectors (lx, ly, lz) for the contractions on the right side.
+        Angular momentum vectors :math:`(\ell_x, \ell_y, \ell_z)` for the contractions on the right
+        side.
         Note that a two dimensional array must be given, even if there is only one angular momentum
         vector.
     exps_b : np.ndarray(K_b,)
@@ -200,7 +202,7 @@ def _compute_differential_operator_integrals(
     Raises
     ------
     IndexError
-        If the `orders_diff` is all zeros, i.e. `(0, 0, 0)`.
+        If the `orders_diff` is all zeros, i.e. :math:`(0, 0, 0)`.
 
     """
     integrals = _compute_differential_operator_integrals_intermediate(

--- a/gbasis/integrals/_diff_operator_int.py
+++ b/gbasis/integrals/_diff_operator_int.py
@@ -70,7 +70,7 @@ def _compute_differential_operator_integrals_intermediate(
     Raises
     ------
     IndexError
-        If the `orders_diff` is all zeros, i.e. :math:`(0, 0, 0)`.
+        If the `orders_diff` is all zeros, i.e. `(0, 0, 0)`.
 
     """
     # pylint: disable=R0914
@@ -202,7 +202,7 @@ def _compute_differential_operator_integrals(
     Raises
     ------
     IndexError
-        If the `orders_diff` is all zeros, i.e. :math:`(0, 0, 0)`.
+        If the `orders_diff` is all zeros, i.e. `(0, 0, 0)`.
 
     """
     integrals = _compute_differential_operator_integrals_intermediate(

--- a/gbasis/integrals/_moment_int.py
+++ b/gbasis/integrals/_moment_int.py
@@ -6,7 +6,7 @@ import numpy as np
 def _compute_multipole_moment_integrals_intermediate(
     coord_moment, order_moment_max, coord_a, angmom_a_max, exps_a, coord_b, angmom_b_max, exps_b
 ):
-    """Return the intermediate multipole moment integrals of two contractions.
+    r"""Return the intermediate multipole moment integrals of two contractions.
 
     # TODO: equation
 
@@ -35,23 +35,6 @@ def _compute_multipole_moment_integrals_intermediate(
 
     Returns
     -------
-    integrals : np.ndarray(D, M_a, L_a, M_b, L_b)
-        Multipole moment integrals associated with the given orders of moments and angular momentum
-        vectors (contractions).
-        First index corresponds to the order of the moment. `D` is the number of moments given.
-        Second index corresponds to segmented contractions within the given generalized contraction
-        `a`, (same exponents and angular momentum but different coefficients). `M_a` is the number
-        of segmented contractions.
-        Third index corresponds to the angular momentum vector a segmented contraction of
-        generalized contraction `a`. `L_a` is the number of angular momentum vectors.
-        Fourth index corresponds to segmented contractions within the given generalized contraction
-        `b`, (same exponents and angular momentum but different coefficients). `M_b` is the number
-        of segmented contractions.
-        Fifth index corresponds to the angular momentum vector a segmented contraction of
-        generalized contraction `b`. `L_b` is the number of angular momentum vectors.
-
-    Returns
-    -------
     integrals : np.ndarray(max_d + 1, max_b + 1, max_a + 1, 3, K_b, K_a)
         Intermediate integrals for each moment order, angular momentum component, and coordinate.
         Dimension 0 corresponds to the order of the moments along the corresponding coordinate.
@@ -62,7 +45,7 @@ def _compute_multipole_moment_integrals_intermediate(
         Dimension 2 corresponds to the angular momentum component of contraction a in the
         corresponding coordinate. `max_a` is the maximum angular momentum component for the left
         side, i.e. `angmom_a_max`.
-        Dimension 3 corresponds to the coordinate dimension, i.e. x, y, and z.
+        Dimension 3 corresponds to the coordinate dimension, i.e. :math:`x, y, \text{and} z`.
         Dimension 4 corresponds to the index for the primitive in contraction b.
         Dimension 5 corresponds to the index for the primitive in contraction a.
 
@@ -160,7 +143,7 @@ def _compute_multipole_moment_integrals_intermediate(
 def _cleanup_intermediate_integrals(
     intermediate_integrals, orders, angmoms_a, coeffs_a, norm_a, angmoms_b, coeffs_b, norm_b
 ):
-    """Return the intermediate integrals after selecting the appropriate components and normalizing.
+    r"""Return the intermediate integrals after selecting appropriate components and normalizing.
 
     Parameters
     ----------
@@ -174,31 +157,33 @@ def _cleanup_intermediate_integrals(
         Dimension 2 corresponds to the angular momentum component of contraction a in the
         corresponding coordinate. `max_a` is the maximum angular momentum component for the left
         side, i.e. `angmom_a_max`.
-        Dimension 3 corresponds to the coordinate dimension, i.e. x, y, and z.
+        Dimension 3 corresponds to the coordinate dimension, i.e. `x`, `y`, and `z`.
         Dimension 4 corresponds to the index for the primitive in contraction b.
         Dimension 5 corresponds to the index for the primitive in contraction a.
     orders : np.ndarray(D, 3)
-        Orders for each dimension (x, y, z).
+        Orders for each dimension :math:`(x, y, z)`.
         Note that a two dimensional array must be given, even if there is only one set of orders.
     angmoms_a : np.ndarray(L_a, 3)
-        Angular momentum vectors (lx, ly, lz) for the contractions on the left side.
+        Angular momentum vectors :math:`(\ell_x, \ell_y, \ell_z)` for the contractions on the left
+        side.
         Note that a two dimensional array must be given, even if there is only one angular momentum
         vector.
     coeffs_a : np.ndarray(K_a, M_a)
         Contraction coefficients of the primitives on the left side.
         The coefficients always correspond to generalized contractions, i.e. two-dimensional array
-        where the first index corresponds to the primitive and the second index corresponds to the
+        where dimension 0 corresponds to the primitive and dimension 1 corresponds to the
         contraction (with the same exponents and angular momentum).
     norm_a : np.ndarray(L_a, K_a)
         Normalization constants for the primitives in each contraction on the left side.
     angmoms_b : np.ndarray(L_b, 3)
-        Angular momentum vectors (lx, ly, lz) for the contractions on the right side.
+        Angular momentum vectors :math:`(\ell_x, \ell_y, \ell_z)` for the contractions on the right
+        side.
         Note that a two dimensional array must be given, even if there is only one angular momentum
         vector.
     coeffs_b : np.ndarray(K_b, M_b)
         Contraction coefficients of the primitives on the right side.
         The coefficients always correspond to generalized contractions, i.e. two-dimensional array
-        where the first index corresponds to the primitive and the second index corresponds to the
+        where dimension 0 corresponds to the primitive and dimension 1 corresponds to the
         contraction (with the same exponents and angular momentum).
     norm_b : np.ndarray(L_b, K_b)
         Normalization constants for the primitives in each contraction on the right side.
@@ -229,7 +214,7 @@ def _cleanup_intermediate_integrals(
         np.arange(3)[np.newaxis, np.newaxis, np.newaxis, :],
     ]
 
-    # multiply the x, y, and z components together
+    # multiply the `x`, `y`, and `z` components together
     integrals = np.prod(integrals, axis=3)
     # NOTE: axis 3 for dimension (x, y, z) of the coordinate has been removed
 
@@ -269,20 +254,21 @@ def _compute_multipole_moment_integrals(
     coeffs_b,
     norm_b,
 ):
-    """Return the multipole moment integrals of two contractions.
+    r"""Return the multipole moment integrals of two contractions.
 
     Parameters
     ----------
     coord_moment : np.ndarray(3,)
         Center of the moment.
     orders_moment : np.ndarray(D, 3)
-        Orders of the moment for each dimension (x, y, z).
+        Orders of the moment for each dimension :math:`(x, y, z)`.
         Note that a two dimensional array must be given, even if there is only one set of orders of
         the moment.
     coord_a : np.ndarray(3,)
         Center of the contraction on the left side.
     angmoms_a : np.ndarray(L_a, 3)
-        Angular momentum vectors (lx, ly, lz) for the contractions on the left side.
+        Angular momentum vectors :math:`(\ell_x, \ell_y, \ell_z)` for the contractions on the left
+        side.
         Note that a two dimensional array must be given, even if there is only one angular momentum
         vector.
     exps_a : np.ndarray(K_a,)
@@ -297,7 +283,8 @@ def _compute_multipole_moment_integrals(
     coord_b : np.ndarray(3,)
         Center of the contraction on the right side.
     angmoms_b : np.ndarray(L_b, 3)
-        Angular momentum vectors (lx, ly, lz) for the contractions on the right side.
+        Angular momentum vectors :math:`(\ell_x, \ell_y, \ell_z)` for the contractions on the right
+        side.
         Note that a two dimensional array must be given, even if there is only one angular momentum
         vector.
     exps_b : np.ndarray(K_b,)
@@ -305,7 +292,7 @@ def _compute_multipole_moment_integrals(
     coeffs_b : np.ndarray(K_b, M_b)
         Contraction coefficients of the primitives on the right side.
         The coefficients always correspond to generalized contractions, i.e. two-dimensional array
-        where the first index corresponds to the primitive and the second index corresponds to the
+        where dimension 0 corresponds to the primitive and dimension 1 corresponds to the
         contraction (with the same exponents and angular momentum).
     norm_b : np.ndarray(L_b, K_b)
         Normalization constants for the primitives in each contraction on the right side.

--- a/gbasis/integrals/_one_elec_int.py
+++ b/gbasis/integrals/_one_elec_int.py
@@ -26,51 +26,52 @@ def _compute_one_elec_integrals(
     boys_func : function(orders, weighted_dist)
         Boys function used to evaluate the one-electron integral.
         `orders` is the orders of the Boys integral that will be evaluated. It should be a
-        three-dimensional numpy array of integers with shape `(M, 1, 1, 1)` where `M` is the number
-        of orders that will be evaluated.
+        three-dimensional `numpy` array of integers with `shape` :math:`(M, 1, 1, 1)` where
+        :math:`M` is the number of orders that will be evaluated.
         `weighted_dist` is the weighted interatomic distance, i.e.
-        :math:`\frac{\alpha_i \beta_j}{\alpha_i + \beta_j} * ||R_{PC}||^2` where :math:`\alpha_i` is
-        the exponent of the ith primitive on the left side and the :math:`\beta_j` is the exponent
-        of the jth primitive on the right side. It should be a four-dimensional numpy array of
-        floats with shape `(1, N, K_b, K_a)` where `N` is the number of point charges, `K_a` and
-        `K_b` are the number of primitives on the left and right side, respectively.
-        Output is the Boys function evaluated for each order and the weighted interactomic distance.
-        It will be a three-dimensional numpy array of shape `(M, N, K_b, K_a)`.
+        :math:`\frac{\alpha_i \beta_j}{\alpha_i + \beta_j} * ||R_{PC}||^2` where :math:`\alpha_i`
+        is the exponent of the i-th primitive on the left side and the :math:`\beta_j` is the
+        exponent of the j-th primitive on the right side. It should be a four-dimensional `numpy`
+        array of floats with `shape` :math:`(1, N, K_b, K_a)`, where :math:`N` is the number of
+        point charges and :math:`K_a` and :math:`K_b` are the number of primitives on the left and
+        right side, respectively.
+        Output is the Boys function evaluated for each order and the weighted interatomic distance.
+        It will be a three-dimensional `numpy` array with `shape` :math:`(M, N, K_b, K_a)`.
     coord_a : np.ndarray(3,)
         Center of the contraction on the left side.
     angmom_a : int
         Angular momentum of the segmented contractions on the left side.
-        We will denote this value to be `L_a`.
+        We will denote this value to be :math:`L_a`.
     exps_a : np.ndarray(K_a,)
         Values of the (square root of the) precisions of the primitives on the left side.
     coeffs_a : np.ndarray(K_a, M_a)
         Contraction coefficients of the primitives on the left side.
         The coefficients always correspond to generalized contractions, i.e. two-dimensional array
-        where the first index corresponds to the primitive and the second index corresponds to the
+        where dimension 0 corresponds to the primitive and dimension 1 corresponds to the
         contraction (with the same exponents and angular momentum).
     coord_b : np.ndarray(3,)
         Center of the contraction on the right side.
     angmom_b : int
         Angular momentum of the segmented contractions on the right side.
-        We will denote this value to be `L_b`.
+        We will denote this value to be :math:`L_b`.
     exps_b : np.ndarray(K_b,)
         Values of the (square root of the) precisions of the primitives on the right side.
     coeffs_b : np.ndarray(K_b, M_b)
         Contraction coefficients of the primitives on the right side.
         The coefficients always correspond to generalized contractions, i.e. two-dimensional array
-        where the first index corresponds to the primitive and the second index corresponds to the
+        where dimension 0 corresponds to the primitive and dimension 1 corresponds to the
         contraction (with the same exponents and angular momentum).
 
     Returns
     -------
     integrals : np.ndarray(L_a + 1, L_a + 1, L_a + 1, L_b + 1, L_b + 1, L_b + 1, M_a, M_b)
         One electron integrals for the given `GeneralizedContractionShell` instances.
-        First, second, and third index correspond to the `x`, `y`, and `z` components of the
+        Dimensions 0, 1, and 2 correspond to the :math:`x, y, \text{and} z` components of the
         angular momentum for contraction a.
-        Fourth, fifth, and sixth index correspond to the `x`, `y`, and `z` components of the
+        Dimensions 3, 4, and 5 correspond to the :math:`x, y, \text{and} z` components of the
         angular momentum for contraction b.
-        Seventh index corresponds to the segmented contractions of contraction a.
-        Eighth index corresponds to the segmented contractions of contraction b.
+        Dimension 6 corresponds to the segmented contractions of contraction a.
+        Dimension 7 corresponds to the segmented contractions of contraction b.
 
     """
 

--- a/gbasis/integrals/_one_elec_int.py
+++ b/gbasis/integrals/_one_elec_int.py
@@ -26,22 +26,22 @@ def _compute_one_elec_integrals(
     boys_func : function(orders, weighted_dist)
         Boys function used to evaluate the one-electron integral.
         `orders` is the orders of the Boys integral that will be evaluated. It should be a
-        three-dimensional `numpy` array of integers with `shape` :math:`(M, 1, 1, 1)` where
-        :math:`M` is the number of orders that will be evaluated.
+        three-dimensional `numpy` array of integers with `shape` (M, 1, 1, 1) where
+        `M` is the number of orders that will be evaluated.
         `weighted_dist` is the weighted interatomic distance, i.e.
         :math:`\frac{\alpha_i \beta_j}{\alpha_i + \beta_j} * ||R_{PC}||^2` where :math:`\alpha_i`
         is the exponent of the i-th primitive on the left side and the :math:`\beta_j` is the
         exponent of the j-th primitive on the right side. It should be a four-dimensional `numpy`
-        array of floats with `shape` :math:`(1, N, K_b, K_a)`, where :math:`N` is the number of
-        point charges and :math:`K_a` and :math:`K_b` are the number of primitives on the left and
+        array of floats with `shape` (1, N, K_b, K_a), where `N` is the number of
+        point charges and `K_a` and `K_b` are the number of primitives on the left and
         right side, respectively.
         Output is the Boys function evaluated for each order and the weighted interatomic distance.
-        It will be a three-dimensional `numpy` array with `shape` :math:`(M, N, K_b, K_a)`.
+        It will be a three-dimensional `numpy` array with `shape` (M, N, K_b, K_a).
     coord_a : np.ndarray(3,)
         Center of the contraction on the left side.
     angmom_a : int
         Angular momentum of the segmented contractions on the left side.
-        We will denote this value to be :math:`L_a`.
+        We will denote this value to be `L_a`.
     exps_a : np.ndarray(K_a,)
         Values of the (square root of the) precisions of the primitives on the left side.
     coeffs_a : np.ndarray(K_a, M_a)
@@ -53,7 +53,7 @@ def _compute_one_elec_integrals(
         Center of the contraction on the right side.
     angmom_b : int
         Angular momentum of the segmented contractions on the right side.
-        We will denote this value to be :math:`L_b`.
+        We will denote this value to be `L_b`.
     exps_b : np.ndarray(K_b,)
         Values of the (square root of the) precisions of the primitives on the right side.
     coeffs_b : np.ndarray(K_b, M_b)

--- a/gbasis/integrals/_two_elec_int.py
+++ b/gbasis/integrals/_two_elec_int.py
@@ -32,18 +32,19 @@ def _compute_two_elec_integrals_angmom_zero(
     Parameters
     ----------
     boys_func : function(orders, weighted_dist)
-        Boys function used to evaluate the one-electron integral.
+        Boys function used to evaluate the two-electron integral.
         `orders` is the orders of the Boys integral that will be evaluated. It should be a
-        three-dimensional numpy array of integers with shape `(M, 1, 1, 1)` where `M` is the number
-        of orders that will be evaluated.
+        three-dimensional `numpy` array of integers with `shape` :math:`(M, 1, 1, 1)` where :
+        math:`M` is the number of orders that will be evaluated.
         `weighted_dist` is the weighted interatomic distance, i.e.
         :math:`\frac{\alpha_i \beta_j}{\alpha_i + \beta_j} * ||R_{PC}||^2` where :math:`\alpha_i` is
-        the exponent of the ith primitive on the left side and the :math:`\beta_j` is the exponent
-        of the jth primitive on the right side. It should be a four-dimensional numpy array of
-        floats with shape `(1, N, K_b, K_a)` where `N` is the number of point charges, `K_a` and
-        `K_b` are the number of primitives on the left and right side, respectively.
-        Output is the Boys function evaluated for each order and the weighted interactomic distance.
-        It will be a three-dimensional numpy array of shape `(M, N, K_b, K_a)`.
+        the exponent of the i-th primitive on the left side and the :math:`\beta_j` is the exponent
+        of the j-th primitive on the right side. It should be a four-dimensional `numpy` array of
+        floats with `shape` :math:`(1, N, K_b, K_a)` where :math:`N` is the number of point charges
+        and :math:`K_a` and :math:`K_b` are the number of primitives on the left and right side,
+        respectively.
+        Output is the Boys function evaluated for each order and the weighted interatomic distance.
+        It will be a three-dimensional `numpy` array with `shape` :math:`(M, N, K_b, K_a)`.
     coord_a : np.ndarray(3,)
         Center of the contraction a.
     exps_a : np.ndarray(K_a,)
@@ -51,7 +52,7 @@ def _compute_two_elec_integrals_angmom_zero(
     coeffs_a : np.ndarray(K_a, M_a)
         Contraction coefficients of the primitives in contraction a.
         The coefficients always correspond to generalized contractions, i.e. two-dimensional array
-        where the first index corresponds to the primitive and the second index corresponds to the
+        where dimension 0 corresponds to the primitive and dimension 1 corresponds to the
         contraction (with the same exponents and angular momentum).
     coord_b : np.ndarray(3,)
         Center of the contraction b.
@@ -60,7 +61,7 @@ def _compute_two_elec_integrals_angmom_zero(
     coeffs_b : np.ndarray(K_b, M_b)
         Contraction coefficients of the primitives in contraction b.
         The coefficients always correspond to generalized contractions, i.e. two-dimensional array
-        where the first index corresponds to the primitive and the second index corresponds to the
+        where dimension 0 corresponds to the primitive and dimension 1 corresponds to the
         contraction (with the same exponents and angular momentum).
     coord_c : np.ndarray(3,)
         Center of the contraction c.
@@ -69,7 +70,7 @@ def _compute_two_elec_integrals_angmom_zero(
     coeffs_c : np.ndarray(K_c, M_c)
         Contraction coefficients of the primitives in contraction c.
         The coefficients always correspond to generalized contractions, i.e. two-dimensional array
-        where the first index corresponds to the primitive and the second index corresponds to the
+        where dimension 0 corresponds to the primitive and dimension 1 corresponds to the
         contraction (with the same exponents and angular momentum).
     coord_d : np.ndarray(3,)
         Center of the contraction d.
@@ -78,7 +79,7 @@ def _compute_two_elec_integrals_angmom_zero(
     coeffs_d : np.ndarray(K_d, M_d)
         Contraction coefficients of the primitives in contraction d.
         The coefficients always correspond to generalized contractions, i.e. two-dimensional array
-        where the first index corresponds to the primitive and the second index corresponds to the
+        where dimension 0 corresponds to the primitive and dimension 1 corresponds to the
         contraction (with the same exponents and angular momentum).
 
     Returns
@@ -86,14 +87,14 @@ def _compute_two_elec_integrals_angmom_zero(
     integrals : np.ndarray(1, 1, 1, 1, M_a, M_b, M_c, M_d)
         Two-electron integrals **in Chemists' notation** of the four generalized contraction shells
         (a, b, c, d).
-        First index correspond to angular momentum components of contraction a.
-        Second index correspond to angular momentum components of contraction b.
-        Third index correspond to angular momentum components of contraction c.
-        Fourth index correspond to angular momentum components of contraction d.
-        Fifth index corresponds to the segmented contractions of contraction a.
-        Sixth index corresponds to the segmented contractions of contraction b.
-        Seventh index corresponds to the segmented contractions of contraction c.
-        Eighth index corresponds to the segmented contractions of contraction d.
+        Dimension 0 correspond to angular momentum components of contraction a.
+        Dimension 1 correspond to angular momentum components of contraction b.
+        Dimension 2 correspond to angular momentum components of contraction c.
+        Dimension 3 correspond to angular momentum components of contraction d.
+        Dimension 4 corresponds to the segmented contractions of contraction a.
+        Dimension 5 corresponds to the segmented contractions of contraction b.
+        Dimension 6 corresponds to the segmented contractions of contraction c.
+        Dimension 7 corresponds to the segmented contractions of contraction d.
         Note that the integrals are in Chemists' notation.
 
     Notes
@@ -178,18 +179,19 @@ def _compute_two_elec_integrals(
     Parameters
     ----------
     boys_func : function(orders, weighted_dist)
-        Boys function used to evaluate the one-electron integral.
+        Boys function used to evaluate the two-electron integral.
         `orders` is the orders of the Boys integral that will be evaluated. It should be a
-        three-dimensional numpy array of integers with shape `(M, 1, 1, 1)` where `M` is the number
-        of orders that will be evaluated.
+        three-dimensional `numpy` array of integers with `shape` :math:`(M, 1, 1, 1)` where :
+        math:`M` is the number of orders that will be evaluated.
         `weighted_dist` is the weighted interatomic distance, i.e.
         :math:`\frac{\alpha_i \beta_j}{\alpha_i + \beta_j} * ||R_{PC}||^2` where :math:`\alpha_i` is
-        the exponent of the ith primitive on the left side and the :math:`\beta_j` is the exponent
-        of the jth primitive on the right side. It should be a four-dimensional numpy array of
-        floats with shape `(1, N, K_b, K_a)` where `N` is the number of point charges, `K_a` and
-        `K_b` are the number of primitives on the left and right side, respectively.
-        Output is the Boys function evaluated for each order and the weighted interactomic distance.
-        It will be a three-dimensional numpy array of shape `(M, N, K_b, K_a)`.
+        the exponent of the i-th primitive on the left side and the :math:`\beta_j` is the exponent
+        of the j-th primitive on the right side. It should be a four-dimensional `numpy` array of
+        floats with `shape` :math:`(1, N, K_b, K_a)` where :math:`N` is the number of point charges
+        and :math:`K_a` and :math:`K_b` are the number of primitives on the left and right side,
+        respectively.
+        Output is the Boys function evaluated for each order and the weighted interatomic distance.
+        It will be a three-dimensional `numpy` array with `shape` :math:`(M, N, K_b, K_a)`.
     coord_a : np.ndarray(3,)
         Center of the contraction a.
     angmom_a : int
@@ -203,7 +205,7 @@ def _compute_two_elec_integrals(
     coeffs_a : np.ndarray(K_a, M_a)
         Contraction coefficients of the primitives in contraction a.
         The coefficients always correspond to generalized contractions, i.e. two-dimensional array
-        where the first index corresponds to the primitive and the second index corresponds to the
+        where dimension 0 corresponds to the primitive and dimension 1 corresponds to the
         contraction (with the same exponents and angular momentum).
     coord_b : np.ndarray(3,)
         Center of the contraction b.
@@ -218,7 +220,7 @@ def _compute_two_elec_integrals(
     coeffs_b : np.ndarray(K_b, M_b)
         Contraction coefficients of the primitives in contraction b.
         The coefficients always correspond to generalized contractions, i.e. two-dimensional array
-        where the first index corresponds to the primitive and the second index corresponds to the
+        where dimension 0 corresponds to the primitive and dimension 1 corresponds to the
         contraction (with the same exponents and angular momentum).
     coord_c : np.ndarray(3,)
         Center of the contraction c.
@@ -233,7 +235,7 @@ def _compute_two_elec_integrals(
     coeffs_c : np.ndarray(K_c, M_c)
         Contraction coefficients of the primitives in contraction c.
         The coefficients always correspond to generalized contractions, i.e. two-dimensional array
-        where the first index corresponds to the primitive and the second index corresponds to the
+        where dimension 0 corresponds to the primitive and dimension 1 corresponds to the
         contraction (with the same exponents and angular momentum).
     coord_d : np.ndarray(3,)
         Center of the contraction d.
@@ -248,7 +250,7 @@ def _compute_two_elec_integrals(
     coeffs_d : np.ndarray(K_d, M_d)
         Contraction coefficients of the primitives in contraction d.
         The coefficients always correspond to generalized contractions, i.e. two-dimensional array
-        where the first index corresponds to the primitive and the second index corresponds to the
+        where dimension 0 corresponds to the primitive and dimension 1 corresponds to the
         contraction (with the same exponents and angular momentum).
 
     Returns
@@ -256,14 +258,15 @@ def _compute_two_elec_integrals(
     integrals : np.ndarray(L_a, L_b, L_c, L_d, M_a, M_b, M_c, M_d)
         Two-electron integrals **in Chemists' notation** of the four generalized contraction shells
         (a, b, c, d).
-        First index correspond to angular momentum components of contraction a.
-        Second index correspond to angular momentum components of contraction b.
-        Third index correspond to angular momentum components of contraction c.
-        Fourth index correspond to angular momentum components of contraction d.
-        Fifth index corresponds to the segmented contractions of contraction a.
-        Sixth index corresponds to the segmented contractions of contraction b.
-        Seventh index corresponds to the segmented contractions of contraction c.
-        Eighth index corresponds to the segmented contractions of contraction d.
+        Dimension 0 correspond to angular momentum components of contraction a.
+        Dimension 1 correspond to angular momentum components of contraction b.
+        Dimension 2 correspond to angular momentum components of contraction c.
+        Dimension 3 correspond to angular momentum components of contraction d.
+        Dimension 4 corresponds to the segmented contractions of contraction a.
+        Dimension 5 corresponds to the segmented contractions of contraction b.
+        Dimension 6 corresponds to the segmented contractions of contraction c.
+        Dimension 7 corresponds to the segmented contractions of contraction d.
+        Note that the integrals are in Chemists' notation.
 
     Raises
     ------
@@ -396,7 +399,7 @@ def _compute_two_elec_integrals(
         )
 
     # FIXME: memory heavy here
-    # NOTE: Ordering convention for electorn transfer recursion
+    # NOTE: Ordering convention for electron transfer recursion
     # axis 0 : c_x (size: m_max_c)
     # axis 1 : c_y (size: m_max_c)
     # axis 2 : c_z (size: m_max_c)
@@ -430,7 +433,7 @@ def _compute_two_elec_integrals(
     # different shapes (e.g. shape(0, 1) and shape(1, 0))into one another. The slices 1:2 on the 0th
     # and the 3rd axis causes problems when they both have dimension zero. There doesn't seem to be
     # an easy enough way around it, so the breaking case (all contractions have angular momentum of
-    # 0) is not is upported. Use `_compute_two_elec_integrals_angmom_zero` for this case.
+    # 0) is not supported. Use `_compute_two_elec_integrals_angmom_zero` for this case.
     # FIXME: i couldn't get the base case (all angmom of zero) to work.
     integrals_etransf[1:2, 0, 0, 0:1, :, :, :, :, :, :] = (
         (rel_coord_c[0] + exps_sum_one / exps_sum_two * rel_coord_a[0])
@@ -787,7 +790,7 @@ def _compute_two_elec_integrals(
     # rearrange to more sensible order
     integrals = np.transpose(integrals_horiz_b2, (1, 0, 3, 2, 4, 6, 5, 7))
 
-    # Get normalzation constants that correspond to the angular momentum components
+    # Get normalization constants that correspond to the angular momentum components
     norm_a = 1 / np.sqrt(np.prod(factorial2(2 * angmom_components_a - 1), axis=1)).reshape(
         -1, 1, 1, 1, 1, 1, 1, 1
     )

--- a/gbasis/integrals/_two_elec_int.py
+++ b/gbasis/integrals/_two_elec_int.py
@@ -34,17 +34,17 @@ def _compute_two_elec_integrals_angmom_zero(
     boys_func : function(orders, weighted_dist)
         Boys function used to evaluate the two-electron integral.
         `orders` is the orders of the Boys integral that will be evaluated. It should be a
-        three-dimensional `numpy` array of integers with `shape` :math:`(M, 1, 1, 1)` where :
+        three-dimensional `numpy` array of integers with `shape` (M, 1, 1, 1) where :
         math:`M` is the number of orders that will be evaluated.
         `weighted_dist` is the weighted interatomic distance, i.e.
         :math:`\frac{\alpha_i \beta_j}{\alpha_i + \beta_j} * ||R_{PC}||^2` where :math:`\alpha_i` is
         the exponent of the i-th primitive on the left side and the :math:`\beta_j` is the exponent
         of the j-th primitive on the right side. It should be a four-dimensional `numpy` array of
-        floats with `shape` :math:`(1, N, K_b, K_a)` where :math:`N` is the number of point charges
-        and :math:`K_a` and :math:`K_b` are the number of primitives on the left and right side,
+        floats with `shape` (1, N, K_b, K_a) where `N` is the number of point charges
+        and `K_a` and `K_b` are the number of primitives on the left and right side,
         respectively.
         Output is the Boys function evaluated for each order and the weighted interatomic distance.
-        It will be a three-dimensional `numpy` array with `shape` :math:`(M, N, K_b, K_a)`.
+        It will be a three-dimensional `numpy` array with `shape` (M, N, K_b, K_a).
     coord_a : np.ndarray(3,)
         Center of the contraction a.
     exps_a : np.ndarray(K_a,)
@@ -181,17 +181,17 @@ def _compute_two_elec_integrals(
     boys_func : function(orders, weighted_dist)
         Boys function used to evaluate the two-electron integral.
         `orders` is the orders of the Boys integral that will be evaluated. It should be a
-        three-dimensional `numpy` array of integers with `shape` :math:`(M, 1, 1, 1)` where :
-        math:`M` is the number of orders that will be evaluated.
+        three-dimensional `numpy` array of integers with `shape` (M, 1, 1, 1) where
+        `M` is the number of orders that will be evaluated.
         `weighted_dist` is the weighted interatomic distance, i.e.
         :math:`\frac{\alpha_i \beta_j}{\alpha_i + \beta_j} * ||R_{PC}||^2` where :math:`\alpha_i` is
         the exponent of the i-th primitive on the left side and the :math:`\beta_j` is the exponent
         of the j-th primitive on the right side. It should be a four-dimensional `numpy` array of
-        floats with `shape` :math:`(1, N, K_b, K_a)` where :math:`N` is the number of point charges
-        and :math:`K_a` and :math:`K_b` are the number of primitives on the left and right side,
+        floats with `shape` (1, N, K_b, K_a) where `N` is the number of point charges
+        and `K_a` and `K_b` are the number of primitives on the left and right side,
         respectively.
         Output is the Boys function evaluated for each order and the weighted interatomic distance.
-        It will be a three-dimensional `numpy` array with `shape` :math:`(M, N, K_b, K_a)`.
+        It will be a three-dimensional `numpy` array with `shape` (M, N, K_b, K_a).
     coord_a : np.ndarray(3,)
         Center of the contraction a.
     angmom_a : int

--- a/gbasis/integrals/angular_momentum.py
+++ b/gbasis/integrals/angular_momentum.py
@@ -16,11 +16,9 @@ class AngularMomentumIntegral(BaseTwoIndexSymmetric):
     ----------
     _axes_contractions : tuple of tuple of GeneralizedContractionShell
         Sets of contractions associated with each axis of the array.
-
-    Properties
-    ----------
     contractions : tuple of GeneralizedContractionShell
         Contractions that are associated with the first and second indices of the array.
+        Property of `AngularMomentumIntegral`.
 
     Methods
     -------
@@ -30,29 +28,29 @@ class AngularMomentumIntegral(BaseTwoIndexSymmetric):
     np.ndarray(M_1, L_cart_1, M_2, L_cart_2, 3)
         Return the integral over the angular momentum operator associated with a
         `GeneralizedContractionShell` instance.
-        `M_1` is the number of segmented contractions with the same exponents (and angular momentum)
+        :math:`M_1` is the number of segmented contractions with the same exponents (and angular
+        momentum) associated with the first index.
+        :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
         associated with the first index.
-        `L_cart_1` is the number of Cartesian contractions for the given angular momentum associated
-        with the first index.
-        `M_2` is the number of segmented contractions with the same exponents (and angular momentum)
+        :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+        momentum) associated with the second index.
+        :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
         associated with the second index.
-        `L_cart_2` is the number of Cartesian contractions for the given angular momentum associated
-        with the second index.
     construct_array_cartesian(self) : np.ndarray(K_cart, K_cart, 3)
         Return the integral over the angular momentum operator associated with Cartesian Gaussians.
-        `K_cart` is the total number of Cartesian contractions within the instance.
+        :math:`K_cart` is the total number of Cartesian contractions within the instance.
     construct_array_spherical(self) : np.ndarray(K_sph, K_sph, 3)
         Return the integral over the angular momentum operators associated with spherical Gaussians
         (atomic orbitals).
-        `K_sph` is the total number of spherical contractions within the instance.
+        :math:`K_sph` is the total number of spherical contractions within the instance.
     construct_array_mix(self, coord_types) : np.ndarray(K_cont, K_cont, 3)
         Return the integral over the angular momentum operators associated with the contraction in
         the given coordinate system.
-        `K_cont` is the total number of contractions within the given basis set.
+        :math:`K_cont` is the total number of contractions within the given basis set.
     construct_array_spherical_lincomb(self, transform) : np.ndarray(K_orbs, K_orbs, 3)
         Return the integral over the angular momentum operator associated with linear combinations
         of spherical Gaussians (linear combinations of atomic orbitals).
-        `K_orbs` is the number of basis functions produced after the linear combinations.
+        :math:`K_orbs` is the number of basis functions produced after the linear combinations.
 
     """
 
@@ -74,31 +72,31 @@ class AngularMomentumIntegral(BaseTwoIndexSymmetric):
         array_contraction : np.ndarray(M_1, L_cart_1, M_2, L_cart_2, 3)
             Integral over than angular momentum operator associated with the given instances of
             GeneralizedContractionShell.
-            Dimension 0 corresponds to the segmented contraction within `contractions_one`. `M_1` is
-            the number of segmented contractions with the same exponents (and angular momentum)
-            associated with the first index.
+            Dimension 0 corresponds to the segmented contraction within `contractions_one`.
+            :math:`M_1` is the number of segmented contractions with the same exponents (and angular
+            momentum) associated with the first index.
             Dimension 1 corresponds to the angular momentum vector of the `contractions_one`.
-            `L_cart_1` is the number of Cartesian contractions for the given angular momentum
+            :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
             associated with the first index.
-            Dimension 2 corresponds to the segmented contraction within `contractions_two`. `M_2` is
-            the number of segmented contractions with the same exponents (and angular momentum)
-            associated with the second index.
+            Dimension 2 corresponds to the segmented contraction within `contractions_two`.
+            :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+            momentum) associated with the second index.
             Dimension 3 corresponds to the angular momentum vector of the `contractions_two`.
-            `L_cart_2` is the number of Cartesian contractions for the given angular momentum
+            :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
             associated with the second index.
-            Dimension 4 corresponds to the dimension of the angular momentum (x, y, z).
+            Dimension 4 corresponds to the direction of the angular momentum :math:`(x, y, z)`.
 
         Raises
         ------
         TypeError
-            If contractions_one is not a GeneralizedContractionShell instance.
-            If contractions_two is not a GeneralizedContractionShell instance.
+            If contractions_one is not a `GeneralizedContractionShell` instance.
+            If contractions_two is not a `GeneralizedContractionShell` instance.
 
         """
         if not isinstance(contractions_one, GeneralizedContractionShell):
-            raise TypeError("`contractions_one` must be a GeneralizedContractionShell instance.")
+            raise TypeError("`contractions_one` must be a `GeneralizedContractionShell` instance.")
         if not isinstance(contractions_two, GeneralizedContractionShell):
-            raise TypeError("`contractions_two` must be a GeneralizedContractionShell instance.")
+            raise TypeError("`contractions_two` must be a `GeneralizedContractionShell` instance.")
 
         diff_integrals = _compute_differential_operator_integrals_intermediate(
             1,
@@ -175,16 +173,16 @@ def angular_momentum_integral(basis, transform=None, coord_type="spherical"):
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each GeneralizedContractionShell instance.
+        coordinate type of each `GeneralizedContractionShell` instance.
         Default is "spherical".
 
     Returns
     -------
     array : np.ndarray(K, K, 3)
         Array associated with the basis functions in the given shells of generalized contractions.
-        Dimensions 0 and 1 of the array are associated with the basis functions in the basis set.
-        `K` is the total number of basis functions in the basis set.
-        Dimension 2 corresponds to the direction of the angular momentum (x, y, z).
+        Dimensions 0 and 1 of the array are associated with the basis functions in the basis set,
+        where :math:`K` is the total number of basis functions in the basis set.
+        Dimension 2 corresponds to the direction of the angular momentum :math:`(x, y, z)`.
 
     """
     if transform is not None:

--- a/gbasis/integrals/electron_repulsion.py
+++ b/gbasis/integrals/electron_repulsion.py
@@ -19,11 +19,9 @@ class ElectronRepulsionIntegral(BaseFourIndexSymmetric):
     ----------
     _axes_contractions : tuple of tuple of GeneralizedContractionShell
         Sets of contractions associated with each axis of the array.
-
-    Properties
-    ----------
     contractions : tuple of GeneralizedContractionShell
-        Contractions that are associated with the first and second indices of the array.
+        Contractions that are associated with the four indices of the array.
+        Property of `ElectronRepulsionIntegral`.
 
     Methods
     -------
@@ -33,42 +31,42 @@ class ElectronRepulsionIntegral(BaseFourIndexSymmetric):
     np.ndarray(M_1, L_cart_1, M_2, L_cart_2, M_3, L_cart_3, M_4, L_cart_4)
         Return the electron-electron repulsion integrals associated with a
         `GeneralizedContractionShell` instances.
-        `M_1` is the number of segmented contractions with the same exponents (and angular momentum)
+        :math:`M_1` is the number of segmented contractions with the same exponents (and angular
+        momentum) associated with the first index.
+        :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
         associated with the first index.
-        `L_cart_1` is the number of Cartesian contractions for the given angular momentum associated
-        with the first index.
-        `M_2` is the number of segmented contractions with the same exponents (and angular momentum)
+        :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+        momentum) associated with the second index.
+        :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
         associated with the second index.
-        `L_cart_2` is the number of Cartesian contractions for the given angular momentum associated
-        with the second index.
-        `M_3` is the number of segmented contractions with the same exponents (and angular momentum)
+        :math:`M_3` is the number of segmented contractions with the same exponents (and angular
+        momentum) associated with the third index.
+        :math:`L_cart_3` is the number of Cartesian contractions for the given angular momentum
         associated with the third index.
-        `L_cart_3` is the number of Cartesian contractions for the given angular momentum associated
-        with the third index.
-        `M_4` is the number of segmented contractions with the same exponents (and angular momentum)
+        :math:`M_4` is the number of segmented contractions with the same exponents (and angular
+        momentum) associated with the fourth index.
+        :math:`L_cart_4` is the number of Cartesian contractions for the given angular momentum
         associated with the fourth index.
-        `L_cart_4` is the number of Cartesian contractions for the given angular momentum associated
-        with the fourth index.
         Note that the integrals are in Chemists' notation.
     construct_array_cartesian(self) : np.ndarray(K_cart, K_cart, K_cart, K_cart)
         Return the electron-electron repulsion integrals associated with Cartesian Gaussians.
-        `K_cart` is the total number of Cartesian contractions within the instance.
+        :math:`K_cart` is the total number of Cartesian contractions within the instance.
         Note that the integrals are in Chemists' notation.
     construct_array_spherical(self) : np.ndarray(K_sph, K_sph, K_sph, K_sph)
         Return the electron-electron repulsion integrals associated with spherical Gaussians (atomic
         orbitals).
-        `K_sph` is the total number of spherical contractions within the instance.
+        :math:`K_sph` is the total number of spherical contractions within the instance.
         Note that the integrals are in Chemists' notation.
     construct_array_mix(self, coord_types) : np.ndarray(K_cont, K_cont, K_cont, K_cont)
         Return the electron-electron repulsion integrals associated with all of the contraction in
         the given coordinate system.
-        `K_cont` is the total number of contractions within the given basis set.
+        :math:`K_cont` is the total number of contractions within the given basis set.
         Note that the integrals are in Chemists' notation.
     construct_array_lincomb(self, transform, coord_type) :
     np.ndarray(K_orbs, K_orbs, K_orbs, K_orbs)
         Return the electron-electron repulsion integrals associated with linear combinations of
         contractions in the given coordinate system.
-        `K_orbs` is the number of basis functions produced after the linear combinations.
+        :math:`K_orbs` is the number of basis functions produced after the linear combinations.
         Note that the integrals are in Chemists' notation.
 
     """
@@ -98,31 +96,31 @@ class ElectronRepulsionIntegral(BaseFourIndexSymmetric):
         -------
         array_cont : np.ndarray(M_1, L_cart_1, M_2, L_cart_2, M_3, L_cart_3, M_4, L_cart_4)
             Electron-electron repulsion integral associated with the given instances of
-            GeneralizedContractionShell.
-            First axis corresponds to the segmented contraction within `cont1`. `M_1` is the number
-            of segmented contractions with the same exponents (and angular momentum) associated with
-            the first index.
-            Second axis corresponds to the angular momentum vector of the `cont1`.`L_cart_1` is the
-            number of Cartesian contractions for the given angular momentum associated with the
-            first index.
-            Third axis corresponds to the segmented contraction within `cont2`. `M_2` is the number
-            of segmented contractions with the same exponents (and angular momentum) associated with
-            the second index.
-            Fourth axis corresponds to the angular momentum vector of the `cont2`.`L_cart_2` is the
-            number of Cartesian contractions for the given angular momentum associated with the
-            second index.
-            Fifth axis corresponds to the segmented contraction within `cont3`. `M_3` is the number
-            of segmented contractions with the same exponents (and angular momentum) associated with
-            the third index.
-            Sixth axis corresponds to the angular momentum vector of the `cont3`.`L_cart_3` is the
-            number of Cartesian contractions for the given angular momentum associated with the
-            third index.
-            Seventh axis corresponds to the segmented contraction within `cont4`. `M_4` is the
-            number of segmented contractions with the same exponents (and angular momentum)
+            `GeneralizedContractionShell`.
+            Dimension 0 corresponds to the segmented contraction within `cont_one`. :math:`M_1` is
+            the number of segmented contractions with the same exponents (and angular momentum)
+            associated with the first index.
+            Dimension 1 corresponds to the angular momentum vector of the `cont_one`.
+            :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
+            associated with the first index.
+            Dimension 2 corresponds to the segmented contraction within `cont_two`.
+            :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+            momentum) associated with the second index.
+            Dimension 3 corresponds to the angular momentum vector of the `cont_two`.
+            :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
+            associated with the second index.
+            Dimension 4 corresponds to the segmented contraction within `cont_three`.
+            :math:`M_3` is the number of segmented contractions with the same exponents (and angular
+            momentum) associated with the third index.
+            Dimension 5 corresponds to the angular momentum vector of the `cont_three`.
+            :math:`L_cart_3` is the number of Cartesian contractions for the given angular momentum
+            associated with the third index.
+            Dimension 6 corresponds to the segmented contraction within `cont_four`.
+            :math:`M_4` is the number of segmented contractions with the same exponents (and angular
+            momentum) associated with the fourth index.
+            Dimension 7 corresponds to the angular momentum vector of the `cont_four`.
+            :math:`L_cart_4` is the number of Cartesian contractions for the given angular momentum
             associated with the fourth index.
-            Eighth axis corresponds to the angular momentum vector of the `cont4`.`L_cart_4` is the
-            number of Cartesian contractions for the given angular momentum associated with the
-            fourth index.
             Integrals are in Chemists' notation, i.e. `cont1` and `cont2` are associated with the
             coordinate :math:`\mathbf{r}_1` and `cont3` and `cont4` are associated with coordinate
             :math:`\mathbf{r}_2`.
@@ -130,10 +128,10 @@ class ElectronRepulsionIntegral(BaseFourIndexSymmetric):
         Raises
         ------
         TypeError
-            If `contractions_one` is not a GeneralizedContractionShell instance.
-            If `contractions_two` is not a GeneralizedContractionShell instance.
-            If `contractions_three` is not a GeneralizedContractionShell instance.
-            If `contractions_four` is not a GeneralizedContractionShell instance.
+            If `cont_one` is not a `GeneralizedContractionShell` instance.
+            If `cont_two` is not a `GeneralizedContractionShell` instance.
+            If `cont_three` is not a `GeneralizedContractionShell` instance.
+            If `cont_four` is not a `GeneralizedContractionShell` instance.
 
         Notes
         -----
@@ -147,13 +145,13 @@ class ElectronRepulsionIntegral(BaseFourIndexSymmetric):
         # pylint: disable=R0914
 
         if not isinstance(cont_one, GeneralizedContractionShell):
-            raise TypeError("`cont_one` must be a GeneralizedContractionShell instance.")
+            raise TypeError("`cont_one` must be a `GeneralizedContractionShell` instance.")
         if not isinstance(cont_two, GeneralizedContractionShell):
-            raise TypeError("`cont_two` must be a GeneralizedContractionShell instance.")
+            raise TypeError("`cont_two` must be a `GeneralizedContractionShell` instance.")
         if not isinstance(cont_three, GeneralizedContractionShell):
-            raise TypeError("`cont_three` must be a GeneralizedContractionShell instance.")
+            raise TypeError("`cont_three` must be a `GeneralizedContractionShell` instance.")
         if not isinstance(cont_four, GeneralizedContractionShell):
-            raise TypeError("`cont_four` must be a GeneralizedContractionShell instance.")
+            raise TypeError("`cont_four` must be a `GeneralizedContractionShell` instance.")
 
         # TODO: we can probably swap the contractions to get the optimal time or memory usage
         if cont_one.angmom == cont_two.angmom == cont_three.angmom == cont_four.angmom == 0:
@@ -223,7 +221,7 @@ def electron_repulsion_integral(
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each GeneralizedContractionShell instance.
+        coordinate type of each `GeneralizedContractionShell` instance.
         Default value is "spherical".
     notation : {"physicist", "chemist"}
         Convention with which the integrals are ordered.
@@ -236,8 +234,7 @@ def electron_repulsion_integral(
         If keyword argument `transform` is provided, then the integrals will be transformed
         accordingly.
         Dimensions 0, 1, 2, and 3 of the array are associated with the basis functions in the basis
-        set.
-        `K` is the total number of basis functions in the basis set.
+        set, where :math:`K` is the total number of basis functions in the basis set.
 
     Raises
     ------

--- a/gbasis/integrals/kinetic_energy.py
+++ b/gbasis/integrals/kinetic_energy.py
@@ -24,28 +24,28 @@ class KineticEnergyIntegral(BaseTwoIndexSymmetric):
     np.ndarray(M_1, L_cart_1, M_2, L_cart_2)
         Return the kinetic energy integral associated with a `GeneralizedContractionShell`
         instance.
-        :math:`M_1` is the number of segmented contractions with the same exponents (and angular
+        `M_1` is the number of segmented contractions with the same exponents (and angular
         momentum) associated with the first index.
-        :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
+        `L_cart_1` is the number of Cartesian contractions for the given angular momentum
         associated with the first index.
-        :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+        `M_2` is the number of segmented contractions with the same exponents (and angular
         momentum) associated with the second index.
-        :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
+        `L_cart_2` is the number of Cartesian contractions for the given angular momentum
         associated with the second index.
     construct_array_cartesian(self) : np.ndarray(K_cart, K_cart)
         Return the kinetic energy integral associated with Cartesian Gaussians.
-        :math:`K_cart` is the total number of Cartesian contractions within the instance.
+        `K_cart` is the total number of Cartesian contractions within the instance.
     construct_array_spherical(self) : np.ndarray(K_sph, K_sph)
         Return the kinetic energy integrals associated with spherical Gaussians (atomic orbitals).
-        :math:`K_sph` is the total number of spherical contractions within the instance.
+        `K_sph` is the total number of spherical contractions within the instance.
     construct_array_mix(self, coord_types) : np.ndarray(K_cont, K_cont)
         Return the kinetic energy integrals associated with the contraction in the given coordinate
         system.
-        :math:`K_cont` is the total number of contractions within the given basis set.
+        `K_cont` is the total number of contractions within the given basis set.
     construct_array_spherical_lincomb(self, transform) : np.ndarray(K_orbs, K_orbs)
         Return the kinetic energy integral associated with linear combinations of spherical
         Gaussians (linear combinations of atomic orbitals).
-        :math:`K_orbs` is the number of basis functions produced after the linear combinations.
+        `K_orbs` is the number of basis functions produced after the linear combinations.
 
     """
 
@@ -68,16 +68,16 @@ class KineticEnergyIntegral(BaseTwoIndexSymmetric):
             Kinetic energy integral associated with the given instances of
             `GeneralizedContractionShell`.
             Dimension 0 corresponds to the segmented contraction within `contractions_one`.
-            :math:`M_1` is the number of segmented contractions with the same exponents (and angular
+            `M_1` is the number of segmented contractions with the same exponents (and angular
             momentum) associated with the first index.
             Dimension 1 corresponds to the angular momentum vector of the `contractions_one`.
-            :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
+            `L_cart_1` is the number of Cartesian contractions for the given angular momentum
             associated with the first index.
             Dimension 2 corresponds to the segmented contraction within `contractions_two`.
-            :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+            `M_2` is the number of segmented contractions with the same exponents (and angular
             momentum) associated with the second index.
             Dimension 3 corresponds to the angular momentum vector of the `contractions_two`.
-            :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
+            `L_cart_2` is the number of Cartesian contractions for the given angular momentum
             associated with the second index.
 
         Raises
@@ -146,7 +146,7 @@ def kinetic_energy_integral(basis, transform=None, coord_type="spherical"):
         If keyword argument `transform` is provided, then the integrals will be transformed
         accordingly.
         Dimensions 0 and 1 of the array are associated with the basis functions in the basis set.
-        :math:`K_orbs` is the total number of basis functions in the basis set.
+        `K_orbs` is the total number of basis functions in the basis set.
 
     """
 

--- a/gbasis/integrals/kinetic_energy.py
+++ b/gbasis/integrals/kinetic_energy.py
@@ -12,11 +12,9 @@ class KineticEnergyIntegral(BaseTwoIndexSymmetric):
     ----------
     _axes_contractions : tuple of tuple of GeneralizedContractionShell
         Sets of contractions associated with each axis of the array.
-
-    Properties
-    ----------
     contractions : tuple of GeneralizedContractionShell
         Contractions that are associated with the first and second indices of the array.
+        Property of `KineticEnergyIntegral`.
 
     Methods
     -------
@@ -26,28 +24,28 @@ class KineticEnergyIntegral(BaseTwoIndexSymmetric):
     np.ndarray(M_1, L_cart_1, M_2, L_cart_2)
         Return the kinetic energy integral associated with a `GeneralizedContractionShell`
         instance.
-        `M_1` is the number of segmented contractions with the same exponents (and angular momentum)
+        :math:`M_1` is the number of segmented contractions with the same exponents (and angular
+        momentum) associated with the first index.
+        :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
         associated with the first index.
-        `L_cart_1` is the number of Cartesian contractions for the given angular momentum associated
-        with the first index.
-        `M_2` is the number of segmented contractions with the same exponents (and angular momentum)
+        :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+        momentum) associated with the second index.
+        :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
         associated with the second index.
-        `L_cart_2` is the number of Cartesian contractions for the given angular momentum associated
-        with the second index.
     construct_array_cartesian(self) : np.ndarray(K_cart, K_cart)
         Return the kinetic energy integral associated with Cartesian Gaussians.
-        `K_cart` is the total number of Cartesian contractions within the instance.
+        :math:`K_cart` is the total number of Cartesian contractions within the instance.
     construct_array_spherical(self) : np.ndarray(K_sph, K_sph)
         Return the kinetic energy integrals associated with spherical Gaussians (atomic orbitals).
-        `K_sph` is the total number of spherical contractions within the instance.
+        :math:`K_sph` is the total number of spherical contractions within the instance.
     construct_array_mix(self, coord_types) : np.ndarray(K_cont, K_cont)
         Return the kinetic energy integrals associated with the contraction in the given coordinate
         system.
-        `K_cont` is the total number of contractions within the given basis set.
+        :math:`K_cont` is the total number of contractions within the given basis set.
     construct_array_spherical_lincomb(self, transform) : np.ndarray(K_orbs, K_orbs)
         Return the kinetic energy integral associated with linear combinations of spherical
         Gaussians (linear combinations of atomic orbitals).
-        `K_orbs` is the number of basis functions produced after the linear combinations.
+        :math:`K_orbs` is the number of basis functions produced after the linear combinations.
 
     """
 
@@ -68,31 +66,31 @@ class KineticEnergyIntegral(BaseTwoIndexSymmetric):
         -------
         array_contraction : np.ndarray(M_1, L_cart_1, M_2, L_cart_2)
             Kinetic energy integral associated with the given instances of
-            GeneralizedContractionShell.
-            First axis corresponds to the segmented contraction within `contractions_one`. `M_1` is
-            the number of segmented contractions with the same exponents (and angular momentum)
+            `GeneralizedContractionShell`.
+            Dimension 0 corresponds to the segmented contraction within `contractions_one`.
+            :math:`M_1` is the number of segmented contractions with the same exponents (and angular
+            momentum) associated with the first index.
+            Dimension 1 corresponds to the angular momentum vector of the `contractions_one`.
+            :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
             associated with the first index.
-            Second axis corresponds to the angular momentum vector of the `contractions_one`.
-            `L_cart_1` is the number of Cartesian contractions for the given angular momentum
-            associated with the first index.
-            Third axis corresponds to the segmented contraction within `contractions_two`. `M_2` is
-            the number of segmented contractions with the same exponents (and angular momentum)
-            associated with the second index.
-            Fourth axis corresponds to the angular momentum vector of the `contractions_two`.
-            `L_cart_2` is the number of Cartesian contractions for the given angular momentum
+            Dimension 2 corresponds to the segmented contraction within `contractions_two`.
+            :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+            momentum) associated with the second index.
+            Dimension 3 corresponds to the angular momentum vector of the `contractions_two`.
+            :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
             associated with the second index.
 
         Raises
         ------
         TypeError
-            If contractions_one is not a GeneralizedContractionShell instance.
-            If contractions_two is not a GeneralizedContractionShell instance.
+            If contractions_one is not a `GeneralizedContractionShell` instance.
+            If contractions_two is not a `GeneralizedContractionShell` instance.
 
         """
         if not isinstance(contractions_one, GeneralizedContractionShell):
-            raise TypeError("`contractions_one` must be a GeneralizedContractionShell instance.")
+            raise TypeError("`contractions_one` must be a `GeneralizedContractionShell` instance.")
         if not isinstance(contractions_two, GeneralizedContractionShell):
-            raise TypeError("`contractions_two` must be a GeneralizedContractionShell instance.")
+            raise TypeError("`contractions_two` must be a `GeneralizedContractionShell` instance.")
 
         coord_a = contractions_one.coord
         angmoms_a = contractions_one.angmom_components_cart
@@ -138,7 +136,7 @@ def kinetic_energy_integral(basis, transform=None, coord_type="spherical"):
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each GeneralizedContractionShell instance.
+        coordinate type of each `GeneralizedContractionShell` instance.
         Default value is "spherical".
 
     Returns
@@ -148,7 +146,7 @@ def kinetic_energy_integral(basis, transform=None, coord_type="spherical"):
         If keyword argument `transform` is provided, then the integrals will be transformed
         accordingly.
         Dimensions 0 and 1 of the array are associated with the basis functions in the basis set.
-        `K_orbs` is the total number of basis functions in the basis set.
+        :math:`K_orbs` is the total number of basis functions in the basis set.
 
     """
 

--- a/gbasis/integrals/moment.py
+++ b/gbasis/integrals/moment.py
@@ -22,28 +22,28 @@ class Moment(BaseTwoIndexSymmetric):
         Initialize.
     construct_array_contraction(self, contraction) : np.ndarray(M_1, L_cart_1, M_2, L_cart_2)
         Return the moment associated with a `GeneralizedContractionShell` instance.
-        :math:`M_1` is the number of segmented contractions with the same exponents (and angular
+        `M_1` is the number of segmented contractions with the same exponents (and angular
         momentum) associated with the first index.
-        :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
+        `L_cart_1` is the number of Cartesian contractions for the given angular momentum
         associated with the first index.
-        :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+        `M_2` is the number of segmented contractions with the same exponents (and angular
         momentum) associated with the second index.
-        :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
+        `L_cart_2` is the number of Cartesian contractions for the given angular momentum
         associated with the second index.
     construct_array_cartesian(self) : np.ndarray(K_cart, K_cart)
         Return the moment integrals associated with Cartesian Gaussians.
-        :math:`K_cart` is the total number of Cartesian contractions within the instance.
+        `K_cart` is the total number of Cartesian contractions within the instance.
     construct_array_spherical(self) : np.ndarray(K_sph, K_sph)
         Return the moment integrals associated with spherical Gaussians (atomic orbitals).
-        :math:`K_sph` is the total number of spherical contractions within the instance.
+        `K_sph` is the total number of spherical contractions within the instance.
     construct_array_mix(self, coord_types, **kwargs) : np.ndarray(K_cont, K_cont)
         Return the moment integrals associated with all of the contraction in the given coordinate
         system.
-        :math:`K_cont` is the total number of contractions within the given basis set.
+        `K_cont` is the total number of contractions within the given basis set.
     construct_array_lincomb(self, transform) : np.ndarray(K_orbs, K_orbs)
         Return the moment integrals associated with the linear combinations of contractions in the
         given coordinate system.
-        :math:`K_orbs` is the number of basis functions produced after the linear combinations.
+        `K_orbs` is the number of basis functions produced after the linear combinations.
 
     """
 
@@ -64,7 +64,7 @@ class Moment(BaseTwoIndexSymmetric):
         moment_coord : np.ndarray(3,)
             Center of the moment.
         moment_orders : np.ndarray(D, 3)
-            Orders of the moment for each dimension :math:`(x, y, z)`.
+            Orders of the moment for each dimension (x, y, z).
             Note that a two dimensional array must be given, even if there is only one set of orders
             of the moment.
 
@@ -73,16 +73,16 @@ class Moment(BaseTwoIndexSymmetric):
         array_contraction : np.ndarray(M_1, L_cart_1, M_2, L_cart_2, D)
             Moment associated with the given instances of `GeneralizedContractionShell`.
             Dimension 0 corresponds to the segmented contraction within `contractions_one`.
-            :math:`M_1` is the number of segmented contractions with the same exponents (and angular
+            `M_1` is the number of segmented contractions with the same exponents (and angular
             momentum) associated with the first index.
             Dimension 1 corresponds to the angular momentum vector of the `contractions_one`.
-            :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
+            `L_cart_1` is the number of Cartesian contractions for the given angular momentum
             associated with the first index.
             Dimension 2 corresponds to the segmented contraction within `contractions_two`.
-            :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+            `M_2` is the number of segmented contractions with the same exponents (and angular
             momentum) associated with the second index.
             Dimension 3 corresponds to the angular momentum vector of the `contractions_two`.
-            :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
+            `L_cart_2` is the number of Cartesian contractions for the given angular momentum
             associated with the second index.
             Dimension 4 corresponds to the orders of the moments. `D` is the number of orders for
             which the moment is computed.
@@ -167,7 +167,7 @@ def moment_integral(basis, moment_coord, moment_orders, transform=None, coord_ty
     moment_coord : np.ndarray(3,)
         Center of the moment.
     moment_orders : np.ndarray(D, 3)
-        Orders of the moment for each dimension :math:`(x, y, z)`.
+        Orders of the moment for each dimension (x, y, z).
         Note that a two dimensional array must be given, even if there is only one set of orders
         of the moment.
     transform : np.ndarray(K_orbs, K_cont)
@@ -188,10 +188,10 @@ def moment_integral(basis, moment_coord, moment_orders, transform=None, coord_ty
     -------
     array : np.ndarray(K_orbs, K_orbs, D)
         Moment integral of the given basis set.
-        Dimensions 0 and 1 of the array correspond to the basis functions. :math:`K_orbs` is the
+        Dimensions 0 and 1 of the array correspond to the basis functions. `K_orbs` is the
         number of basis functions in the basis set.
         Dimension 2 of the array corresponds to the moment.
-        :math:`D` is the number of different moments.
+        `D` is the number of different moments.
 
     Notes
     -----

--- a/gbasis/integrals/moment.py
+++ b/gbasis/integrals/moment.py
@@ -12,11 +12,9 @@ class Moment(BaseTwoIndexSymmetric):
     ----------
     _axes_contractions : tuple of tuple of GeneralizedContractionShell
         Sets of contractions associated with each axis of the moment.
-
-    Properties
-    ----------
     contractions : tuple of GeneralizedContractionShell
         Contractions that are associated with the first and second indices of the array.
+        Property of `Moment`.
 
     Methods
     -------
@@ -24,28 +22,28 @@ class Moment(BaseTwoIndexSymmetric):
         Initialize.
     construct_array_contraction(self, contraction) : np.ndarray(M_1, L_cart_1, M_2, L_cart_2)
         Return the moment associated with a `GeneralizedContractionShell` instance.
-        `M_1` is the number of segmented contractions with the same exponents (and angular momentum)
+        :math:`M_1` is the number of segmented contractions with the same exponents (and angular
+        momentum) associated with the first index.
+        :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
         associated with the first index.
-        `L_cart_1` is the number of Cartesian contractions for the given angular momentum associated
-        with the first index.
-        `M_2` is the number of segmented contractions with the same exponents (and angular momentum)
+        :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+        momentum) associated with the second index.
+        :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
         associated with the second index.
-        `L_cart_2` is the number of Cartesian contractions for the given angular momentum associated
-        with the second index.
     construct_array_cartesian(self) : np.ndarray(K_cart, K_cart)
         Return the moment integrals associated with Cartesian Gaussians.
-        `K_cart` is the total number of Cartesian contractions within the instance.
+        :math:`K_cart` is the total number of Cartesian contractions within the instance.
     construct_array_spherical(self) : np.ndarray(K_sph, K_sph)
         Return the moment integrals associated with spherical Gaussians (atomic orbitals).
-        `K_sph` is the total number of spherical contractions within the instance.
+        :math:`K_sph` is the total number of spherical contractions within the instance.
     construct_array_mix(self, coord_types, **kwargs) : np.ndarray(K_cont, K_cont)
         Return the moment integrals associated with all of the contraction in the given coordinate
         system.
-        `K_cont` is the total number of contractions within the given basis set.
+        :math:`K_cont` is the total number of contractions within the given basis set.
     construct_array_lincomb(self, transform) : np.ndarray(K_orbs, K_orbs)
         Return the moment integrals associated with the linear combinations of contractions in the
         given coordinate system.
-        `K_orbs` is the number of basis functions produced after the linear combinations.
+        :math:`K_orbs` is the number of basis functions produced after the linear combinations.
 
     """
 
@@ -66,59 +64,61 @@ class Moment(BaseTwoIndexSymmetric):
         moment_coord : np.ndarray(3,)
             Center of the moment.
         moment_orders : np.ndarray(D, 3)
-            Orders of the moment for each dimension (x, y, z).
+            Orders of the moment for each dimension :math:`(x, y, z)`.
             Note that a two dimensional array must be given, even if there is only one set of orders
             of the moment.
 
         Returns
         -------
         array_contraction : np.ndarray(M_1, L_cart_1, M_2, L_cart_2, D)
-            Moment associated with the given instances of GeneralizedContractionShell.
-            First axis corresponds to the segmented contraction within `contractions_one`. `M_1` is
-            the number of segmented contractions with the same exponents (and angular momentum)
+            Moment associated with the given instances of `GeneralizedContractionShell`.
+            Dimension 0 corresponds to the segmented contraction within `contractions_one`.
+            :math:`M_1` is the number of segmented contractions with the same exponents (and angular
+            momentum) associated with the first index.
+            Dimension 1 corresponds to the angular momentum vector of the `contractions_one`.
+            :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
             associated with the first index.
-            Second axis corresponds to the angular momentum vector of the `contractions_one`.
-            `L_cart_1` is the number of Cartesian contractions for the given angular momentum
-            associated with the first index.
-            Third axis corresponds to the segmented contraction within `contractions_two`. `M_2` is
-            the number of segmented contractions with the same exponents (and angular momentum)
+            Dimension 2 corresponds to the segmented contraction within `contractions_two`.
+            :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+            momentum) associated with the second index.
+            Dimension 3 corresponds to the angular momentum vector of the `contractions_two`.
+            :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
             associated with the second index.
-            Fourth axis corresponds to the angular momentum vector of the `contractions_two`.
-            `L_cart_2` is the number of Cartesian contractions for the given angular momentum
-            associated with the second index.
-            Fifth axis corresponds to the orders of the moments. `D` is the number of orders for
+            Dimension 4 corresponds to the orders of the moments. `D` is the number of orders for
             which the moment is computed.
 
         Raises
         ------
         TypeError
-            If contractions_one is not a GeneralizedContractionShell instance.
-            If contractions_two is not a GeneralizedContractionShell instance.
-            If moment_coord is not a one-dimensional numpy array with 3 elements.
-            If moment_orders is not a two-dimensional numpy array with 3 columns and dtype int.
+            If contractions_one is not a `GeneralizedContractionShell` instance.
+            If contractions_two is not a `GeneralizedContractionShell` instance.
+            If moment_coord is not a one-dimensional `numpy` array with 3 elements.
+            If moment_orders is not a two-dimensional `numpy` array with 3 columns and `dtype` int.
 
         Notes
         -----
         Even though it will be faster to access the different orders of moments if it was associated
-        with the first axis, the API will be consistent with the rest of the BaseTwoSymmetric class
-        if the first four indices correspond to the segmented contraction and the angular momentum
-        vector. If many orders of moments are calculated (the exact number depends on the size of
-        the basis set), then it may be faster to access the moments if the fifth axis is moved back
-        to the front prior to the access. Use `np.transpose(array, (4, 0, 1, 2, 3))` to change the
-        order.
+        with the first axis, the API will be consistent with the rest of the `BaseTwoSymmetric`
+        class if the first four indices correspond to the segmented contraction and the angular
+        momentum vector. If many orders of moments are calculated (the exact number depends on the
+        size of the basis set), then it may be faster to access the moments if the fifth axis is
+        moved back to the front prior to the access. Use `np.transpose(array, (4, 0, 1, 2, 3))`
+        to change the order.
 
         """
         # pylint: disable=R0914
         if not isinstance(contractions_one, GeneralizedContractionShell):
-            raise TypeError("`contractions_one` must be a GeneralizedContractionShell instance.")
+            raise TypeError("`contractions_one` must be a `GeneralizedContractionShell` instance.")
         if not isinstance(contractions_two, GeneralizedContractionShell):
-            raise TypeError("`contractions_two` must be a GeneralizedContractionShell instance.")
+            raise TypeError("`contractions_two` must be a `GeneralizedContractionShell` instance.")
         if not (
             isinstance(moment_coord, np.ndarray)
             and moment_coord.ndim == 1
             and moment_coord.size == 3
         ):
-            raise TypeError("`moment_coord` must be a one-dimensional numpy array with 3 elements.")
+            raise TypeError(
+                "`moment_coord` must be a one-dimensional `numpy` array with 3 elements."
+            )
         if not (
             isinstance(moment_orders, np.ndarray)
             and moment_orders.ndim == 2
@@ -126,7 +126,8 @@ class Moment(BaseTwoIndexSymmetric):
             and moment_orders.dtype == int
         ):
             raise TypeError(
-                "`moment_orders` must be a two-dimensional numpy array with 3 columns and dtype int"
+                "`moment_orders` must be a two-dimensional `numpy` array with 3 columns and `dtype`"
+                " int"
             )
 
         coord_a = contractions_one.coord
@@ -166,7 +167,7 @@ def moment_integral(basis, moment_coord, moment_orders, transform=None, coord_ty
     moment_coord : np.ndarray(3,)
         Center of the moment.
     moment_orders : np.ndarray(D, 3)
-        Orders of the moment for each dimension (x, y, z).
+        Orders of the moment for each dimension :math:`(x, y, z)`.
         Note that a two dimensional array must be given, even if there is only one set of orders
         of the moment.
     transform : np.ndarray(K_orbs, K_cont)
@@ -180,16 +181,17 @@ def moment_integral(basis, moment_coord, moment_orders, transform=None, coord_ty
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each GeneralizedContractionShell instance.
+        coordinate type of each `GeneralizedContractionShell` instance.
         Default value is "spherical".
 
     Returns
     -------
     array : np.ndarray(K_orbs, K_orbs, D)
         Moment integral of the given basis set.
-        Dimensions 0 and 1 of the array correspond to the basis functions. `K_orbs` is the number of
-        basis functions in the basis set.
-        Dimension 2 of the array coresponds to the moment. `D` is the number of different moments.
+        Dimensions 0 and 1 of the array correspond to the basis functions. :math:`K_orbs` is the
+        number of basis functions in the basis set.
+        Dimension 2 of the array corresponds to the moment.
+        :math:`D` is the number of different moments.
 
     Notes
     -----

--- a/gbasis/integrals/momentum.py
+++ b/gbasis/integrals/momentum.py
@@ -13,11 +13,9 @@ class MomentumIntegral(BaseTwoIndexSymmetric):
     ----------
     _axes_contractions : tuple of tuple of GeneralizedContractionShell
         Sets of contractions associated with each axis of the array.
-
-    Properties
-    ----------
     contractions : tuple of GeneralizedContractionShell
         Contractions that are associated with the first and second indices of the array.
+        Property of `MomentumIntegral`.
 
     Methods
     -------
@@ -27,29 +25,29 @@ class MomentumIntegral(BaseTwoIndexSymmetric):
     np.ndarray(M_1, L_cart_1, M_2, L_cart_2, 3)
         Return the integral over the momentum operator associated with a
         `GeneralizedContractionShell` instance.
-        `M_1` is the number of segmented contractions with the same exponents (and angular momentum)
+        :math:`M_1` is the number of segmented contractions with the same exponents (and angular
+        momentum) associated with the first index.
+        :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
         associated with the first index.
-        `L_cart_1` is the number of Cartesian contractions for the given angular momentum associated
-        with the first index.
-        `M_2` is the number of segmented contractions with the same exponents (and angular momentum)
+        :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+        momentum) associated with the second index.
+        :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
         associated with the second index.
-        `L_cart_2` is the number of Cartesian contractions for the given angular momentum associated
-        with the second index.
     construct_array_cartesian(self) : np.ndarray(K_cart, K_cart, 3)
         Return the integral over the momentum operator associated with Cartesian Gaussians.
-        `K_cart` is the total number of Cartesian contractions within the instance.
+        :math:`K_cart` is the total number of Cartesian contractions within the instance.
     construct_array_spherical(self) : np.ndarray(K_sph, K_sph, 3)
         Return the integral over the momentum operator associated with spherical Gaussians (atomic
         orbitals).
-        `K_sph` is the total number of spherical contractions within the instance.
+        :math:`K_sph` is the total number of spherical contractions within the instance.
     construct_array_mix(self, coord_types) : np.ndarray(K_cont, K_cont, 3)
         Return the integral over the momentum operator associated with the contraction in the given
         coordinate system.
-        `K_cont` is the total number of contractions within the given basis set.
+        :math:`K_cont` is the total number of contractions within the given basis set.
     construct_array_spherical_lincomb(self, transform) : np.ndarray(K_orbs, K_orbs, 3)
         Return the integral over the momentum operator associated with linear combinations of
         spherical Gaussians (linear combinations of atomic orbitals).
-        `K_orbs` is the number of basis functions produced after the linear combinations.
+        :math:`K_orbs` is the number of basis functions produced after the linear combinations.
 
     """
 
@@ -70,32 +68,32 @@ class MomentumIntegral(BaseTwoIndexSymmetric):
         -------
         array_contraction : np.ndarray(M_1, L_cart_1, M_2, L_cart_2, 3)
             Integral over than momentum operator associated with the given instances of
-            GeneralizedContractionShell.
-            Dimension 0 corresponds to the segmented contraction within `contractions_one`. `M_1` is
+            `GeneralizedContractionShell`.
+            Dimension 0 corresponds to the segmented contraction within `cont_one`. :math:`M_1` is
             the number of segmented contractions with the same exponents (and angular momentum)
             associated with the first index.
-            Dimension 1 corresponds to the angular momentum vector of the `contractions_one`.
-            `L_cart_1` is the number of Cartesian contractions for the given angular momentum
+            Dimension 1 corresponds to the angular momentum vector of the `cont_one`.
+            :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
             associated with the first index.
-            Dimension 2 corresponds to the segmented contraction within `contractions_two`. `M_2` is
-            the number of segmented contractions with the same exponents (and angular momentum)
+            Dimension 2 corresponds to the segmented contraction within `cont_two`.
+            :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+            momentum) associated with the second index.
+            Dimension 3 corresponds to the angular momentum vector of the `cont_two`.
+            :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
             associated with the second index.
-            Dimension 3 corresponds to the angular momentum vector of the `contractions_two`.
-            `L_cart_2` is the number of Cartesian contractions for the given angular momentum
-            associated with the second index.
-            Dimension 4 corresponds to the dimension of the momentum (x, y, z).
+            Dimension 4 corresponds to the dimension of the momentum :math:`(x, y, z)`.
 
         Raises
         ------
         TypeError
-            If contractions_one is not a GeneralizedContractionShell instance.
-            If contractions_two is not a GeneralizedContractionShell instance.
+            If contractions_one is not a `GeneralizedContractionShell` instance.
+            If contractions_two is not a `GeneralizedContractionShell` instance.
 
         """
         if not isinstance(contractions_one, GeneralizedContractionShell):
-            raise TypeError("`contractions_one` must be a GeneralizedContractionShell instance.")
+            raise TypeError("`contractions_one` must be a `GeneralizedContractionShell` instance.")
         if not isinstance(contractions_two, GeneralizedContractionShell):
-            raise TypeError("`contractions_two` must be a GeneralizedContractionShell instance.")
+            raise TypeError("`contractions_two` must be a `GeneralizedContractionShell` instance.")
 
         output = _compute_differential_operator_integrals(
             np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
@@ -114,7 +112,7 @@ class MomentumIntegral(BaseTwoIndexSymmetric):
 
 
 def momentum_integral(basis, transform=None, coord_type="spherical"):
-    """Return integral over momentum operator of the given basi set.
+    """Return integral over momentum operator of the given basis set.
 
     Parameters
     ----------
@@ -131,15 +129,15 @@ def momentum_integral(basis, transform=None, coord_type="spherical"):
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each GeneralizedContractionShell instance.
+        coordinate type of each `GeneralizedContractionShell` instance.
         Default value is "spherical".
 
     Returns
     -------
     array : np.ndarray(K_orbs, K_orbs)
         Momentum integral of the given basis set.
-        Dimensions 0 and 1 of the array correspond to the basis functions. `K_orbs` is the number of
-        basis functions in the basis set.
+        Dimensions 0 and 1 of the array correspond to the basis functions. :math:`K_orbs` is the
+        number of basis functions in the basis set.
 
     """
 

--- a/gbasis/integrals/momentum.py
+++ b/gbasis/integrals/momentum.py
@@ -25,29 +25,29 @@ class MomentumIntegral(BaseTwoIndexSymmetric):
     np.ndarray(M_1, L_cart_1, M_2, L_cart_2, 3)
         Return the integral over the momentum operator associated with a
         `GeneralizedContractionShell` instance.
-        :math:`M_1` is the number of segmented contractions with the same exponents (and angular
+        `M_1` is the number of segmented contractions with the same exponents (and angular
         momentum) associated with the first index.
-        :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
+        `L_cart_1` is the number of Cartesian contractions for the given angular momentum
         associated with the first index.
-        :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+        `M_2` is the number of segmented contractions with the same exponents (and angular
         momentum) associated with the second index.
-        :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
+        `L_cart_2` is the number of Cartesian contractions for the given angular momentum
         associated with the second index.
     construct_array_cartesian(self) : np.ndarray(K_cart, K_cart, 3)
         Return the integral over the momentum operator associated with Cartesian Gaussians.
-        :math:`K_cart` is the total number of Cartesian contractions within the instance.
+        `K_cart` is the total number of Cartesian contractions within the instance.
     construct_array_spherical(self) : np.ndarray(K_sph, K_sph, 3)
         Return the integral over the momentum operator associated with spherical Gaussians (atomic
         orbitals).
-        :math:`K_sph` is the total number of spherical contractions within the instance.
+        `K_sph` is the total number of spherical contractions within the instance.
     construct_array_mix(self, coord_types) : np.ndarray(K_cont, K_cont, 3)
         Return the integral over the momentum operator associated with the contraction in the given
         coordinate system.
-        :math:`K_cont` is the total number of contractions within the given basis set.
+        `K_cont` is the total number of contractions within the given basis set.
     construct_array_spherical_lincomb(self, transform) : np.ndarray(K_orbs, K_orbs, 3)
         Return the integral over the momentum operator associated with linear combinations of
         spherical Gaussians (linear combinations of atomic orbitals).
-        :math:`K_orbs` is the number of basis functions produced after the linear combinations.
+        `K_orbs` is the number of basis functions produced after the linear combinations.
 
     """
 
@@ -69,19 +69,19 @@ class MomentumIntegral(BaseTwoIndexSymmetric):
         array_contraction : np.ndarray(M_1, L_cart_1, M_2, L_cart_2, 3)
             Integral over than momentum operator associated with the given instances of
             `GeneralizedContractionShell`.
-            Dimension 0 corresponds to the segmented contraction within `cont_one`. :math:`M_1` is
+            Dimension 0 corresponds to the segmented contraction within `cont_one`. `M_1` is
             the number of segmented contractions with the same exponents (and angular momentum)
             associated with the first index.
             Dimension 1 corresponds to the angular momentum vector of the `cont_one`.
-            :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
+            `L_cart_1` is the number of Cartesian contractions for the given angular momentum
             associated with the first index.
             Dimension 2 corresponds to the segmented contraction within `cont_two`.
-            :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+            `M_2` is the number of segmented contractions with the same exponents (and angular
             momentum) associated with the second index.
             Dimension 3 corresponds to the angular momentum vector of the `cont_two`.
-            :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
+            `L_cart_2` is the number of Cartesian contractions for the given angular momentum
             associated with the second index.
-            Dimension 4 corresponds to the dimension of the momentum :math:`(x, y, z)`.
+            Dimension 4 corresponds to the dimension of the momentum (x, y, z).
 
         Raises
         ------
@@ -136,7 +136,7 @@ def momentum_integral(basis, transform=None, coord_type="spherical"):
     -------
     array : np.ndarray(K_orbs, K_orbs)
         Momentum integral of the given basis set.
-        Dimensions 0 and 1 of the array correspond to the basis functions. :math:`K_orbs` is the
+        Dimensions 0 and 1 of the array correspond to the basis functions. `K_orbs` is the
         number of basis functions in the basis set.
 
     """

--- a/gbasis/integrals/nuclear_electron_attraction.py
+++ b/gbasis/integrals/nuclear_electron_attraction.py
@@ -21,14 +21,14 @@ def nuclear_electron_attraction_integral(
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each GeneralizedContractionShell instance.
+        coordinate type of each `GeneralizedContractionShell` instance.
         Default value is "spherical".
 
     Returns
     -------
     array : np.ndarray(K_cart, K_cart)
         Array associated with the given set of contracted Cartesian Gaussians.
-        First and second indices of the array are associated with the contracted Cartesian
+        Dimensions 0 and 1 are associated with the contracted Cartesian
         Gaussians. `K_cart` is the total number of Cartesian contractions within the instance.
 
     """

--- a/gbasis/integrals/nuclear_electron_attraction.py
+++ b/gbasis/integrals/nuclear_electron_attraction.py
@@ -16,6 +16,12 @@ def nuclear_electron_attraction_integral(
         Coordinates of each atom.
     nuclear_charges : np.ndarray(N_nuc)
         Charges of each atom.
+    transform : np.ndarray(K, K_cont)
+        Transformation matrix from the basis set in the given coordinate system (e.g. AO) to linear
+        combinations of contractions (e.g. MO).
+        Transformation is applied to the left, i.e. the sum is over the index 1 of `transform`
+        and index 0 of the array for contractions.
+        Default is no transformation.
     coord_type : {"cartesian", list/tuple of "cartesian" or "spherical", "spherical"}
         Types of the coordinate system for the contractions.
         If "cartesian", then all of the contractions are treated as Cartesian contractions.

--- a/gbasis/integrals/overlap.py
+++ b/gbasis/integrals/overlap.py
@@ -23,27 +23,27 @@ class Overlap(BaseTwoIndexSymmetric):
     construct_array_contraction(contractions_one, contractions_two) :
     np.ndarray(M_1, L_cart_1, M_2, L_cart_2)
         Return the overlap associated with a `GeneralizedContractionShell` instance.
-        :math:`M_1` is the number of segmented contractions with the same exponents (and angular
+        `M_1` is the number of segmented contractions with the same exponents (and angular
         momentum) associated with the first index.
-        :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
+        `L_cart_1` is the number of Cartesian contractions for the given angular momentum
         associated with the first index.
-        :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+        `M_2` is the number of segmented contractions with the same exponents (and angular
         momentum) associated with the second index.
-        :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
+        `L_cart_2` is the number of Cartesian contractions for the given angular momentum
         associated with the second index.
     construct_array_cartesian(self) : np.ndarray(K_cart, K_cart)
         Return the overlap integrals associated with Cartesian Gaussians.
-        :math:`K_cart` is the total number of Cartesian contractions within the instance.
+        `K_cart` is the total number of Cartesian contractions within the instance.
     construct_array_spherical(self) : np.ndarray(K_sph, K_sph)
         Return the overlap integrals associated with spherical Gaussians (atomic orbitals).
-        :math:`K_sph` is the total number of spherical contractions within the instance.
+        `K_sph` is the total number of spherical contractions within the instance.
     construct_array_mix(self, coord_types, **kwargs) : np.ndarray(K_cont, K_cont)
         Return the overlap integrals associated with the contraction in the given coordinate system.
-        :math:`K_cont` is the total number of contractions within the given basis set.
+        `K_cont` is the total number of contractions within the given basis set.
     construct_array_lincomb(self, transform) : np.ndarray(K_orbs, K_orbs)
         Return the overlap integrals associated with the linear combinations of contractions in the
         given coordinate system.
-        :math:`K_orbs` is the number of basis functions produced after the linear combinations.
+        `K_orbs` is the number of basis functions produced after the linear combinations.
 
     """
 
@@ -64,17 +64,17 @@ class Overlap(BaseTwoIndexSymmetric):
         -------
         array_contraction : np.ndarray(M_1, L_cart_1, M_2, L_cart_2)
             Overlap associated with the given instances of `GeneralizedContractionShell`.
-            Dimension 0 corresponds to the segmented contraction within `cont_one`. :math:`M_1` is
+            Dimension 0 corresponds to the segmented contraction within `cont_one`. `M_1` is
             the number of segmented contractions with the same exponents (and angular momentum)
             associated with the first index.
             Dimension 1 corresponds to the angular momentum vector of the `cont_one`.
-            :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
+            `L_cart_1` is the number of Cartesian contractions for the given angular momentum
             associated with the first index.
             Dimension 2 corresponds to the segmented contraction within `cont_two`.
-            :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+            `M_2` is the number of segmented contractions with the same exponents (and angular
             momentum) associated with the second index.
             Dimension 3 corresponds to the angular momentum vector of the `cont_two`.
-            :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
+            `L_cart_2` is the number of Cartesian contractions for the given angular momentum
             associated with the second index.
 
         Raises
@@ -132,7 +132,7 @@ def overlap_integral(basis, transform=None, coord_type="spherical"):
     -------
     array : np.ndarray(K_orbs, K_orbs)
         Overlap integral of the given basis set.
-        Dimensions 0 and 1 of the array correspond to the basis functions. :math:`K_orbs` is the
+        Dimensions 0 and 1 of the array correspond to the basis functions. `K_orbs` is the
         number of basis functions in the basis set.
 
     """

--- a/gbasis/integrals/overlap.py
+++ b/gbasis/integrals/overlap.py
@@ -89,29 +89,21 @@ class Overlap(BaseTwoIndexSymmetric):
         if not isinstance(contractions_two, GeneralizedContractionShell):
             raise TypeError("`contractions_two` must be a `GeneralizedContractionShell` instance.")
 
-        coord_a = contractions_one.coord
-        angmoms_a = contractions_one.angmom_components_cart
-        alphas_a = contractions_one.exps
-        coeffs_a = contractions_one.coeffs
-        norm_a_prim = contractions_one.norm_prim_cart
-        coord_b = contractions_two.coord
-        angmoms_b = contractions_two.angmom_components_cart
-        alphas_b = contractions_two.exps
-        coeffs_b = contractions_two.coeffs
-        norm_b_prim = contractions_two.norm_prim_cart
         return _compute_multipole_moment_integrals(
             np.zeros(3),
             np.zeros((1, 3), dtype=int),
-            coord_a,
-            angmoms_a,
-            alphas_a,
-            coeffs_a,
-            norm_a_prim,
-            coord_b,
-            angmoms_b,
-            alphas_b,
-            coeffs_b,
-            norm_b_prim,
+            # contraction on the left hand side
+            contractions_one.coord,
+            contractions_one.angmom_components_cart,
+            contractions_one.exps,
+            contractions_one.coeffs,
+            contractions_one.norm_prim_cart,
+            # contraction on the right hand side
+            contractions_two.coord,
+            contractions_two.angmom_components_cart,
+            contractions_two.exps,
+            contractions_two.coeffs,
+            contractions_two.norm_prim_cart,
         )[0]
 
 

--- a/gbasis/integrals/overlap.py
+++ b/gbasis/integrals/overlap.py
@@ -12,11 +12,9 @@ class Overlap(BaseTwoIndexSymmetric):
     ----------
     _axes_contractions : tuple of tuple of GeneralizedContractionShell
         Sets of contractions associated with each axis of the array.
-
-    Properties
-    ----------
     contractions : tuple of GeneralizedContractionShell
         Contractions that are associated with the first and second indices of the array.
+        Property of `Overlap`.
 
     Methods
     -------
@@ -25,27 +23,27 @@ class Overlap(BaseTwoIndexSymmetric):
     construct_array_contraction(contractions_one, contractions_two) :
     np.ndarray(M_1, L_cart_1, M_2, L_cart_2)
         Return the overlap associated with a `GeneralizedContractionShell` instance.
-        `M_1` is the number of segmented contractions with the same exponents (and angular momentum)
+        :math:`M_1` is the number of segmented contractions with the same exponents (and angular
+        momentum) associated with the first index.
+        :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
         associated with the first index.
-        `L_cart_1` is the number of Cartesian contractions for the given angular momentum associated
-        with the first index.
-        `M_2` is the number of segmented contractions with the same exponents (and angular momentum)
+        :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+        momentum) associated with the second index.
+        :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
         associated with the second index.
-        `L_cart_2` is the number of Cartesian contractions for the given angular momentum associated
-        with the second index.
     construct_array_cartesian(self) : np.ndarray(K_cart, K_cart)
         Return the overlap integrals associated with Cartesian Gaussians.
-        `K_cart` is the total number of Cartesian contractions within the instance.
+        :math:`K_cart` is the total number of Cartesian contractions within the instance.
     construct_array_spherical(self) : np.ndarray(K_sph, K_sph)
         Return the overlap integrals associated with spherical Gaussians (atomic orbitals).
-        `K_sph` is the total number of spherical contractions within the instance.
+        :math:`K_sph` is the total number of spherical contractions within the instance.
     construct_array_mix(self, coord_types, **kwargs) : np.ndarray(K_cont, K_cont)
         Return the overlap integrals associated with the contraction in the given coordinate system.
-        `K_cont` is the total number of contractions within the given basis set.
+        :math:`K_cont` is the total number of contractions within the given basis set.
     construct_array_lincomb(self, transform) : np.ndarray(K_orbs, K_orbs)
         Return the overlap integrals associated with the linear combinations of contractions in the
         given coordinate system.
-        `K_orbs` is the number of basis functions produced after the linear combinations.
+        :math:`K_orbs` is the number of basis functions produced after the linear combinations.
 
     """
 
@@ -65,31 +63,31 @@ class Overlap(BaseTwoIndexSymmetric):
         Returns
         -------
         array_contraction : np.ndarray(M_1, L_cart_1, M_2, L_cart_2)
-            Overlap associated with the given instances of GeneralizedContractionShell.
-            First axis corresponds to the segmented contraction within `contractions_one`. `M_1` is
+            Overlap associated with the given instances of `GeneralizedContractionShell`.
+            Dimension 0 corresponds to the segmented contraction within `cont_one`. :math:`M_1` is
             the number of segmented contractions with the same exponents (and angular momentum)
             associated with the first index.
-            Second axis corresponds to the angular momentum vector of the `contractions_one`.
-            `L_cart_1` is the number of Cartesian contractions for the given angular momentum
+            Dimension 1 corresponds to the angular momentum vector of the `cont_one`.
+            :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
             associated with the first index.
-            Third axis corresponds to the segmented contraction within `contractions_two`. `M_2` is
-            the number of segmented contractions with the same exponents (and angular momentum)
-            associated with the second index.
-            Fourth axis corresponds to the angular momentum vector of the `contractions_two`.
-            `L_cart_2` is the number of Cartesian contractions for the given angular momentum
+            Dimension 2 corresponds to the segmented contraction within `cont_two`.
+            :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+            momentum) associated with the second index.
+            Dimension 3 corresponds to the angular momentum vector of the `cont_two`.
+            :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
             associated with the second index.
 
         Raises
         ------
         TypeError
-            If contractions_one is not a GeneralizedContractionShell instance.
-            If contractions_two is not a GeneralizedContractionShell instance.
+            If contractions_one is not a `GeneralizedContractionShell` instance.
+            If contractions_two is not a `GeneralizedContractionShell` instance.
 
         """
         if not isinstance(contractions_one, GeneralizedContractionShell):
-            raise TypeError("`contractions_one` must be a GeneralizedContractionShell instance.")
+            raise TypeError("`contractions_one` must be a `GeneralizedContractionShell` instance.")
         if not isinstance(contractions_two, GeneralizedContractionShell):
-            raise TypeError("`contractions_two` must be a GeneralizedContractionShell instance.")
+            raise TypeError("`contractions_two` must be a `GeneralizedContractionShell` instance.")
 
         coord_a = contractions_one.coord
         angmoms_a = contractions_one.angmom_components_cart
@@ -135,15 +133,15 @@ def overlap_integral(basis, transform=None, coord_type="spherical"):
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each GeneralizedContractionShell instance.
+        coordinate type of each `GeneralizedContractionShell` instance.
         Default value is "spherical".
 
     Returns
     -------
     array : np.ndarray(K_orbs, K_orbs)
         Overlap integral of the given basis set.
-        Dimensions 0 and 1 of the array correspond to the basis functions. `K_orbs` is the number of
-        basis functions in the basis set.
+        Dimensions 0 and 1 of the array correspond to the basis functions. :math:`K_orbs` is the
+        number of basis functions in the basis set.
 
     """
     if transform is not None:

--- a/gbasis/integrals/overlap_asymm.py
+++ b/gbasis/integrals/overlap_asymm.py
@@ -24,36 +24,36 @@ class OverlapAsymmetric(BaseTwoIndexAsymmetric):
     construct_array_contraction(contractions_one, contractions_two) :
     np.ndarray(M_1, L_cart_1, M_2, L_cart_2)
         Return the overlap associated with the two `GeneralizedContractionShell` instances.
-        :math:`M_1` is the number of segmented contractions with the same exponents (and angular
+        `M_1` is the number of segmented contractions with the same exponents (and angular
         momentum) associated with the first index.
-        :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
+        `L_cart_1` is the number of Cartesian contractions for the given angular momentum
         associated with the first index.
-        :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+        `M_2` is the number of segmented contractions with the same exponents (and angular
         momentum) associated with the second index.
-        :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
+        `L_cart_2` is the number of Cartesian contractions for the given angular momentum
         associated with the second index.
     construct_array_cartesian(self) : np.ndarray(K_cart_1, K_cart_2)
         Return the overlap integrals between Cartesian Gaussians of the two basis sets.
-        :math:`K_cart_1` is the total number of Cartesian contractions within `contractions_one`.
-        :math:`K_cart_2` is the total number of Cartesian contractions within `contractions_two`.
+        `K_cart_1` is the total number of Cartesian contractions within `contractions_one`.
+        `K_cart_2` is the total number of Cartesian contractions within `contractions_two`.
     construct_array_spherical(self) : np.ndarray(K_sph_1, K_sph_2)
         Return the overlap integrals associated with spherical Gaussians (atomic orbitals) of the
         two basis sets.
-        :math:`K_sph_1` is the total number of spherical contractions within `contractions_one`.
-        :math:`K_sph_2` is the total number of spherical contractions within `contractions_two`.
+        `K_sph_1` is the total number of spherical contractions within `contractions_one`.
+        `K_sph_2` is the total number of spherical contractions within `contractions_two`.
     construct_array_mix(self, coord_types_one, coord_types_two) :
     np.ndarray(K_cont_1, K_cont_2)
         Return the overlap integrals associated with the contractions in the given coordinate
         systems of the two basis sets.
-        :math:`K_cont_1` is the total number of contractions within the given basis set.
-        :math:`K_cont_2` is the total number of contractions within the given basis set.
+        `K_cont_1` is the total number of contractions within the given basis set.
+        `K_cont_2` is the total number of contractions within the given basis set.
     construct_array_lincomb(self, transform_one, transform_two, coord_type_one, coord_type_two) :
     np.ndarray(K_orbs_1, K_orbs_2)
         Return the overlap integrals associated with the linear combinations of contractions of the
         two basis sets.
-        :math:`K_orbs_1` is the number of basis functions produced after the linear combinations of
+        `K_orbs_1` is the number of basis functions produced after the linear combinations of
         the spherical contractions associated with `contractions_one`.
-        :math:`K_orbs_2` is the number of basis functions produced after the linear combinations of
+        `K_orbs_2` is the number of basis functions produced after the linear combinations of
         the spherical contractions associated with `contractions_two`.
 
     """
@@ -109,9 +109,9 @@ def overlap_integral_asymmetric(
     array : np.ndarray(K_orbs_1, K_orbs_2)
         Overlap integral of the given basis set.
         Dimensions 0 of the array correspond to the basis functions in `basis_one`.
-        :math:`K_orbs_1` is the number of basis functions in the `basis_one`.
+        `K_orbs_1` is the number of basis functions in the `basis_one`.
         Dimensions 1 of the array correspond to the basis functions in `basis_two`.
-        :math:`K_orbs_2` is the number of basis functions in the `basis_two`.
+        `K_orbs_2` is the number of basis functions in the `basis_two`.
 
     """
     return OverlapAsymmetric(basis_one, basis_two).construct_array_lincomb(

--- a/gbasis/integrals/overlap_asymm.py
+++ b/gbasis/integrals/overlap_asymm.py
@@ -10,13 +10,12 @@ class OverlapAsymmetric(BaseTwoIndexAsymmetric):
     ----------
     _axes_contractions : tuple of tuple of GeneralizedContractionShell
         Sets of contractions associated with each axis of the array.
-
-    Properties
-    ----------
     contractions_one : tuple of GeneralizedContractionShell
         Contractions that are associated with the first index of the array.
+        Property of `OverlapAsymmetric`.
     contractions_two : tuple of GeneralizedContractionShell
         Contractions that are associated with the second index of the array.
+        Property of `OverlapAsymmetric`.
 
     Methods
     -------
@@ -25,37 +24,37 @@ class OverlapAsymmetric(BaseTwoIndexAsymmetric):
     construct_array_contraction(contractions_one, contractions_two) :
     np.ndarray(M_1, L_cart_1, M_2, L_cart_2)
         Return the overlap associated with the two `GeneralizedContractionShell` instances.
-        `M_1` is the number of segmented contractions with the same exponents (and angular momentum)
+        :math:`M_1` is the number of segmented contractions with the same exponents (and angular
+        momentum) associated with the first index.
+        :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
         associated with the first index.
-        `L_cart_1` is the number of Cartesian contractions for the given angular momentum associated
-        with the first index.
-        `M_2` is the number of segmented contractions with the same exponents (and angular momentum)
+        :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+        momentum) associated with the second index.
+        :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
         associated with the second index.
-        `L_cart_2` is the number of Cartesian contractions for the given angular momentum associated
-        with the second index.
     construct_array_cartesian(self) : np.ndarray(K_cart_1, K_cart_2)
         Return the overlap integrals between Cartesian Gaussians of the two basis sets.
-        `K_cart_1` is the total number of Cartesian contractions within the `contractions_one`.
-        `K_cart_2` is the total number of Cartesian contractions within the `contractions_two`.
+        :math:`K_cart_1` is the total number of Cartesian contractions within `contractions_one`.
+        :math:`K_cart_2` is the total number of Cartesian contractions within `contractions_two`.
     construct_array_spherical(self) : np.ndarray(K_sph_1, K_sph_2)
         Return the overlap integrals associated with spherical Gaussians (atomic orbitals) of the
         two basis sets.
-        `K_sph_1` is the total number of spherical contractions within the `contractions_one`.
-        `K_sph_2` is the total number of spherical contractions within the `contractions_two`.
+        :math:`K_sph_1` is the total number of spherical contractions within `contractions_one`.
+        :math:`K_sph_2` is the total number of spherical contractions within `contractions_two`.
     construct_array_mix(self, coord_types_one, coord_types_two) :
     np.ndarray(K_cont_1, K_cont_2)
         Return the overlap integrals associated with the contractions in the given coordinate
         systems of the two basis sets.
-        `K_cont_1` is the total number of contractions within the given basis set.
-        `K_cont_2` is the total number of contractions within the given basis set.
+        :math:`K_cont_1` is the total number of contractions within the given basis set.
+        :math:`K_cont_2` is the total number of contractions within the given basis set.
     construct_array_lincomb(self, transform_one, transform_two, coord_type_one, coord_type_two) :
     np.ndarray(K_orbs_1, K_orbs_2)
         Return the overlap integrals associated with the linear combinations of contractions of the
         two basis sets.
-        `K_orbs_1` is the number of basis functions produced after the linear combinations of the
-        spherical contractions associated with `contractions_one`.
-        `K_orbs_2` is the number of basis functions produced after the linear combinations of the
-        spherical contractions associated with `contractions_two`.
+        :math:`K_orbs_1` is the number of basis functions produced after the linear combinations of
+        the spherical contractions associated with `contractions_one`.
+        :math:`K_orbs_2` is the number of basis functions produced after the linear combinations of
+        the spherical contractions associated with `contractions_two`.
 
     """
 
@@ -95,24 +94,24 @@ def overlap_integral_asymmetric(
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each GeneralizedContractionShell instance.
+        coordinate type of each `GeneralizedContractionShell` instance.
         Default value is "spherical".
     coord_type_two : {"cartesian", list/tuple of "cartesian" or "spherical", "spherical"}
         Types of the coordinate system for the contractions in `basis_two`.
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each GeneralizedContractionShell instance.
+        coordinate type of each `GeneralizedContractionShell` instance.
         Default value is "spherical".
 
     Returns
     -------
     array : np.ndarray(K_orbs_1, K_orbs_2)
         Overlap integral of the given basis set.
-        Dimensions 0 of the array correspond to the basis functions in `basis_one`. `K_orbs_1` is
-        the number of basis functions in the `basis_one`.
-        Dimensions 1 of the array correspond to the basis functions in `basis_two`. `K_orbs_2` is
-        the number of basis functions in the `basis_two`.
+        Dimensions 0 of the array correspond to the basis functions in `basis_one`.
+        :math:`K_orbs_1` is the number of basis functions in the `basis_one`.
+        Dimensions 1 of the array correspond to the basis functions in `basis_two`.
+        :math:`K_orbs_2` is the number of basis functions in the `basis_two`.
 
     """
     return OverlapAsymmetric(basis_one, basis_two).construct_array_lincomb(

--- a/gbasis/integrals/point_charge.py
+++ b/gbasis/integrals/point_charge.py
@@ -24,11 +24,9 @@ class PointChargeIntegral(BaseTwoIndexSymmetric):
     ----------
     _axes_contractions : tuple of tuple of GeneralizedContractionShell
         Sets of contractions associated with each axis of the array.
-
-    Properties
-    ----------
     contractions : tuple of GeneralizedContractionShell
         Contractions that are associated with the first and second indices of the array.
+        Property of `PointChargeIntegral`.
 
     Methods
     -------
@@ -36,33 +34,33 @@ class PointChargeIntegral(BaseTwoIndexSymmetric):
         Initialize.
     boys_func : np.ndarray(np.ndarray(M, K_b, K_a))
         Boys function used to evaluate the one-electron integral.
-        `M` is the number of orders that will be evaluated. `K_a` and `K_b` are the number of
-        primitives on the left and right side, respectively.
+        `M` is the number of orders that will be evaluated.
+        `K_a` and `K_b` are the number of primitives on the left and right side, respectively.
     construct_array_contraction(self, contractions_one, contractions_two, points_coords,
-                                points_charges)
+                                points_charge)
         Return the point charge integrals for the given `GeneralizedContractionShell` instances.
-        `M_1` is the number of segmented contractions with the same exponents (and angular momentum)
+        :math:`M_1` is the number of segmented contractions with the same exponents (and angular
+        momentum) associated with the first index.
+        :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
         associated with the first index.
-        `L_cart_1` is the number of Cartesian contractions for the given angular momentum associated
-        with the first index.
-        `M_2` is the number of segmented contractions with the same exponents (and angular momentum)
+        :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+        momentum) associated with the second index.
+        :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
         associated with the second index.
-        `L_cart_2` is the number of Cartesian contractions for the given angular momentum associated
-        with the second index.
     construct_array_cartesian(self) : np.ndarray(K_cart, K_cart)
         Return the one-electron integrals associated with Cartesian Gaussians.
-        `K_cart` is the total number of Cartesian contractions within the instance.
+        :math:`K_cart` is the total number of Cartesian contractions within the instance.
     construct_array_spherical(self) : np.ndarray(K_sph, K_sph)
         Return the one-electron integrals associated with spherical Gaussians (atomic orbitals).
-        `K_sph` is the total number of spherical contractions within the instance.
+        :math:`K_sph` is the total number of spherical contractions within the instance.
     construct_array_mix(self, coord_types, **kwargs) : np.ndarray(K_cont, K_cont)
         Return the one-electron integrals associated with the contraction in the given coordinate
         system.
-        `K_cont` is the total number of contractions within the given basis set.
+        :math:`K_cont` is the total number of contractions within the given basis set.
     construct_array_lincomb(self, transform) : np.ndarray(K_orbs, K_orbs)
         Return the one-electron integrals associated with the linear combinations of contractions in
         the given coordinate system.
-        `K_orbs` is the number of basis functions produced after the linear combinations.
+        :math:`K_orbs` is the number of basis functions produced after the linear combinations.
 
     """
 
@@ -87,14 +85,16 @@ class PointChargeIntegral(BaseTwoIndexSymmetric):
 
             where :math:`\alpha_i` is the exponent of the ith primitive on the left side and the
             :math:`\beta_j` is the exponent of the jth primitive on the right side.
-            `N` is the number of point charges. `K_a` and `K_b` are the number of primitives on the
-            left and right side, respectively. Note that the index 2 corresponds to the primitive on
-            the right side and the index 3 corresponds to the primitive on the left side.
+            :math:`N` is the number of point charges.
+            :math:`K_a` and :math:`K_b` are the number of primitives on the left and right side,
+            respectively.
+            Note that the index 2 corresponds to the primitive on the right side and the index 3
+            corresponds to the primitive on the left side.
 
         Returns
         -------
         boys_eval : np.ndarray(M, N, K_b, K_a)
-            Output is the Boys function evaluated for each order and the weighted interactomic
+            Output is the Boys function evaluated for each order and the weighted interatomic
             distance.
 
         Notes
@@ -107,8 +107,8 @@ class PointChargeIntegral(BaseTwoIndexSymmetric):
 
         To use another `boys_func`, simply overwrite this function (via monkeypatching or
         inheritance) with the desired boys function. Make sure to follow the same API, i.e. *have
-        the same inputs including their shapes and types*. Note that the index `1` corresponds to
-        the primitive on the right side and the index `2` correspond to the primitive on the left
+        the same inputs including their shapes and types*. Note that the index `2` corresponds to
+        the primitive on the right side and the index `3` corresponds to the primitive on the left
         side.
 
         """
@@ -116,9 +116,9 @@ class PointChargeIntegral(BaseTwoIndexSymmetric):
 
     @classmethod
     def construct_array_contraction(
-        cls, contractions_one, contractions_two, points_coords, points_charges
+        cls, contractions_one, contractions_two, points_coords, points_charge
     ):
-        """Return point charge interaction integral for the given contractions and point charges.
+        r"""Return point charge interaction integral for the given contractions and point charges.
 
         Parameters
         ----------
@@ -129,50 +129,50 @@ class PointChargeIntegral(BaseTwoIndexSymmetric):
             Contracted Cartesian Gaussians (of the same shell) associated with the second index of
             the array.
         points_coords : np.ndarray(N, 3)
-            Coordinates of the point charges.
-            Rows correspond to the different point charges and columns correspond to the x, y, and z
-            components.
-        points_charges : np.ndarray(N)
-            Charge of the point charges.
+            Cartesian coordinates of each point charge.
+            Rows correspond to the different point charges and columns correspond to the
+            :math:`x, y, \text{and} z` components.
+        points_charge : np.ndarray(N)
+            Charge of each point charge.
 
         Returns
         -------
         array_contraction : np.ndarray(M_1, L_cart_1, M_2, L_cart_2, N)
             Point charge integral associated with the given instances of
-            GeneralizedContractionShell.
-            First axis corresponds to the segmented contraction within `contractions_one`. `M_1` is
+            `GeneralizedContractionShell`.
+            Dimension 0 corresponds to the segmented contraction within `cont_one`. :math:`M_1` is
             the number of segmented contractions with the same exponents (and angular momentum)
             associated with the first index.
-            Second axis corresponds to the angular momentum vector of the `contractions_one`.
-            `L_cart_1` is the number of Cartesian contractions for the given angular momentum
+            Dimension 1 corresponds to the angular momentum vector of the `cont_one`.
+            :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
             associated with the first index.
-            Third axis corresponds to the segmented contraction within `contractions_two`. `M_2` is
-            the number of segmented contractions with the same exponents (and angular momentum)
+            Dimension 2 corresponds to the segmented contraction within `cont_two`.
+            :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+            momentum) associated with the second index.
+            Dimension 3 corresponds to the angular momentum vector of the `cont_two`.
+            :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
             associated with the second index.
-            Fourth axis corresponds to the angular momentum vector of the `contractions_two`.
-            `L_cart_2` is the number of Cartesian contractions for the given angular momentum
-            associated with the second index.
-            Fifth axis cooresponds to the point charge. `N` is the number of points charges.
+            Dimension 4 corresponds to the point charge. `N` is the number of point charges.
 
         Raises
         ------
         TypeError
-            If `contractions_one` is not a GeneralizedContractionShell instance.
-            If `contractions_two` is not a GeneralizedContractionShell instance.
-            If `points_coords` is not a two-dimensional numpy array of dtype int/float with 3
+            If `contractions_one` is not a `GeneralizedContractionShell` instance.
+            If `contractions_two` is not a `GeneralizedContractionShell` instance.
+            If `points_coords` is not a two-dimensional `numpy` array of `dtype` int/float with 3
             columns.
-            If `points_charges` is not a one-dimensional numpy array of int/float.
+            If `points_charge` is not a one-dimensional `numpy` array of int/float.
         ValueError
             If `points_coords` does not have the same number of rows as the size of
-            `points_charges`.
+            `points_charge`.
 
         """
         # pylint: disable=R0914
 
         if not isinstance(contractions_one, GeneralizedContractionShell):
-            raise TypeError("`contractions_one` must be a GeneralizedContractionShell instance.")
+            raise TypeError("`contractions_one` must be a `GeneralizedContractionShell` instance.")
         if not isinstance(contractions_two, GeneralizedContractionShell):
-            raise TypeError("`contractions_two` must be a GeneralizedContractionShell instance.")
+            raise TypeError("`contractions_two` must be a `GeneralizedContractionShell` instance.")
         if not (
             isinstance(points_coords, np.ndarray)
             and points_coords.ndim == 2
@@ -180,21 +180,21 @@ class PointChargeIntegral(BaseTwoIndexSymmetric):
             and points_coords.dtype in [int, float]
         ):
             raise TypeError(
-                "`points_coords` must be a two-dimensional numpy array of dtype int/float with "
+                "`points_coords` must be a two-dimensional `numpy` array of `dtype` int/float with "
                 "three columns."
             )
         if not (
-            isinstance(points_charges, np.ndarray)
-            and points_charges.ndim == 1
-            and points_charges.dtype in [int, float]
+            isinstance(points_charge, np.ndarray)
+            and points_charge.ndim == 1
+            and points_charge.dtype in [int, float]
         ):
             raise TypeError(
-                "`points_charges` must be a one-dimensional numpy array of integers or floats."
+                "`points_charge` must be a one-dimensional `numpy` array of integers or floats."
             )
-        if points_coords.shape[0] != points_charges.size:
+        if points_coords.shape[0] != points_charge.size:
             raise ValueError(
                 "`points_coords` must have the same number of rows as there are elements in "
-                "`points_charges`."
+                "`points_charge`."
             )
 
         # TODO: Overlap screening
@@ -245,7 +245,7 @@ class PointChargeIntegral(BaseTwoIndexSymmetric):
         # axis 3 : angular momentum vector of contraction two (in the same order as angmoms_b)
         # axis 4 : point charge
         output = (
-            -points_charges
+            -points_charge
             * integrals[
                 np.arange(coeffs_a.shape[1])[:, None, None, None, None],
                 angmoms_a_x[None, :, None, None, None],
@@ -266,21 +266,19 @@ class PointChargeIntegral(BaseTwoIndexSymmetric):
 
 
 def point_charge_integral(
-    basis, points_coords, points_charges, transform=None, coord_type="spherical"
+    basis, points_coords, points_charge, transform=None, coord_type="spherical"
 ):
-    """Return the point-charge interaction integrals of basis set in the given coordinate systems.
+    r"""Return the point-charge interaction integrals of basis set in the given coordinate systems.
 
     Parameters
     ----------
     basis : list/tuple of GeneralizedContractionShell
         Shells of generalized contractions.
-    points : np.ndarray(N, 3)
-        Rows correspond to the points and columns correspond to the x, y, and z components.
     points_coords : np.ndarray(N, 3)
         Coordinates of the point charges (in atomic units).
-        Rows correspond to the different point charges and columns correspond to the x, y, and z
-        components.
-    points_charges : np.ndarray(N)
+        Rows correspond to the different point charges and columns correspond to the
+        :math:`x, y, \text{and} z` components.
+    points_charge : np.ndarray(N)
         Charge at each given point.
     transform : np.ndarray(K, K_cont)
         Transformation matrix from the basis set in the given coordinate system (e.g. AO) to linear
@@ -293,7 +291,7 @@ def point_charge_integral(
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
-        coordinate type of each GeneralizedContractionShell instance.
+        coordinate type of each `GeneralizedContractionShell` instance.
         Default value is "spherical".
 
     Returns
@@ -302,22 +300,22 @@ def point_charge_integral(
         Evaluations of the basis functions at the given coordinates.
         If keyword argument `transform` is provided, then the transformed basis functions will be
         evaluted at the given points.
-        `K` is the total number of basis functions within the given basis set.
-        `N` is the number of coordinates at which the contractions are evaluated.
+        :math:`K` is the total number of basis functions within the given basis set.
+        :math:`N` is the number of coordinates at which the contractions are evaluated.
 
     """
     if transform is not None:
         return PointChargeIntegral(basis).construct_array_lincomb(
-            transform, coord_type, points_coords=points_coords, points_charges=points_charges
+            transform, coord_type, points_coords=points_coords, points_charge=points_charge
         )
     if coord_type == "cartesian":
         return PointChargeIntegral(basis).construct_array_cartesian(
-            points_coords=points_coords, points_charges=points_charges
+            points_coords=points_coords, points_charge=points_charge
         )
     if coord_type == "spherical":
         return PointChargeIntegral(basis).construct_array_spherical(
-            points_coords=points_coords, points_charges=points_charges
+            points_coords=points_coords, points_charge=points_charge
         )
     return PointChargeIntegral(basis).construct_array_mix(
-        coord_type, points_coords=points_coords, points_charges=points_charges
+        coord_type, points_coords=points_coords, points_charge=points_charge
     )

--- a/gbasis/integrals/point_charge.py
+++ b/gbasis/integrals/point_charge.py
@@ -39,28 +39,28 @@ class PointChargeIntegral(BaseTwoIndexSymmetric):
     construct_array_contraction(self, contractions_one, contractions_two, points_coords,
                                 points_charge)
         Return the point charge integrals for the given `GeneralizedContractionShell` instances.
-        :math:`M_1` is the number of segmented contractions with the same exponents (and angular
+        `M_1` is the number of segmented contractions with the same exponents (and angular
         momentum) associated with the first index.
-        :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
+        `L_cart_1` is the number of Cartesian contractions for the given angular momentum
         associated with the first index.
-        :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+        `M_2` is the number of segmented contractions with the same exponents (and angular
         momentum) associated with the second index.
-        :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
+        `L_cart_2` is the number of Cartesian contractions for the given angular momentum
         associated with the second index.
     construct_array_cartesian(self) : np.ndarray(K_cart, K_cart)
         Return the one-electron integrals associated with Cartesian Gaussians.
-        :math:`K_cart` is the total number of Cartesian contractions within the instance.
+        `K_cart` is the total number of Cartesian contractions within the instance.
     construct_array_spherical(self) : np.ndarray(K_sph, K_sph)
         Return the one-electron integrals associated with spherical Gaussians (atomic orbitals).
-        :math:`K_sph` is the total number of spherical contractions within the instance.
+        `K_sph` is the total number of spherical contractions within the instance.
     construct_array_mix(self, coord_types, **kwargs) : np.ndarray(K_cont, K_cont)
         Return the one-electron integrals associated with the contraction in the given coordinate
         system.
-        :math:`K_cont` is the total number of contractions within the given basis set.
+        `K_cont` is the total number of contractions within the given basis set.
     construct_array_lincomb(self, transform) : np.ndarray(K_orbs, K_orbs)
         Return the one-electron integrals associated with the linear combinations of contractions in
         the given coordinate system.
-        :math:`K_orbs` is the number of basis functions produced after the linear combinations.
+        `K_orbs` is the number of basis functions produced after the linear combinations.
 
     """
 
@@ -85,8 +85,8 @@ class PointChargeIntegral(BaseTwoIndexSymmetric):
 
             where :math:`\alpha_i` is the exponent of the ith primitive on the left side and the
             :math:`\beta_j` is the exponent of the jth primitive on the right side.
-            :math:`N` is the number of point charges.
-            :math:`K_a` and :math:`K_b` are the number of primitives on the left and right side,
+            `N` is the number of point charges.
+            `K_a` and `K_b` are the number of primitives on the left and right side,
             respectively.
             Note that the index 2 corresponds to the primitive on the right side and the index 3
             corresponds to the primitive on the left side.
@@ -140,17 +140,17 @@ class PointChargeIntegral(BaseTwoIndexSymmetric):
         array_contraction : np.ndarray(M_1, L_cart_1, M_2, L_cart_2, N)
             Point charge integral associated with the given instances of
             `GeneralizedContractionShell`.
-            Dimension 0 corresponds to the segmented contraction within `cont_one`. :math:`M_1` is
+            Dimension 0 corresponds to the segmented contraction within `cont_one`. `M_1` is
             the number of segmented contractions with the same exponents (and angular momentum)
             associated with the first index.
             Dimension 1 corresponds to the angular momentum vector of the `cont_one`.
-            :math:`L_cart_1` is the number of Cartesian contractions for the given angular momentum
+            `L_cart_1` is the number of Cartesian contractions for the given angular momentum
             associated with the first index.
             Dimension 2 corresponds to the segmented contraction within `cont_two`.
-            :math:`M_2` is the number of segmented contractions with the same exponents (and angular
+            `M_2` is the number of segmented contractions with the same exponents (and angular
             momentum) associated with the second index.
             Dimension 3 corresponds to the angular momentum vector of the `cont_two`.
-            :math:`L_cart_2` is the number of Cartesian contractions for the given angular momentum
+            `L_cart_2` is the number of Cartesian contractions for the given angular momentum
             associated with the second index.
             Dimension 4 corresponds to the point charge. `N` is the number of point charges.
 
@@ -300,8 +300,8 @@ def point_charge_integral(
         Evaluations of the basis functions at the given coordinates.
         If keyword argument `transform` is provided, then the transformed basis functions will be
         evaluted at the given points.
-        :math:`K` is the total number of basis functions within the given basis set.
-        :math:`N` is the number of coordinates at which the contractions are evaluated.
+        `K` is the total number of basis functions within the given basis set.
+        `N` is the number of coordinates at which the contractions are evaluated.
 
     """
     if transform is not None:

--- a/gbasis/parsers.py
+++ b/gbasis/parsers.py
@@ -22,7 +22,7 @@ def parse_nwchem(nwchem_basis_file):
     Notes
     -----
     Angular momentum symbol is hard-coded into this function. This means that if the selected basis
-    set has an angular momentum greater tha "k", an error will be raised.
+    set has an angular momentum greater than "k", an error will be raised.
 
     """
     # pylint: disable=R0914
@@ -88,7 +88,7 @@ def parse_gbs(gbs_basis_file):
     Notes
     -----
     Angular momentum symbol is hard-coded into this function. This means that if the selected basis
-    set has an angular momentum greater tha "k", an error will be raised.
+    set has an angular momentum greater than "k", an error will be raised.
 
     Since Gaussian94 basis format does not explicitly state which contractions are generalized, we
     infer that subsequent contractions belong to the same generalized shell if they have the same
@@ -183,17 +183,17 @@ def make_contractions(basis_dict, atoms, coords):
     Raises
     ------
     TypeError
-        If atoms is not a list or tuple of strings.
-        If coords is not a two-dimensional numpy array with 3 columns.
+        If `atoms` is not a list or tuple of strings.
+        If `coords` is not a two-dimensional `numpy` array with 3 columns.
     ValueError
-        If the length of atoms is not equal to the number of rows of coords.
+        If the length of atoms is not equal to the number of rows of `coords`.
 
     """
     if not (isinstance(atoms, (list, tuple)) and all(isinstance(i, str) for i in atoms)):
         raise TypeError("Atoms must be provided as a list or tuple.")
     if not (isinstance(coords, np.ndarray) and coords.ndim == 2 and coords.shape[1] == 3):
         raise TypeError(
-            "Coordinates must be provided as a two-dimensional numpy array with three columns."
+            "Coordinates must be provided as a two-dimensional `numpy` array with three columns."
         )
     if len(atoms) != coords.shape[0]:
         raise ValueError("Number of atoms must be equal to the number of rows in the coordinates.")

--- a/gbasis/spherical.py
+++ b/gbasis/spherical.py
@@ -234,7 +234,7 @@ def generate_transformation(angmom, cartesian_order, spherical_order, apply_from
         The angular momentum :math:`\ell` of the basis function(s).
     cartesian_order : np.ndarray((angmom + 1) * (angmom + 2) / 2, 3)
         The x, y, and z components of the angular momentum for each primitive,
-        (:math:`\vec{a} = (a_x, a_y, a_z)`, where :math:`a_x + a_y + a_z = l`).
+        (:math:`\vec{a} = (a_x, a_y, a_z)`, where :math:`a_x + a_y + a_z = \ell`).
         The order in which the contractions are given defines the order in which
         they will appear in the transformation matrix.
     spherical_order : (2 * angmom + 1)-tuple/list of int

--- a/gbasis/spherical.py
+++ b/gbasis/spherical.py
@@ -4,9 +4,12 @@ from scipy.special import comb, factorial, factorial2
 
 
 def shift_factor(mag):
-    """Calculate the shift factor for solid harmonics.
+    r"""Calculate the shift factor for solid harmonics.
 
-    `shift_factor` = 0 if `mag` >= 0 and `shift_factor` = 1/2 if `mag` < 0.
+    .. math::
+       \mathrm{shift\_factor} = \begin{cases}
+       0 & \mathrm{mag} \geq 0\\
+       \frac{1}{2} & \mathrm{mag} < 0 \end{cases}
 
     Parameters
     ----------

--- a/gbasis/spherical.py
+++ b/gbasis/spherical.py
@@ -6,7 +6,7 @@ from scipy.special import comb, factorial, factorial2
 def shift_factor(mag):
     """Calculate the shift factor for solid harmonics.
 
-    shift_factor = 0 if mag >= 0 and shift_factor = 1/2 if mag < 0.
+    `shift_factor` = 0 if `mag` >= 0 and `shift_factor` = 1/2 if `mag` < 0.
 
     Parameters
     ----------
@@ -21,7 +21,7 @@ def shift_factor(mag):
     Raises
     ------
     TypeError
-        If mag is not an integer.
+        If `mag` is not an integer.
 
     """
     if not isinstance(mag, int):
@@ -59,14 +59,15 @@ def expansion_coeff(angmom, mag, i, j, k):
     Raises
     ------
     TypeError
-        If angmom is not an integer.
-        If mag is not an integer.
-        If i or j is not an integer.
-        If k is not a float.
+        If `angmom` is not an integer.
+        If `mag` is not an integer.
+        If `i` is not an integer.
+        If `j` is not an integer.
+        If `k` is not a float.
     ValueError
-        If angmom is negative.
-        If mag has a greater magnitude than angmom.
-        If k is not either an integer (mag >= 0) or a half integer (mag < 0).
+        If `angmom` is negative.
+        If `mag` has a greater magnitude than angmom.
+        If `k is not either an integer (mag >= 0) or a half integer (mag < 0).
 
     """
     if not isinstance(angmom, int):
@@ -76,19 +77,19 @@ def expansion_coeff(angmom, mag, i, j, k):
     if not isinstance(mag, int):
         raise TypeError("The magnetic quantum number must be an integer.")
     if np.abs(mag) > angmom:
-        raise ValueError("The magnetic quantum number must be between -(angmom) and angmom.")
+        raise ValueError("The magnetic quantum number must be between -(`angmom`) and `angmom`.")
     if not isinstance(i, int):
-        raise TypeError("Index i must be an integer")
+        raise TypeError("Index `i` must be an integer")
     if not isinstance(j, int):
-        raise TypeError("Index j must be an integer")
+        raise TypeError("Index `j` must be an integer")
     if isinstance(k, int):
         k = float(k)
     if not isinstance(k, float):
-        raise TypeError("Index k must be a float.")
+        raise TypeError("Index `k` must be a float.")
     if k != int(k) and mag >= 0:
-        raise ValueError("Index k must be an integer for non-negative magnetic quantum numbers.")
+        raise ValueError("Index `k` must be an integer for non-negative magnetic quantum numbers.")
     if k != int(k) + 0.5 and mag < 0:
-        raise ValueError("Index k must be a half integer for negative magnetic quantum numbers.")
+        raise ValueError("Index `k` must be a half integer for negative magnetic quantum numbers.")
 
     if mag < 0:
         return np.real(
@@ -133,11 +134,11 @@ def harmonic_norm(angmom, mag):
     Raises
     ------
     TypeError
-        If angmom is not an integer.
-        If mag is not an integer.
+        If `angmom` is not an integer.
+        If `mag` is not an integer.
     ValueError
-        If angmom is negative.
-        If mag has a greater magnitude than angmom.
+        If `angmom` is negative.
+        If `mag` has a greater magnitude than `angmom`.
 
     """
     if not isinstance(angmom, int):
@@ -147,7 +148,7 @@ def harmonic_norm(angmom, mag):
     if not isinstance(mag, int):
         raise TypeError("The magnetic quantum number must be an integer.")
     if np.abs(mag) > angmom:
-        raise ValueError("The magnetic quantum number must be between -(angmom) and angmom.")
+        raise ValueError("The magnetic quantum number must be between -(`angmom`) and `angmom`.")
 
     return (1 / (2 ** np.abs(mag) * factorial(angmom))) * np.sqrt(
         (2 * factorial(angmom + np.abs(mag)) * factorial(angmom - np.abs(mag)))
@@ -181,11 +182,11 @@ def real_solid_harmonic(angmom, mag):
     Raises
     ------
     TypeError
-        If angmom is not an integer.
-        If mag is not an integer.
+        If `angmom` is not an integer.
+        If `mag` is not an integer.
     ValueError
-        If angmom is negative.
-        If mag has a greater magnitude than angmom.
+        If `angmom` is negative.
+        If `mag` has a greater magnitude than `angmom`.
 
     """
     if not isinstance(angmom, int):
@@ -195,7 +196,7 @@ def real_solid_harmonic(angmom, mag):
     if not isinstance(mag, int):
         raise TypeError("The magnetic quantum number must be an integer.")
     if np.abs(mag) > angmom:
-        raise ValueError("The magnetic quantum number must be between -(angmom) and angmom.")
+        raise ValueError("The magnetic quantum number must be between -(`angmom`) and `angmom`.")
 
     harmonic = {}
     norm = harmonic_norm(angmom, mag)
@@ -227,7 +228,7 @@ def generate_transformation(angmom, cartesian_order, spherical_order, apply_from
     Parameters
     ----------
     angmom : int
-        The angular momentum of the basis function(s).
+        The angular momentum :math:`\ell` of the basis function(s).
     cartesian_order : np.ndarray((angmom + 1) * (angmom + 2) / 2, 3)
         The x, y, and z components of the angular momentum for each primitive,
         (:math:`\vec{a} = (a_x, a_y, a_z)`, where :math:`a_x + a_y + a_z = l`).
@@ -246,17 +247,17 @@ def generate_transformation(angmom, cartesian_order, spherical_order, apply_from
     Raises
     ------
     TypeError
-        If angmom is not an integer.
-        If cartesian_order is not an array.
-        If each member of cartesian_order is not a tuple.
+        If `angmom` is not an integer.
+        If `cartesian_order` is not an array.
+        If each member of `cartesian_order` is not a tuple.
         If `spherical_order` is not a list/tuple of integers
     ValueError
-        If angmom is negative.
-        If cartesian_order does not have shape (angmom, 3).
-        If the Cartesian components of any contracitons do not sum to angmom.
+        If `angmom` is negative.
+        If `cartesian_order` does not have `shape` :math:`(\ell, 3)`.
+        If the Cartesian components of any contractions do not sum to `angmom`.
         If `apply_from` is not one of "left" or "right".
-        If `spherical_order` does not contain exactly 2 * angmom + 1 integers that ranges from
-        -angmom to angmom.
+        If `spherical_order` does not contain exactly :math:`2 * \ell + 1` integers that range from
+        -`angmom` to `angmom`.
 
     """
     if not isinstance(angmom, int):
@@ -290,8 +291,8 @@ def generate_transformation(angmom, cartesian_order, spherical_order, apply_from
         and set(spherical_order) == set(range(-angmom, angmom + 1))
     ):
         raise ValueError(
-            "`spherical_order` must contain exactly 2 * angmom + 1 integers that ranges from "
-            " -angmom to angmom."
+            "`spherical_order` must contain exactly 2 * `angmom` + 1 integers that range from "
+            " -`angmom` to `angmom`."
         )
 
     order = {

--- a/gbasis/spherical.py
+++ b/gbasis/spherical.py
@@ -1,4 +1,4 @@
-"""Convert from Cartesian Gaussians to Spherical Gaussians."""
+"""Convert from Cartesian Gaussians to spherical Gaussians."""
 import numpy as np
 from scipy.special import comb, factorial, factorial2
 

--- a/gbasis/wrappers.py
+++ b/gbasis/wrappers.py
@@ -4,30 +4,30 @@ import numpy as np
 
 
 def from_iodata(mol):
-    """Return basis set stored within the IOData instance in iodata.
+    """Return basis set stored within the `IOData` instance in `iodata`.
 
     Parameters
     ----------
     mol : iodata.iodata.IOData
-        IOData instance from iodata module.
+        `IOData` instance from `iodata` module.
 
     Returns
     -------
     basis : tuple of gbasis.contraciton.GeneralizedContractionShell
-        Basis set object used within the gbasis module.
-        GeneralizedContractionShell corresponds to the Shell object within iodata.basis.
+        Basis set object used within the `gbasis` module.
+        `GeneralizedContractionShell` corresponds to the `Shell` object within `iodata.basis`.
 
     Raises
     ------
     NotImplementedError
-        If any contractions in the given IOData instance is spherical.
+        If any contractions in the given `IOData` instance is spherical.
     ValueError
-        If `mol` is not an iodata.iodata.IOData instance.
-        If the primitive normalization scheme of the shells in IOData instance is not "L2".
+        If `mol` is not an `iodata.iodata.IOData` instance.
+        If the primitive normalization scheme of the shells in `IOData` instance is not "L2".
 
     Notes
     -----
-    The version of the module iodata must be greater than 0.1.7.
+    The version of the module `iodata` must be greater than 0.1.7.
 
     """
     if not (
@@ -48,7 +48,7 @@ def from_iodata(mol):
     iodata_angmom = "spdfghiklmnoqrtuvwxyzabce"
 
     class IODataShell(GeneralizedContractionShell):
-        """Shell object that is compatible with gbasis' shell object.
+        """Shell object that is compatible with `gbasis`' shell object.
 
         See `gbasis.contractions.GeneralizedContractionShell` for the documentation.
 
@@ -56,7 +56,7 @@ def from_iodata(mol):
 
         @property
         def angmom_components_cart(self):
-            r"""Return the angular momentum components as ordered within the MolecularBasis.
+            r"""Return the angular momentum components as ordered within the `MolecularBasis`.
 
             Returns
             -------
@@ -75,7 +75,7 @@ def from_iodata(mol):
 
         @property
         def angmom_components_sph(self):
-            """Return the ordering of the magnetic quantum numbers for the given angmom.
+            """Return the ordering of the magnetic quantum numbers for the given angular momentum.
 
             Returns
             -------
@@ -132,7 +132,7 @@ def from_iodata(mol):
 
     if molbasis.primitive_normalization != "L2":  # pragma: no cover
         raise ValueError(
-            "Only L2 normalization scheme is supported in gbasis. Given IOData instance uses "
+            "Only L2 normalization scheme is supported in `gbasis`. Given `IOData` instance uses "
             "primitive normalization scheme, {}".format(molbasis.primitive_normalization)
         )
 
@@ -176,34 +176,34 @@ def from_iodata(mol):
 
 
 def from_pyscf(mol):
-    """Return basis set stored within the Mole instance in pyscf.
+    """Return basis set stored within the `Mole` instance in `pyscf`.
 
     Parameters
     ----------
     mol : pyscf.gto.mole.Mole
-        Mole object in pyscf.
+        `Mole` object in `pyscf`.
 
     Returns
     -------
     basis : tuple of gbasis.contraciton.GeneralizedContractionShell
         Contractions for each atom.
-        Contractions are ordered by the atom first, then the contractions as ordered in pyscf.
+        Contractions are ordered by the atom first, then the contractions as ordered in `pyscf`.
 
     Raises
     ------
     ValueError
-        If `mol` is not a pyscf.gto.mole.Mole instance.
+        If `mol` is not a `pyscf.gto.mole.Mole` instance.
 
     Notes
     -----
-    This function touches the internal components of pyscf, which may or may not be documented. This
-    function will break as soon as the internal components change. If so, please raise an issue at
-    https://github.com/theochem/gbasis. It is supported for, at least, pyscf version 1.6.1.
+    This function touches the internal components of `pyscf`, which may or may not be documented.
+    This function will break as soon as the internal components change. If so, please raise an issue
+    at https://github.com/theochem/gbasis. It is supported for, at least, `pyscf` version 1.6.1.
 
     """
     # pylint: disable=W0212
     if not (mol.__class__.__name__ == "Mole" and hasattr(mol, "_basis")):
-        raise ValueError("`mol` must be a pyscf.gto.mole.Mole instance.")
+        raise ValueError("`mol` must be a `pyscf.gto.mole.Mole` instance.")
 
     basis = []
     for atom, coord in mol._atom:

--- a/gbasis/wrappers.py
+++ b/gbasis/wrappers.py
@@ -64,7 +64,7 @@ def from_iodata(mol):
                 The x, y, and z components of the angular momentum vectors
                 (:math:`\vec{a} = (a_x, a_y, a_z)` where :math:`a_x + a_y + a_z = \ell`).
                 `L` is the number of Cartesian contracted Gaussian functions for the given
-                angular momentum, i.e. :math:`(angmom + 1) * (angmom + 2) / 2`
+                angular momentum, i.e. :math:`(\ell + 1) * (\ell + 2) / 2`
 
             """
             if self.angmom == 0:

--- a/gbasis/wrappers.py
+++ b/gbasis/wrappers.py
@@ -63,7 +63,7 @@ def from_iodata(mol):
             angmom_components_cart : np.ndarray(L, 3)
                 The x, y, and z components of the angular momentum vectors
                 (:math:`\vec{a} = (a_x, a_y, a_z)` where :math:`a_x + a_y + a_z = \ell`).
-                :math:`L` is the number of Cartesian contracted Gaussian functions for the given
+                `L` is the number of Cartesian contracted Gaussian functions for the given
                 angular momentum, i.e. :math:`(angmom + 1) * (angmom + 2) / 2`
 
             """

--- a/tests/test_base_four_symm.py
+++ b/tests/test_base_four_symm.py
@@ -19,14 +19,14 @@ def test_init():
 
 
 def test_contractions():
-    """Test BaseFourIndexSymmetric.constractions."""
+    """Test BaseFourIndexSymmetric.contractions."""
     Test = disable_abstract(BaseFourIndexSymmetric)  # noqa: N806
     cont = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     test = Test([cont])
     assert test.contractions[0] == cont
 
 
-def test_contruct_array_contraction():
+def test_construct_array_contraction():
     """Test BaseFourIndexSymmetric.construct_array_contraction."""
     # enable only the abstract method construct_array_contraction
     Test = disable_abstract(  # noqa: N806
@@ -40,7 +40,7 @@ def test_contruct_array_contraction():
         Test([contractions])
 
 
-def test_contruct_array_cartesian():
+def test_construct_array_cartesian():
     """Test BaseFourIndexSymmetric.construct_array_cartesian."""
     cont_one = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones((1, 1)), np.ones(1))
     cont_two = GeneralizedContractionShell(2, np.array([2, 3, 4]), np.ones((1, 1)), 2 * np.ones(1))
@@ -89,7 +89,7 @@ def test_contruct_array_cartesian():
     assert np.allclose(test.construct_array_cartesian(), answer)
 
 
-def test_contruct_array_spherical():
+def test_construct_array_spherical():
     """Test BaseFourIndexSymmetric.construct_array_spherical."""
     contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     transform = generate_transformation(
@@ -165,7 +165,7 @@ def test_contruct_array_spherical():
     cont_two.norm_cont = np.ones((1, cont_two.num_cart))
     test = Test([cont_one, cont_two])
     # NOTE: since the test subarray (output of construct_array_contraction) does not satisfy the
-    # symmeteries of the two electron integral, only the last permutation is used. If this output
+    # symmetries of the two electron integral, only the last permutation is used. If this output
     # satisfies the symmetries of two electron integrals, then all these permutations should result
     # in the same array.
     # FIXME: not a good test
@@ -398,7 +398,7 @@ def test_contruct_array_spherical():
     )
 
 
-def test_contruct_array_mix():
+def test_construct_array_mix():
     """Test BaseFourIndex.construct_array_mix."""
     contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
 
@@ -509,7 +509,7 @@ def test_contruct_array_mix():
         test.construct_array_mix(["cartesian"] * 3, a=3),
 
 
-def test_contruct_array_lincomb():
+def test_construct_array_lincomb():
     """Test BaseFourIndexSymmetric.construct_array_lincomb."""
     contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
     sph_transform = generate_transformation(
@@ -601,7 +601,7 @@ def test_contruct_array_lincomb():
     )
     orb_transform = np.random.rand(8, 8)
     # NOTE: since the test subarray (output of construct_array_contraction) does not satisfy the
-    # symmeteries of the two electron integral, only the last permutation is used. If this output
+    # symmetries of the two electron integral, only the last permutation is used. If this output
     # satisfies the symmetries of two electron integrals, then all these permutations should result
     # in the same array.
     # FIXME: not a good test

--- a/tests/test_point_charge.py
+++ b/tests/test_point_charge.py
@@ -123,16 +123,13 @@ def test_point_charge_cartesian():
     point_charge_obj = PointChargeIntegral(basis)
 
     points_coords = np.random.rand(5, 3)
-    points_charges = np.random.rand(5)
+    points_charge = np.random.rand(5)
     assert np.allclose(
         point_charge_obj.construct_array_cartesian(
-            points_coords=points_coords, points_charges=points_charges
+            points_coords=points_coords, points_charge=points_charge
         ),
         point_charge_integral(
-            basis,
-            points_coords=points_coords,
-            points_charges=points_charges,
-            coord_type="cartesian",
+            basis, points_coords=points_coords, points_charge=points_charge, coord_type="cartesian"
         ),
     )
 
@@ -144,16 +141,13 @@ def test_point_charge_spherical():
     point_charge_obj = PointChargeIntegral(basis)
 
     points_coords = np.random.rand(5, 3)
-    points_charges = np.random.rand(5)
+    points_charge = np.random.rand(5)
     assert np.allclose(
         point_charge_obj.construct_array_spherical(
-            points_coords=points_coords, points_charges=points_charges
+            points_coords=points_coords, points_charge=points_charge
         ),
         point_charge_integral(
-            basis,
-            points_coords=points_coords,
-            points_charges=points_charges,
-            coord_type="spherical",
+            basis, points_coords=points_coords, points_charge=points_charge, coord_type="spherical"
         ),
     )
 
@@ -165,12 +159,12 @@ def test_point_charge_mix():
     point_charge_obj = PointChargeIntegral(basis)
 
     points_coords = np.random.rand(5, 3)
-    points_charges = np.random.rand(5)
+    points_charge = np.random.rand(5)
     assert np.allclose(
         point_charge_obj.construct_array_mix(
-            ["spherical"] * 8, points_coords=points_coords, points_charges=points_charges
+            ["spherical"] * 8, points_coords=points_coords, points_charge=points_charge
         ),
-        point_charge_integral(basis, points_coords, points_charges, coord_type=["spherical"] * 8),
+        point_charge_integral(basis, points_coords, points_charge, coord_type=["spherical"] * 8),
     )
 
 
@@ -181,13 +175,13 @@ def test_point_charge_lincomb():
     point_charge_obj = PointChargeIntegral(basis)
 
     points_coords = np.random.rand(5, 3)
-    points_charges = np.random.rand(5)
+    points_charge = np.random.rand(5)
     transform = np.random.rand(14, 18)
     assert np.allclose(
         point_charge_obj.construct_array_lincomb(
-            transform, "spherical", points_coords=points_coords, points_charges=points_charges
+            transform, "spherical", points_coords=points_coords, points_charge=points_charge
         ),
         point_charge_integral(
-            basis, points_coords=points_coords, points_charges=points_charges, transform=transform
+            basis, points_coords=points_coords, points_charge=points_charge, transform=transform
         ),
     )


### PR DESCRIPTION
Currently there are some docstring section headers that aren't recognized by Napoleon/numpydoc guidelines.