### PR TITLE
 Add interface to pyscf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,10 @@ matrix:
       sudo: required
       dist: xenial
       env: TOXENV=py37
+    - python: 3.6
+      env: TOXENV=optional
+  allow_failures:
+    - python: 3.6
+      env: TOXENV=optional
 install: pip install tox
 script: tox

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
         ],
         "test": ["tox", "pytest", "pytest-cov"],
         "iodata": ["tox", "iodata>0.1.7"],
+        "pyscf": ["tox", "pyscf>=1.6.1"],
     },
     # If there are data files included in your packages that need to be
     # installed, specify them here.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,qa
+envlist = py35,py36,py37,qa,optional
 
 [flake8]
 max-line-length = 100
@@ -29,6 +29,16 @@ ignore =
 
 [testenv]
 deps =
+    pytest
+    pytest-cov
+commands =
+    pytest --cov={envsitepackagesdir}/gbasis --cov-branch tests
+# prevent exit when error is encountered
+ignore_errors = true
+
+[testenv:optional]
+deps =
+    pyscf
     pytest
     pytest-cov
 commands =


### PR DESCRIPTION
Issue:
Couple hacky things:
1. I didn't want to have pyscf dependency, so the input is checked by the class
and attribute names
2. Tox doesn't install pyscf, which means that this part won't be tested by
travis (but it is tested with 100% coverage)