### PR TITLE
Clean up porcelain

### DIFF
--- a/gbasis/angular_momentum.py
+++ b/gbasis/angular_momentum.py
@@ -155,96 +155,40 @@ class AngularMomentumIntegral(BaseTwoIndexSymmetric):
         return -1j * np.transpose(output, (3, 2, 4, 1, 0))
 
 
-def angular_momentum_integral_cartesian(basis):
-    r"""Return the integral over :math:`hat{L}` of the basis set in the Cartesian form.
+def angular_momentum_integral(basis, transform=None, coord_type="spherical"):
+    r"""Return the integral over :math:`hat{L}` of the given basis set.
 
     Parameters
     ----------
     basis : list/tuple of GeneralizedContractionShell
-        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
-
-    Returns
-    -------
-    array : np.ndarray(K_cart, K_cart, 3)
-        Array associated with the given set of contracted Cartesian Gaussians.
-        Dimensions 0 and 1 of the array are associated with the contracted Cartesian Gaussians.
-        `K_cart` is the total number of Cartesian contractions within the instance.
-        Dimension 2 corresponds to the direction of the angular momentum (x, y, z).
-
-    """
-    return AngularMomentumIntegral(basis).construct_array_cartesian()
-
-
-def angular_momentum_integral_spherical(basis):
-    r"""Return the integral over :math:`hat{L}` of the basis set in the spherical form.
-
-    Parameters
-    ----------
-    basis : list/tuple of GeneralizedContractionShell
-        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
-
-    Returns
-    -------
-    array : np.ndarray(K_sph, K_sph, 3)
-        Array associated with the given set of contracted spherical Gaussians.
-        Dimensions of the array are associated with two contracted spherical Gaussians (atomic
-        orbitals). `K_sph` is the total number of spherical contractions within the instance.
-        Dimension 2 corresponds to the direction of the angular momentum (x, y, z).
-
-    """
-    return AngularMomentumIntegral(basis).construct_array_spherical()
-
-
-def angular_momentum_integral_mix(basis, coord_types):
-    r"""Return the integral over :math:`hat{L}` of the basis set in the given coordinate systems.
-
-    Parameters
-    ----------
-    basis : list/tuple of GeneralizedContractionShell
-        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
-    coord_types : list/tuple of str
-        Types of the coordinate system for each GeneralizedContractionShell.
-        Each entry must be one of "cartesian" or "spherical".
-
-    Returns
-    -------
-    array : np.ndarray(K_cont, K_cont, 3)
-        Array associated with the contractions in the given coordinate systems.
-        Dimensions 0 and 1 of the array are associated with two contractions in the given coordinate
-        system. `K_cont` is the total number of contractions within the given basis set.
-        Dimension 2 corresponds to the direction of the angular momentum (x, y, z).
-
-    """
-    return AngularMomentumIntegral(basis).construct_array_mix(coord_types)
-
-
-def angular_momentum_integral_lincomb(basis, transform, coord_type="spherical"):
-    r"""Return integral over :math:`hat{L}` of the linearly combined basis set.
-
-    Parameters
-    ----------
-    basis : list/tuple of GeneralizedContractionShell
-        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
-    transform : np.ndarray(K_orbs, K_sph)
-        Array associated with the linear combinations of spherical Gaussians (LCAO's).
-        Transformation is applied to the left, i.e. the sum is over the second index of `transform`
-        and first index of the array for contracted spherical Gaussians.
-    coord_type : {"cartesian", list/tuple of "cartesian" or "spherical", "spherical"}
+        Shells of generalized contractions.
+    transform : np.ndarray(K, K_cont)
+        Transformation matrix from the basis set in the given coordinate system (e.g. AO) to linear
+        combinations of contractions (e.g. MO).
+        Transformation is applied to the left, i.e. the sum is over the index 1 of `transform`
+        and index 0 of the array for contractions.
+        Default is no transformation.
+    coord_type : {"cartesian", "spherical", list/tuple of "cartesian" or "spherical}
         Types of the coordinate system for the contractions.
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
         If "spherical", then all of the contractions are treated as spherical contractions.
         If list/tuple, then each entry must be a "cartesian" or "spherical" to specify the
         coordinate type of each GeneralizedContractionShell instance.
-        Default value is "spherical".
+        Default is "spherical".
 
     Returns
     -------
-    array : np.ndarray(K_orbs, K_orbs, 3)
-        Array whose first and second indices are associated with the linear combinations of the
-        contracted spherical Gaussians.
-        Dimensions 0 and 1 of the array correspond to the linear combination of contracted spherical
-        Gaussians. `K_orbs` is the number of basis functions produced after the linear combinations.
+    array : np.ndarray(K, K, 3)
+        Array associated with the basis functions in the given shells of generalized contractions.
+        Dimensions 0 and 1 of the array are associated with the basis functions in the basis set.
+        `K` is the total number of basis functions in the basis set.
         Dimension 2 corresponds to the direction of the angular momentum (x, y, z).
 
     """
-    return AngularMomentumIntegral(basis).construct_array_lincomb(transform, coord_type)
+    if transform is not None:
+        return AngularMomentumIntegral(basis).construct_array_lincomb(transform, coord_type)
+    if coord_type == "spherical":
+        return AngularMomentumIntegral(basis).construct_array_spherical()
+    if coord_type == "cartesian":
+        return AngularMomentumIntegral(basis).construct_array_cartesian()
+    return AngularMomentumIntegral(basis).construct_array_mix(coord_type)

--- a/gbasis/density.py
+++ b/gbasis/density.py
@@ -61,7 +61,7 @@ def eval_density_using_evaluated_orbs(one_density_matrix, orb_eval):
     return np.sum(density, axis=0)
 
 
-def eval_density(one_density_matrix, basis, coords, transform=None, coord_type="spherical"):
+def eval_density(one_density_matrix, basis, points, transform=None, coord_type="spherical"):
     """Return the density of the given basis set at the given coordinates.
 
     Parameters
@@ -72,7 +72,7 @@ def eval_density(one_density_matrix, basis, coords, transform=None, coord_type="
         be expressed with respect to the transformed basis set.
     basis : list/tuple of GeneralizedContractionShell
         Shells of generalized contractions.
-    coords : np.ndarray(N, 3)
+    points : np.ndarray(N, 3)
         Coordinates of the points in space (in atomic units) where the basis functions are
         evaluated.
         Rows correspond to the points and columns correspond to the x, y, and z components.
@@ -96,7 +96,7 @@ def eval_density(one_density_matrix, basis, coords, transform=None, coord_type="
         Density evaluated at the given points.
 
     """
-    orb_eval = evaluate_basis(basis, coords, transform=transform, coord_type=coord_type)
+    orb_eval = evaluate_basis(basis, points, transform=transform, coord_type=coord_type)
     return eval_density_using_evaluated_orbs(one_density_matrix, orb_eval)
 
 
@@ -105,7 +105,7 @@ def eval_deriv_reduced_density_matrix(
     orders_two,
     one_density_matrix,
     basis,
-    coords,
+    points,
     transform=None,
     coord_type="spherical",
 ):
@@ -143,7 +143,7 @@ def eval_deriv_reduced_density_matrix(
         be expressed with respect to the transformed basis set.
     basis : list/tuple of GeneralizedContractionShell
         Shells of generalized contractions.
-    coords : np.ndarray(N, 3)
+    points : np.ndarray(N, 3)
         Coordinates of the points in space (in atomic units) where the basis functions are
         evaluated.
         Rows correspond to the points and columns correspond to the x, y, and z components.
@@ -168,13 +168,13 @@ def eval_deriv_reduced_density_matrix(
 
     """
     deriv_orb_eval_one = evaluate_deriv_basis(
-        basis, coords, orders_one, transform=transform, coord_type=coord_type
+        basis, points, orders_one, transform=transform, coord_type=coord_type
     )
     if np.array_equal(orders_one, orders_two):
         deriv_orb_eval_two = deriv_orb_eval_one
     else:
         deriv_orb_eval_two = evaluate_deriv_basis(
-            basis, coords, orders_two, transform=transform, coord_type=coord_type
+            basis, points, orders_two, transform=transform, coord_type=coord_type
         )
     density = one_density_matrix.dot(deriv_orb_eval_two)
     density *= deriv_orb_eval_one
@@ -183,7 +183,7 @@ def eval_deriv_reduced_density_matrix(
 
 
 def eval_deriv_density(
-    orders, one_density_matrix, basis, coords, transform=None, coord_type="spherical"
+    orders, one_density_matrix, basis, points, transform=None, coord_type="spherical"
 ):
     """Return the derivative of density of the given transformed basis set at the given coordinates.
 
@@ -197,7 +197,7 @@ def eval_deriv_density(
         be expressed with respect to the transformed basis set.
     basis : list/tuple of GeneralizedContractionShell
         Shells of generalized contractions.
-    coords : np.ndarray(N, 3)
+    points : np.ndarray(N, 3)
         Coordinates of the points in space (in atomic units) where the basis functions are
         evaluated.
         Rows correspond to the points and columns correspond to the x, y, and z components.
@@ -224,7 +224,7 @@ def eval_deriv_density(
     # pylint: disable=R0914
     total_l_x, total_l_y, total_l_z = orders
 
-    output = np.zeros(coords.shape[0])
+    output = np.zeros(points.shape[0])
     for l_x in range(total_l_x // 2 + 1):
         # prevent double counting for the middle of the even total_l_x
         # e.g. If total_l_x == 4, then l_x is in [0, 1, 2, 3, 4]. Exploiting symmetry we only need
@@ -244,7 +244,7 @@ def eval_deriv_density(
                     orders_two,
                     one_density_matrix,
                     basis,
-                    coords,
+                    points,
                     transform=transform,
                     coord_type=coord_type,
                 )
@@ -253,7 +253,7 @@ def eval_deriv_density(
 
 
 def eval_density_gradient(
-    one_density_matrix, basis, coords, transform=None, coord_type="spherical"
+    one_density_matrix, basis, points, transform=None, coord_type="spherical"
 ):
     """Return the gradient of the density evaluated at the given coordinates.
 
@@ -265,7 +265,7 @@ def eval_density_gradient(
         be expressed with respect to the transformed basis set.
     basis : list/tuple of GeneralizedContractionShell
         Shells of generalized contractions.
-    coords : np.ndarray(N, 3)
+    points : np.ndarray(N, 3)
         Coordinates of the points in space (in atomic units) where the basis functions are
         evaluated.
         Rows correspond to the points and columns correspond to the x, y, and z components.
@@ -295,7 +295,7 @@ def eval_density_gradient(
                 np.array([1, 0, 0]),
                 one_density_matrix,
                 basis,
-                coords,
+                points,
                 transform=transform,
                 coord_type=coord_type,
             ),
@@ -303,7 +303,7 @@ def eval_density_gradient(
                 np.array([0, 1, 0]),
                 one_density_matrix,
                 basis,
-                coords,
+                points,
                 transform=transform,
                 coord_type=coord_type,
             ),
@@ -311,7 +311,7 @@ def eval_density_gradient(
                 np.array([0, 0, 1]),
                 one_density_matrix,
                 basis,
-                coords,
+                points,
                 transform=transform,
                 coord_type=coord_type,
             ),
@@ -320,7 +320,7 @@ def eval_density_gradient(
 
 
 def eval_density_laplacian(
-    one_density_matrix, basis, coords, transform=None, coord_type="spherical"
+    one_density_matrix, basis, points, transform=None, coord_type="spherical"
 ):
     """Return the Laplacian of the density evaluated at the given coordinates.
 
@@ -332,7 +332,7 @@ def eval_density_laplacian(
         be expressed with respect to the transformed basis set.
     basis : list/tuple of GeneralizedContractionShell
         Shells of generalized contractions.
-    coords : np.ndarray(N, 3)
+    points : np.ndarray(N, 3)
         Coordinates of the points in space (in atomic units) where the basis functions are
         evaluated.
         Rows correspond to the points and columns correspond to the x, y, and z components.
@@ -360,7 +360,7 @@ def eval_density_laplacian(
         np.array([2, 0, 0]),
         one_density_matrix,
         basis,
-        coords,
+        points,
         transform=transform,
         coord_type=coord_type,
     )
@@ -368,7 +368,7 @@ def eval_density_laplacian(
         np.array([0, 2, 0]),
         one_density_matrix,
         basis,
-        coords,
+        points,
         transform=transform,
         coord_type=coord_type,
     )
@@ -376,14 +376,14 @@ def eval_density_laplacian(
         np.array([0, 0, 2]),
         one_density_matrix,
         basis,
-        coords,
+        points,
         transform=transform,
         coord_type=coord_type,
     )
     return output
 
 
-def eval_density_hessian(one_density_matrix, basis, coords, transform=None, coord_type="spherical"):
+def eval_density_hessian(one_density_matrix, basis, points, transform=None, coord_type="spherical"):
     """Return the Hessian of the density evaluated at the given coordinates.
 
     Parameters
@@ -394,7 +394,7 @@ def eval_density_hessian(one_density_matrix, basis, coords, transform=None, coor
         be expressed with respect to the transformed basis set.
     basis : list/tuple of GeneralizedContractionShell
         Shells of generalized contractions.
-    coords : np.ndarray(N, 3)
+    points : np.ndarray(N, 3)
         Coordinates of the points in space (in atomic units) where the basis functions are
         evaluated.
         Rows correspond to the points and columns correspond to the x, y, and z components.
@@ -427,7 +427,7 @@ def eval_density_hessian(one_density_matrix, basis, coords, transform=None, coor
                     orders_one + orders_two,
                     one_density_matrix,
                     basis,
-                    coords,
+                    points,
                     transform=transform,
                     coord_type=coord_type,
                 )
@@ -439,7 +439,7 @@ def eval_density_hessian(one_density_matrix, basis, coords, transform=None, coor
 
 
 def eval_posdef_kinetic_energy_density(
-    one_density_matrix, basis, coords, transform=None, coord_type="spherical"
+    one_density_matrix, basis, points, transform=None, coord_type="spherical"
 ):
     r"""Return evaluations of positive definite kinetic energy density.
 
@@ -463,7 +463,7 @@ def eval_posdef_kinetic_energy_density(
         be expressed with respect to the transformed basis set.
     basis : list/tuple of GeneralizedContractionShell
         Shells of generalized contractions.
-    coords : np.ndarray(N, 3)
+    points : np.ndarray(N, 3)
         Coordinates of the points in space (in atomic units) where the basis functions are
         evaluated.
         Rows correspond to the points and columns correspond to the x, y, and z components.
@@ -488,14 +488,14 @@ def eval_posdef_kinetic_energy_density(
         given coordinates.
 
     """
-    output = np.zeros(coords.shape[0])
+    output = np.zeros(points.shape[0])
     for orders in np.identity(3, dtype=int):
         output += eval_deriv_reduced_density_matrix(
             orders,
             orders,
             one_density_matrix,
             basis,
-            coords,
+            points,
             transform=transform,
             coord_type=coord_type,
         )
@@ -504,7 +504,7 @@ def eval_posdef_kinetic_energy_density(
 
 # TODO: test against a reference
 def eval_general_kinetic_energy_density(
-    one_density_matrix, basis, coords, alpha, transform=None, coord_type="spherical"
+    one_density_matrix, basis, points, alpha, transform=None, coord_type="spherical"
 ):
     r"""Return evaluations of general form of the kinetic energy density.
 
@@ -522,7 +522,7 @@ def eval_general_kinetic_energy_density(
         be expressed with respect to the transformed basis set.
     basis : list/tuple of GeneralizedContractionShell
         Shells of generalized contractions.
-    coords : np.ndarray(N, 3)
+    points : np.ndarray(N, 3)
         Coordinates of the points in space (in atomic units) where the basis functions are
         evaluated.
         Rows correspond to the points and columns correspond to the x, y, and z components.
@@ -558,10 +558,10 @@ def eval_general_kinetic_energy_density(
         raise TypeError("`alpha` must be an int or float.")
 
     general_kinetic_energy_density = eval_posdef_kinetic_energy_density(
-        one_density_matrix, basis, coords, transform=transform, coord_type=coord_type
+        one_density_matrix, basis, points, transform=transform, coord_type=coord_type
     )
     if alpha != 0:
         general_kinetic_energy_density += alpha * eval_density_laplacian(
-            one_density_matrix, basis, coords, transform=transform, coord_type=coord_type
+            one_density_matrix, basis, points, transform=transform, coord_type=coord_type
         )
     return general_kinetic_energy_density

--- a/gbasis/electrostatic_potential.py
+++ b/gbasis/electrostatic_potential.py
@@ -6,7 +6,7 @@ import numpy as np
 def electrostatic_potential(
     basis,
     one_density_matrix,
-    coords_points,
+    points,
     nuclear_coords,
     nuclear_charges,
     transform=None,
@@ -23,7 +23,7 @@ def electrostatic_potential(
         One-electron density matrix in terms of the given basis set.
         If the basis is transformed using `transform` keyword, then the density matrix is assumed to
         be expressed with respect to the transformed basis set.
-    coords_points : np.ndarray(N, 3)
+    points : np.ndarray(N, 3)
         Coordinates of the points in space (in atomic units) where the basis functions are
         evaluated.
         Rows correspond to the points and columns correspond to the x, y, and z components.
@@ -127,11 +127,7 @@ def electrostatic_potential(
             "`coord_type` must be 'spherical', 'cartesian', or a list/tuple of these strings."
         )
     hartree_potential = point_charge_integral(
-        basis,
-        coords_points,
-        -np.ones(coords_points.shape[0]),
-        transform=transform,
-        coord_type=coord_type,
+        basis, points, -np.ones(points.shape[0]), transform=transform, coord_type=coord_type
     )
     hartree_potential *= one_density_matrix[:, :, None]
     hartree_potential = np.sum(hartree_potential, axis=(0, 1))
@@ -140,7 +136,7 @@ def electrostatic_potential(
     old_settings = np.seterr(divide="ignore")
     external_potential = (
         nuclear_charges[None, :]
-        / np.sum((coords_points[:, :, None] - nuclear_coords.T[None, :, :]) ** 2, axis=1) ** 0.5
+        / np.sum((points[:, :, None] - nuclear_coords.T[None, :, :]) ** 2, axis=1) ** 0.5
     )
     # zero out potentials of elements that are too close to the nucleus
     external_potential[external_potential > 1.0 / np.array(threshold_dist)] = 0

--- a/gbasis/eval.py
+++ b/gbasis/eval.py
@@ -26,26 +26,26 @@ class Eval(BaseOneIndex):
     -------
     __init__(self, contractions)
         Initialize.
-    construct_array_contraction(contraction, coords) : np.ndarray(M, L_cart, N)
+    construct_array_contraction(contraction, points) : np.ndarray(M, L_cart, N)
         Return the evaluations of the given Cartesian contractions at the given coordinates.
         `M` is the number of segmented contractions with the same exponents (and angular momentum).
         `L_cart` is the number of Cartesian contractions for the given angular momentum.
         `N` is the number of coordinates at which the contractions are evaluated.
-    construct_array_cartesian(self, coords) : np.ndarray(K_cart, N)
+    construct_array_cartesian(self, points) : np.ndarray(K_cart, N)
         Return the evaluations of the Cartesian contractions of the instance at the given
         coordinates.
         `K_cart` is the total number of Cartesian contractions within the instance.
         `N` is the number of coordinates at which the contractions are evaluated.
-    construct_array_spherical(self, coords) : np.ndarray(K_sph, N)
+    construct_array_spherical(self, points) : np.ndarray(K_sph, N)
         Return the evaluations of the spherical contractions of the instance at the given
         coordinates.
         `K_sph` is the total number of spherical contractions within the instance.
         `N` is the number of coordinates at which the contractions are evaluated.
-    construct_array_mix(self, coord_types, coords) : np.ndarray(K_cont, N)
+    construct_array_mix(self, coord_types, points) : np.ndarray(K_cont, N)
         Return the evaluatations of the contraction in the given coordinate system.
         `K_cont` is the total number of contractions within the given basis set.
         `N` is the number of coordinates at which the contractions are evaluated.
-    construct_array_lincomb(self, transform, coord_type, coords) : np.ndarray(K_orbs, N)
+    construct_array_lincomb(self, transform, coord_type, points) : np.ndarray(K_orbs, N)
         Return the evaluations of the linear combinations of contractions in the given coordinate
         system.
         `K_orbs` is the number of basis functions produced after the linear combinations.
@@ -54,7 +54,7 @@ class Eval(BaseOneIndex):
     """
 
     @staticmethod
-    def construct_array_contraction(contractions, coords):
+    def construct_array_contraction(contractions, points):
         """Return the evaluations of the given contractions at the given coordinates.
 
         Parameters
@@ -62,7 +62,7 @@ class Eval(BaseOneIndex):
         contractions : GeneralizedContractionShell
             Contracted Cartesian Gaussians (of the same shell) that will be used to construct an
             array.
-        coords : np.ndarray(N, 3)
+        points : np.ndarray(N, 3)
             Coordinates of the points in space (in atomic units) where the basis functions are
             evaluated.
             Rows correspond to the points and columns correspond to the x, y, and z components.
@@ -83,21 +83,21 @@ class Eval(BaseOneIndex):
         ------
         TypeError
             If contractions is not a GeneralizedContractionShell instance.
-            If coords is not a two-dimensional numpy array with 3 columns.
+            If points is not a two-dimensional numpy array with 3 columns.
 
         Note
         ----
         Since all of the keyword arguments of `construct_array_cartesian`,
         `construct_array_spherical`, and `construct_array_lincomb` are ultimately passed
         down to this method, all of the mentioned methods must be called with the keyword arguments
-        `coords` and `orders`.
+        `points` and `orders`.
 
         """
         if not isinstance(contractions, GeneralizedContractionShell):
             raise TypeError("`contractions` must be a GeneralizedContractionShell instance.")
-        if not (isinstance(coords, np.ndarray) and coords.ndim == 2 and coords.shape[1] == 3):
+        if not (isinstance(points, np.ndarray) and points.ndim == 2 and points.shape[1] == 3):
             raise TypeError(
-                "`coords` must be given as a two-dimensional numpy array with 3 columnms."
+                "`points` must be given as a two-dimensional numpy array with 3 columnms."
             )
 
         alphas = contractions.exps
@@ -106,19 +106,19 @@ class Eval(BaseOneIndex):
         center = contractions.coord
         norm_prim_cart = contractions.norm_prim_cart
         output = _eval_deriv_contractions(
-            coords, np.zeros(3), center, angmom_comps, alphas, prim_coeffs, norm_prim_cart
+            points, np.zeros(3), center, angmom_comps, alphas, prim_coeffs, norm_prim_cart
         )
         return output
 
 
-def evaluate_basis(basis, coords, transform=None, coord_type="spherical"):
+def evaluate_basis(basis, points, transform=None, coord_type="spherical"):
     """Evaluate the basis set in the given coordinate system at the given coordinates.
 
     Parameters
     ----------
     basis : list/tuple of GeneralizedContractionShell
         Shells of generalized contractions.
-    coords : np.ndarray(N, 3)
+    points : np.ndarray(N, 3)
         Coordinates of the points in space (in atomic units) where the basis functions are
         evaluated.
         Rows correspond to the points and columns correspond to the x, y, and z components.
@@ -147,9 +147,9 @@ def evaluate_basis(basis, coords, transform=None, coord_type="spherical"):
 
     """
     if transform is not None:
-        return Eval(basis).construct_array_lincomb(transform, coord_type, coords=coords)
+        return Eval(basis).construct_array_lincomb(transform, coord_type, points=points)
     if coord_type == "cartesian":
-        return Eval(basis).construct_array_cartesian(coords=coords)
+        return Eval(basis).construct_array_cartesian(points=points)
     if coord_type == "spherical":
-        return Eval(basis).construct_array_spherical(coords=coords)
-    return Eval(basis).construct_array_mix(coord_type, coords=coords)
+        return Eval(basis).construct_array_spherical(points=points)
+    return Eval(basis).construct_array_mix(coord_type, points=points)

--- a/gbasis/eval_deriv.py
+++ b/gbasis/eval_deriv.py
@@ -26,26 +26,26 @@ class EvalDeriv(BaseOneIndex):
     -------
     __init__(self, contractions)
         Initialize.
-    construct_array_contraction(contraction, coords, orders) : np.ndarray(M, L_cart, N)
+    construct_array_contraction(contraction, points, orders) : np.ndarray(M, L_cart, N)
         Return the evaluations of the given Cartesian contractions at the given coordinates.
         `M` is the number of segmented contractions with the same exponents (and angular momentum).
         `L_cart` is the number of Cartesian contractions for the given angular momentum.
         `N` is the number of coordinates at which the contractions are evaluated.
-    construct_array_cartesian(self, coords, orders) : np.ndarray(K_cart, N)
+    construct_array_cartesian(self, points, orders) : np.ndarray(K_cart, N)
         Return the evaluations of the derivatives of the Cartesian contractions of the instance at
         the given coordinates.
         `K_cart` is the total number of Cartesian contractions within the instance.
         `N` is the number of coordinates at which the contractions are evaluated.
-    construct_array_spherical(self, coords, orders) : np.ndarray(K_sph, N)
+    construct_array_spherical(self, points, orders) : np.ndarray(K_sph, N)
         Return the evaluations of the derivatives of the spherical contractions of the instance at
         the given coordinates.
         `K_sph` is the total number of spherical contractions within the instance.
         `N` is the number of coordinates at which the contractions are evaluated.
-    construct_array_mix(self, coord_types, coords, orders) : np.ndarray(K_cont, N)
+    construct_array_mix(self, coord_types, points, orders) : np.ndarray(K_cont, N)
         Return the array associated with all of the contraction in the given coordinate system.
         `K_cont` is the total number of contractions within the given basis set.
         `N` is the number of coordinates at which the contractions are evaluated.
-    construct_array_lincomb(self, transform, coord_type, coords, orders) : np.ndarray(K_orbs, N)
+    construct_array_lincomb(self, transform, coord_type, points, orders) : np.ndarray(K_orbs, N)
         Return the evaluatiosn of derivatives of the  linear combinations of contractions in the
         given coordinate system.
         `K_orbs` is the number of basis functions produced after the linear combinations.
@@ -54,7 +54,7 @@ class EvalDeriv(BaseOneIndex):
     """
 
     @staticmethod
-    def construct_array_contraction(contractions, coords, orders):
+    def construct_array_contraction(contractions, points, orders):
         """Return the array associated with a set of contracted Cartesian Gaussians.
 
         Parameters
@@ -62,7 +62,7 @@ class EvalDeriv(BaseOneIndex):
         contractions : GeneralizedContractionShell
             Contracted Cartesian Gaussians (of the same shell) that will be used to construct an
             array.
-        coords : np.ndarray(N, 3)
+        points : np.ndarray(N, 3)
             Coordinates of the points in space (in atomic units) where the basis functions are
             evaluated.
             Rows correspond to the points and columns correspond to the x, y, and z components.
@@ -85,7 +85,7 @@ class EvalDeriv(BaseOneIndex):
         ------
         TypeError
             If contractions is not a GeneralizedContractionShell instance.
-            If coords is not a two-dimensional numpy array with 3 columns.
+            If points is not a two-dimensional numpy array with 3 columns.
             If orders is not a one-dimensional numpy array with 3 elements.
         ValueError
             If orders has any negative numbers.
@@ -96,14 +96,14 @@ class EvalDeriv(BaseOneIndex):
         Since all of the keyword arguments of `construct_array_cartesian`,
         `construct_array_spherical`, and `construct_array_lincomb` are ultimately passed
         down to this method, all of the mentioned methods must be called with the keyword arguments
-        `coords` and `orders`.
+        `points` and `orders`.
 
         """
         if not isinstance(contractions, GeneralizedContractionShell):
             raise TypeError("`contractions` must be a GeneralizedContractionShell instance.")
-        if not (isinstance(coords, np.ndarray) and coords.ndim == 2 and coords.shape[1] == 3):
+        if not (isinstance(points, np.ndarray) and points.ndim == 2 and points.shape[1] == 3):
             raise TypeError(
-                "`coords` must be given as a two-dimensional numpy array with 3 columnms."
+                "`points` must be given as a two-dimensional numpy array with 3 columnms."
             )
         if not (isinstance(orders, np.ndarray) and orders.shape == (3,)):
             raise TypeError(
@@ -120,7 +120,7 @@ class EvalDeriv(BaseOneIndex):
         center = contractions.coord
         norm_prim_cart = contractions.norm_prim_cart
         output = _eval_deriv_contractions(
-            coords, orders, center, angmom_comps, alphas, prim_coeffs, norm_prim_cart
+            points, orders, center, angmom_comps, alphas, prim_coeffs, norm_prim_cart
         )
         return output
 
@@ -167,10 +167,10 @@ def evaluate_deriv_basis(basis, points, orders, transform=None, coord_type="sphe
     """
     if transform is not None:
         return EvalDeriv(basis).construct_array_lincomb(
-            transform, coord_type, coords=points, orders=orders
+            transform, coord_type, points=points, orders=orders
         )
     if coord_type == "cartesian":
-        return EvalDeriv(basis).construct_array_cartesian(coords=points, orders=orders)
+        return EvalDeriv(basis).construct_array_cartesian(points=points, orders=orders)
     if coord_type == "spherical":
-        return EvalDeriv(basis).construct_array_spherical(coords=points, orders=orders)
-    return EvalDeriv(basis).construct_array_mix(coord_type, coords=points, orders=orders)
+        return EvalDeriv(basis).construct_array_spherical(points=points, orders=orders)
+    return EvalDeriv(basis).construct_array_mix(coord_type, points=points, orders=orders)

--- a/gbasis/kinetic_energy.py
+++ b/gbasis/kinetic_energy.py
@@ -6,7 +6,7 @@ import numpy as np
 
 
 class KineticEnergyIntegral(BaseTwoIndexSymmetric):
-    """Class for obtaining the kinetic energy integral for a set of Gaussian contractions.
+    """Class for obtaining the kinetic energy integrals.
 
     Attributes
     ----------
@@ -120,78 +120,19 @@ class KineticEnergyIntegral(BaseTwoIndexSymmetric):
         return -0.5 * np.sum(output, axis=0)
 
 
-def kinetic_energy_integral_cartesian(basis):
-    """Return the kinetic energy integral of the basis set in the Cartesian form.
+def kinetic_energy_integral(basis, transform=None, coord_type="spherical"):
+    """Return kinetic energy integral of the given basis set.
 
     Parameters
     ----------
     basis : list/tuple of GeneralizedContractionShell
-        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
-
-    Returns
-    -------
-    array : np.ndarray(K_cart, K_cart)
-        Array associated with the given set of contracted Cartesian Gaussians.
-        First and second indices of the array are associated with the contracted Cartesian
-        Gaussians. `K_cart` is the total number of Cartesian contractions within the instance.
-
-    """
-    return KineticEnergyIntegral(basis).construct_array_cartesian()
-
-
-def kinetic_energy_integral_spherical(basis):
-    """Return the kinetic energy integral of the basis set in the spherical form.
-
-    Parameters
-    ----------
-    basis : list/tuple of GeneralizedContractionShell
-        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
-
-    Returns
-    -------
-    array : np.ndarray(K_sph, K_sph)
-        Array associated with the given set of contracted spherical Gaussians.
-        First and second indices of the array are associated with two contracted spherical Gaussians
-        (atomic orbitals). `K_sph` is the total number of spherical contractions within the
-        instance.
-
-    """
-    return KineticEnergyIntegral(basis).construct_array_spherical()
-
-
-def kinetic_energy_integral_mix(basis, coord_types):
-    """Return the kinetic energy integral of the basis set in the given coordinate systems.
-
-    Parameters
-    ----------
-    basis : list/tuple of GeneralizedContractionShell
-        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
-    coord_types : list/tuple of str
-        Types of the coordinate system for each GeneralizedContractionShell.
-        Each entry must be one of "cartesian" or "spherical".
-
-    Returns
-    -------
-    array : np.ndarray(K_cont, K_cont)
-        Array associated with the contractions in the given coordinate systems.
-        First and second indices of the array are associated with two contractions in the given
-        coordinate system. `K_cont` is the total number of contractions within the given basis set.
-
-    """
-    return KineticEnergyIntegral(basis).construct_array_mix(coord_types)
-
-
-def kinetic_energy_integral_lincomb(basis, transform, coord_type="spherical"):
-    """Return kinetic energy integral of the linearly combined basis set in the spherical form.
-
-    Parameters
-    ----------
-    basis : list/tuple of GeneralizedContractionShell
-        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
-    transform : np.ndarray(K_orbs, K_sph)
-        Array associated with the linear combinations of spherical Gaussians (LCAO's).
-        Transformation is applied to the left, i.e. the sum is over the second index of `transform`
-        and first index of the array for contracted spherical Gaussians.
+        Shells of generalized contractions.
+    transform : np.ndarray(K_orbs, K_cont)
+        Transformation matrix from the basis set in the given coordinate system (e.g. AO) to linear
+        combinations of contractions (e.g. MO).
+        Transformation is applied to the left, i.e. the sum is over the index 1 of `transform`
+        and index 0 of the array for contractions.
+        Default is no transformation.
     coord_type : {"cartesian", list/tuple of "cartesian" or "spherical", "spherical"}
         Types of the coordinate system for the contractions.
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
@@ -203,11 +144,18 @@ def kinetic_energy_integral_lincomb(basis, transform, coord_type="spherical"):
     Returns
     -------
     array : np.ndarray(K_orbs, K_orbs)
-        Array whose first and second indices are associated with the linear combinations of the
-        contracted spherical Gaussians.
-        First and second indices of the array correspond to the linear combination of contracted
-        spherical Gaussians. `K_orbs` is the number of basis functions produced after the linear
-        combinations.
+        Kinetic energy integral of the given basis set.
+        If keyword argument `transform` is provided, then the integrals will be transformed
+        accordingly.
+        Dimensions 0 and 1 of the array are associated with the basis functions in the basis set.
+        `K_orbs` is the total number of basis functions in the basis set.
 
     """
-    return KineticEnergyIntegral(basis).construct_array_lincomb(transform, coord_type)
+
+    if transform is not None:
+        return KineticEnergyIntegral(basis).construct_array_lincomb(transform, coord_type)
+    if coord_type == "cartesian":
+        return KineticEnergyIntegral(basis).construct_array_cartesian()
+    if coord_type == "spherical":
+        return KineticEnergyIntegral(basis).construct_array_spherical()
+    return KineticEnergyIntegral(basis).construct_array_mix(coord_type)

--- a/gbasis/moment.py
+++ b/gbasis/moment.py
@@ -156,129 +156,25 @@ class Moment(BaseTwoIndexSymmetric):
         return np.transpose(output, (1, 2, 3, 4, 0))
 
 
-def moment_cartesian(basis, moment_coord, moment_orders):
-    """Return the moment of the basis set in the Cartesian form.
+def moment_integral(basis, moment_coord, moment_orders, transform=None, coord_type="spherical"):
+    """Return moment integral of the given basis set.
 
     Parameters
     ----------
     basis : list/tuple of GeneralizedContractionShell
-        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
+        Shells of generalized contractions.
     moment_coord : np.ndarray(3,)
         Center of the moment.
     moment_orders : np.ndarray(D, 3)
         Orders of the moment for each dimension (x, y, z).
         Note that a two dimensional array must be given, even if there is only one set of orders
         of the moment.
-
-    Returns
-    -------
-    array : np.ndarray(K_cart, K_cart, D)
-        Array associated with the given set of contracted Cartesian Gaussians.
-        First and second indices of the array are associated with the contracted Cartesian
-        Gaussians. `K_cart` is the total number of Cartesian contractions within the instance.
-
-    Notes
-    -----
-    If enough orders of moments are calculated (the exact number depends on the size of the basis
-    set), then it may be faster to access the moments for each order if the fifth axis is moved back
-    to the front prior to the access. Use `np.transpose(array, (4, 0, 1, 2, 3))` to change the
-    order.
-
-    """
-    return Moment(basis).construct_array_cartesian(
-        moment_coord=moment_coord, moment_orders=moment_orders
-    )
-
-
-def moment_spherical(basis, moment_coord, moment_orders):
-    """Return the moment of the basis set in the spherical form.
-
-    Parameters
-    ----------
-    basis : list/tuple of GeneralizedContractionShell
-        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
-    moment_coord : np.ndarray(3,)
-        Center of the moment.
-    moment_orders : np.ndarray(D, 3)
-        Orders of the moment for each dimension (x, y, z).
-        Note that a two dimensional array must be given, even if there is only one set of orders
-        of the moment.
-
-    Returns
-    -------
-    array : np.ndarray(K_sph, K_sph, D)
-        Array associated with the spherical contractions.
-        First and second indices of the array are associated with two contracted spherical Gaussians
-        (atomic orbitals). `K_sph` is the total number of spherical contractions within the
-        instance.
-
-    Notes
-    -----
-    If enough orders of moments are calculated (the exact number depends on the size of the basis
-    set), then it may be faster to access the moments for each order if the fifth axis is moved back
-    to the front prior to the access. Use `np.transpose(array, (4, 0, 1, 2, 3))` to change the
-    order.
-
-    """
-    return Moment(basis).construct_array_spherical(
-        moment_coord=moment_coord, moment_orders=moment_orders
-    )
-
-
-def moment_mix(basis, moment_coord, moment_orders, coord_types):
-    """Return the moment of the basis set in the given coordinate system.
-
-    Parameters
-    ----------
-    basis : list/tuple of GeneralizedContractionShell
-        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
-    moment_coord : np.ndarray(3,)
-        Center of the moment.
-    moment_orders : np.ndarray(D, 3)
-        Orders of the moment for each dimension (x, y, z).
-        Note that a two dimensional array must be given, even if there is only one set of orders
-        of the moment.
-    coord_types : list/tuple of str
-        Types of the coordinate system for each GeneralizedContractionShell.
-        Each entry must be one of "cartesian" or "spherical".
-
-    Returns
-    -------
-    array : np.ndarray(K_cont, K_cont, D)
-        Array associated with the contractions in the given coordinate systems.
-        First and second indices of the array are associated with two contractions in the given
-        coordinate system. `K_cont` is the total number of contractions within the given basis set.
-
-    Notes
-    -----
-    If enough orders of moments are calculated (the exact number depends on the size of the basis
-    set), then it may be faster to access the moments for each order if the fifth axis is moved back
-    to the front prior to the access. Use `np.transpose(array, (4, 0, 1, 2, 3))` to change the
-    order.
-
-    """
-    return Moment(basis).construct_array_mix(
-        coord_types, moment_coord=moment_coord, moment_orders=moment_orders
-    )
-
-
-def moment_lincomb(basis, transform, moment_coord, moment_orders, coord_type="spherical"):
-    """Return the moment of the linear combination of the basis set.
-
-    Parameters
-    ----------
-    basis : list/tuple of GeneralizedContractionShell
-        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
-    transform : np.ndarray(K_orbs, K_sph)
-        Array associated with the linear combinations of spherical Gaussians (LCAO's).
-        Transformation is applied to the left, i.e. the sum is over the second index of `transform`
-        and first index of the array for contracted spherical Gaussians.
-    moment_coord : np.ndarray(3,)
-        Center of the moment.
-    moment_orders : np.ndarray(D, 3)
-        Orders of the moment for each dimension (x, y, z).
-        Note that a two dimensional array must be given, even if there is only one set of orders
-        of the moment.
+    transform : np.ndarray(K_orbs, K_cont)
+        Transformation matrix from the basis set in the given coordinate system (e.g. AO) to linear
+        combinations of contractions (e.g. MO).
+        Transformation is applied to the left, i.e. the sum is over the index 1 of `transform`
+        and index 0 of the array for contractions.
+        Default is no transformation.
     coord_type : {"cartesian", list/tuple of "cartesian" or "spherical", "spherical"}
         Types of the coordinate system for the contractions.
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
@@ -290,10 +186,10 @@ def moment_lincomb(basis, transform, moment_coord, moment_orders, coord_type="sp
     Returns
     -------
     array : np.ndarray(K_orbs, K_orbs, D)
-        Array whose first and second indices are associated with the linear combinations of the
-        contractions.
-        First and second indices of the array correspond to the linear combination of contractions.
-        `K_orbs` is the number of basis functions produced after the linear combinations.
+        Moment integral of the given basis set.
+        Dimensions 0 and 1 of the array correspond to the basis functions. `K_orbs` is the number of
+        basis functions in the basis set.
+        Dimension 2 of the array coresponds to the moment. `D` is the number of different moments.
 
     Notes
     -----
@@ -303,6 +199,19 @@ def moment_lincomb(basis, transform, moment_coord, moment_orders, coord_type="sp
     order.
 
     """
-    return Moment(basis).construct_array_lincomb(
-        transform, coord_type, moment_coord=moment_coord, moment_orders=moment_orders
+
+    if transform is not None:
+        return Moment(basis).construct_array_lincomb(
+            transform, coord_type, moment_coord=moment_coord, moment_orders=moment_orders
+        )
+    if coord_type == "cartesian":
+        return Moment(basis).construct_array_cartesian(
+            moment_coord=moment_coord, moment_orders=moment_orders
+        )
+    if coord_type == "spherical":
+        return Moment(basis).construct_array_spherical(
+            moment_coord=moment_coord, moment_orders=moment_orders
+        )
+    return Moment(basis).construct_array_mix(
+        coord_type, moment_coord=moment_coord, moment_orders=moment_orders
     )

--- a/gbasis/momentum.py
+++ b/gbasis/momentum.py
@@ -7,7 +7,7 @@ import numpy as np
 
 # TODO: need to test against reference
 class MomentumIntegral(BaseTwoIndexSymmetric):
-    """Class for obtaining the momentum integral for a set of Gaussian contractions.
+    """Class for obtaining the momentum integral.
 
     Attributes
     ----------
@@ -113,80 +113,19 @@ class MomentumIntegral(BaseTwoIndexSymmetric):
         return -1j * np.transpose(output, (1, 2, 3, 4, 0))
 
 
-def momentum_integral_cartesian(basis):
-    r"""Return the integral over momentum operator of the basis set in the Cartesian form.
+def momentum_integral(basis, transform=None, coord_type="spherical"):
+    """Return integral over momentum operator of the given basi set.
 
     Parameters
     ----------
     basis : list/tuple of GeneralizedContractionShell
-        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
-
-    Returns
-    -------
-    array : np.ndarray(K_cart, K_cart, 3)
-        Array associated with the given set of contracted Cartesian Gaussians.
-        Dimensions 0 and 1 of the array are associated with the contracted Cartesian Gaussians.
-        `K_cart` is the total number of Cartesian contractions within the instance.
-        Dimension 2 corresponds to the direction of the momentum (x, y, z).
-
-    """
-    return MomentumIntegral(basis).construct_array_cartesian()
-
-
-def momentum_integral_spherical(basis):
-    r"""Return the integral over momentum operator of the basis set in the spherical form.
-
-    Parameters
-    ----------
-    basis : list/tuple of GeneralizedContractionShell
-        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
-
-    Returns
-    -------
-    array : np.ndarray(K_sph, K_sph, 3)
-        Array associated with the given set of contracted spherical Gaussians.
-        Dimensions of the array are associated with two contracted spherical Gaussians (atomic
-        orbitals). `K_sph` is the total number of spherical contractions within the instance.
-        Dimension 2 corresponds to the direction of the momentum (x, y, z).
-
-    """
-    return MomentumIntegral(basis).construct_array_spherical()
-
-
-def momentum_integral_mix(basis, coord_types):
-    r"""Return the integral over momentum operator of the basis set in the given coordinate systems.
-
-    Parameters
-    ----------
-    basis : list/tuple of GeneralizedContractionShell
-        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
-    coord_types : list/tuple of str
-        Types of the coordinate system for each GeneralizedContractionShell.
-        Each entry must be one of "cartesian" or "spherical".
-
-    Returns
-    -------
-    array : np.ndarray(K_cont, K_cont, 3)
-        Array associated with the contractions in the given coordinate systems.
-        Dimensions 0 and 1 of the array are associated with two contractions in the given coordinate
-        system. `K_cont` is the total number of contractions within the given basis set.
-        Dimension 2 corresponds to the direction of the momentum (x, y, z).
-
-    """
-    return MomentumIntegral(basis).construct_array_mix(coord_types)
-
-
-def momentum_integral_lincomb(basis, transform, coord_type="spherical"):
-    r"""Return integral over momentum operator of the linearly combined basis set.
-
-    Parameters
-    ----------
-    basis : list/tuple of GeneralizedContractionShell
-        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
-    transform : np.ndarray(K_orbs, K_sph)
-        Array associated with the linear combinations of spherical Gaussians (LCAO's).
-        Transformation is applied to the left, i.e. the sum is over the second index of `transform`
-        and first index of the array for contracted spherical Gaussians.
+        Shells of generalized contractions.
+    transform : np.ndarray(K_orbs, K_cont)
+        Transformation matrix from the basis set in the given coordinate system (e.g. AO) to linear
+        combinations of contractions (e.g. MO).
+        Transformation is applied to the left, i.e. the sum is over the index 1 of `transform`
+        and index 0 of the array for contractions.
+        Default is no transformation.
     coord_type : {"cartesian", list/tuple of "cartesian" or "spherical", "spherical"}
         Types of the coordinate system for the contractions.
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
@@ -197,12 +136,17 @@ def momentum_integral_lincomb(basis, transform, coord_type="spherical"):
 
     Returns
     -------
-    array : np.ndarray(K_orbs, K_orbs, 3)
-        Array whose first and second indices are associated with the linear combinations of the
-        contracted spherical Gaussians.
-        Dimensions 0 and 1 of the array correspond to the linear combination of contracted spherical
-        Gaussians. `K_orbs` is the number of basis functions produced after the linear combinations.
-        Dimension 2 corresponds to the direction of the momentum (x, y, z).
+    array : np.ndarray(K_orbs, K_orbs)
+        Momentum integral of the given basis set.
+        Dimensions 0 and 1 of the array correspond to the basis functions. `K_orbs` is the number of
+        basis functions in the basis set.
 
     """
-    return MomentumIntegral(basis).construct_array_lincomb(transform, coord_type)
+
+    if transform is not None:
+        return MomentumIntegral(basis).construct_array_lincomb(transform, coord_type)
+    if coord_type == "cartesian":
+        return MomentumIntegral(basis).construct_array_cartesian()
+    if coord_type == "spherical":
+        return MomentumIntegral(basis).construct_array_spherical()
+    return MomentumIntegral(basis).construct_array_mix(coord_type)

--- a/gbasis/nuclear_electron_attraction.py
+++ b/gbasis/nuclear_electron_attraction.py
@@ -1,99 +1,17 @@
 """Module for computing the nuclear electron attraction."""
-from gbasis.point_charge import (
-    point_charge_cartesian,
-    point_charge_lincomb,
-    point_charge_mix,
-    point_charge_spherical,
-)
+from gbasis.point_charge import point_charge_integral
 import numpy as np
 
 
-def nuclear_electron_attraction_cartesian(basis, nuclear_coords, nuclear_charges):
+def nuclear_electron_attraction_integral(
+    basis, nuclear_coords, nuclear_charges, transform=None, coord_type="spherical"
+):
     """Return the nuclear electron attraction integrals of the basis set in the Cartesian form.
 
     Parameters
     ----------
     basis : list/tuple of GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
-    nuclear_coords : np.ndarray(N_nuc, 3)
-        Coordinates of each atom.
-    nuclear_charges : np.ndarray(N_nuc)
-        Charges of each atom.
-
-    Returns
-    -------
-    array : np.ndarray(K_cart, K_cart)
-        Array associated with the given set of contracted Cartesian Gaussians.
-        First and second indices of the array are associated with the contracted Cartesian
-        Gaussians. `K_cart` is the total number of Cartesian contractions within the instance.
-
-    """
-    return np.sum(point_charge_cartesian(basis, nuclear_coords, nuclear_charges), axis=2)
-
-
-def nuclear_electron_attraction_spherical(basis, nuclear_coords, nuclear_charges):
-    """Return the nuclear electron attraction integrals of the basis set in the spherical form.
-
-    Parameters
-    ----------
-    basis : list/tuple of GeneralizedContractionShell
-        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
-    nuclear_coords : np.ndarray(N_nuc, 3)
-        Coordinates of each atom.
-    nuclear_charges : np.ndarray(N_nuc)
-        Charges of each atom.
-
-    Returns
-    -------
-    array : np.ndarray(K_sph, K_sph)
-        Array associated with the spherical contractions.
-        First and second indices of the array are associated with two contracted spherical Gaussians
-        (atomic orbitals). `K_sph` is the total number of spherical contractions within the
-        instance.
-
-    """
-    return np.sum(point_charge_spherical(basis, nuclear_coords, nuclear_charges), axis=2)
-
-
-def nuclear_electron_attraction_mix(basis, nuclear_coords, nuclear_charges, coord_types):
-    """Return the nuclear electron attraction integrals of the basis set in the spherical form.
-
-    Parameters
-    ----------
-    basis : list/tuple of GeneralizedContractionShell
-        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
-    nuclear_coords : np.ndarray(N_nuc, 3)
-        Coordinates of each atom.
-    nuclear_charges : np.ndarray(N_nuc)
-        Charges of each atom.
-    coord_types : list/tuple of str
-        Types of the coordinate system for each GeneralizedContractionShell.
-        Each entry must be one of "cartesian" or "spherical".
-
-    Returns
-    -------
-    array : np.ndarray(K_cont, K_cont)
-        Array associated with the contractions in the given coordinate systems.
-        First and second indices of the array are associated with two contractions. `K_cont` is the
-        total number of contractions within the instance.
-
-    """
-    return np.sum(point_charge_mix(basis, nuclear_coords, nuclear_charges, coord_types), axis=2)
-
-
-def nuclear_electron_attraction_lincomb(
-    basis, transform, nuclear_coords, nuclear_charges, coord_type="spherical"
-):
-    """Return the nuclear electron attraction integrals of the LCAO's in the spherical form.
-
-    Parameters
-    ----------
-    basis : list/tuple of GeneralizedContractionShell
-        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
-    transform : np.ndarray(K_orbs, K_sph)
-        Array associated with the linear combinations of spherical Gaussians (LCAO's).
-        Transformation is applied to the left, i.e. the sum is over the second index of `transform`
-        and first index of the array for contracted spherical Gaussians.
     nuclear_coords : np.ndarray(N_nuc, 3)
         Coordinates of each atom.
     nuclear_charges : np.ndarray(N_nuc)
@@ -108,16 +26,15 @@ def nuclear_electron_attraction_lincomb(
 
     Returns
     -------
-    array : np.ndarray(K_orbs, K_orbs)
-        Array whose first and second indices are associated with the linear combinations of the
-        contractions.
-        First and second indices of the array correspond to the linear combination of contractions.
-        `K_orbs` is the number of basis functions produced after the linear combinations.
+    array : np.ndarray(K_cart, K_cart)
+        Array associated with the given set of contracted Cartesian Gaussians.
+        First and second indices of the array are associated with the contracted Cartesian
+        Gaussians. `K_cart` is the total number of Cartesian contractions within the instance.
 
     """
     return np.sum(
-        point_charge_lincomb(
-            basis, transform, nuclear_coords, nuclear_charges, coord_type=coord_type
+        point_charge_integral(
+            basis, nuclear_coords, nuclear_charges, transform=transform, coord_type=coord_type
         ),
         axis=2,
     )

--- a/gbasis/overlap.py
+++ b/gbasis/overlap.py
@@ -117,79 +117,19 @@ class Overlap(BaseTwoIndexSymmetric):
         )[0]
 
 
-def overlap_cartesian(basis):
-    """Return the overlap of the basis set in the Cartesian form.
+def overlap_integral(basis, transform=None, coord_type="spherical"):
+    """Return overlap integral of the given basis set.
 
     Parameters
     ----------
     basis : list/tuple of GeneralizedContractionShell
-        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
-
-    Returns
-    -------
-    array : np.ndarray(K_cart, K_cart)
-        Array associated with the given set of contracted Cartesian Gaussians.
-        First and second indices of the array are associated with the contracted Cartesian
-        Gaussians. `K_cart` is the total number of Cartesian contractions within the instance.
-
-    """
-    return Overlap(basis).construct_array_cartesian()
-
-
-def overlap_spherical(basis):
-    """Return the overlap of the basis set in the spherical form.
-
-    Parameters
-    ----------
-    basis : list/tuple of GeneralizedContractionShell
-        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
-
-    Returns
-    -------
-    array : np.ndarray(K_sph, K_sph)
-        Array associated with the atomic orbitals associated with the given set(s) of contracted
-        Cartesian Gaussians.
-        First and second indices of the array are associated with two contracted spherical Gaussians
-        (atomic orbitals). `K_sph` is the total number of spherical contractions within the
-        instance.
-
-    """
-    return Overlap(basis).construct_array_spherical()
-
-
-def overlap_mix(basis, coord_types):
-    """Return the overlap of the basis set in the given coordinate systems.
-
-    Parameters
-    ----------
-    basis : list/tuple of GeneralizedContractionShell
-        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
-    coord_types : list/tuple of str
-        Types of the coordinate system for each GeneralizedContractionShell.
-        Each entry must be one of "cartesian" or "spherical".
-
-    Returns
-    -------
-    array : np.ndarray(K_cont, K_cont)
-        Array associated with the contractions in the given coordinate systems.
-        First and second indices of the array are associated with two contractions in the given
-        coordinate system. `K_cont` is the total number of contractions within the given basis set.
-
-    """
-    return Overlap(basis).construct_array_mix(coord_types)
-
-
-def overlap_lincomb(basis, transform, coord_type="spherical"):
-    """Return the overlap of the linear combination of the basis set.
-
-    Parameters
-    ----------
-    basis : list/tuple of GeneralizedContractionShell
-        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
-    transform : np.ndarray(K_orbs, K_sph)
-        Array associated with the linear combinations of spherical Gaussians (LCAO's).
-        Transformation is applied to the left, i.e. the sum is over the second index of `transform`
-        and first index of the array for contracted spherical Gaussians.
+        Shells of generalized contractions.
+    transform : np.ndarray(K_orbs, K_cont)
+        Transformation matrix from the basis set in the given coordinate system (e.g. AO) to linear
+        combinations of contractions (e.g. MO).
+        Transformation is applied to the left, i.e. the sum is over the index 1 of `transform`
+        and index 0 of the array for contractions.
+        Default is no transformation.
     coord_type : {"cartesian", list/tuple of "cartesian" or "spherical", "spherical"}
         Types of the coordinate system for the contractions.
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
@@ -201,10 +141,15 @@ def overlap_lincomb(basis, transform, coord_type="spherical"):
     Returns
     -------
     array : np.ndarray(K_orbs, K_orbs)
-        Array whose first and second indices are associated with the linear combinations of the
-        contractions.
-        First and second indices of the array correspond to the linear combination of contractions.
-        `K_orbs` is the number of basis functions produced after the linear combinations.
+        Overlap integral of the given basis set.
+        Dimensions 0 and 1 of the array correspond to the basis functions. `K_orbs` is the number of
+        basis functions in the basis set.
 
     """
-    return Overlap(basis).construct_array_lincomb(transform, coord_type)
+    if transform is not None:
+        return Overlap(basis).construct_array_lincomb(transform, coord_type)
+    if coord_type == "cartesian":
+        return Overlap(basis).construct_array_cartesian()
+    if coord_type == "spherical":
+        return Overlap(basis).construct_array_spherical()
+    return Overlap(basis).construct_array_mix(coord_type)

--- a/gbasis/point_charge.py
+++ b/gbasis/point_charge.py
@@ -265,110 +265,29 @@ class PointChargeIntegral(BaseTwoIndexSymmetric):
         return output
 
 
-def point_charge_cartesian(basis, coords_points, charges_points):
-    """Return the integrals of the interaction b/w Cartesian contractions given point charges.
+def point_charge_integral(
+    basis, coords_points, charges_points, transform=None, coord_type="spherical"
+):
+    """Return the point-charge interaction integrals of basis set in the given coordinate systems.
 
     Parameters
     ----------
     basis : list/tuple of GeneralizedContractionShell
-        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
+        Shells of generalized contractions.
+    points : np.ndarray(N, 3)
+        Rows correspond to the points and columns correspond to the x, y, and z components.
     coords_points : np.ndarray(N, 3)
-        Coordinates of the point charges.
+        Coordinates of the point charges (in atomic units).
         Rows correspond to the different point charges and columns correspond to the x, y, and z
         components.
     charges_points : np.ndarray(N)
-        Charge of the point charges.
-
-    Returns
-    -------
-    array : np.ndarray(K_cart, K_cart, N)
-        Array associated with the given set of contracted Cartesian Gaussians.
-        First and second indices of the array are associated with the contracted Cartesian
-        Gaussians. `K_cart` is the total number of Cartesian contractions within the instance.
-
-    """
-    return PointChargeIntegral(basis).construct_array_cartesian(
-        coords_points=coords_points, charges_points=charges_points
-    )
-
-
-def point_charge_spherical(basis, coords_points, charges_points):
-    """Return the point-charge interation integrals of the basis set in the spherical form.
-
-    Parameters
-    ----------
-    basis : list/tuple of GeneralizedContractionShell
-        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
-    coords_points : np.ndarray(3,)
-        Coordinate of the point charge.
-        Rows correspond to the different point charges and columns correspond to the x, y, and z
-        components.
-    charges_points : float
-        Charge of the point charge.
-
-    Returns
-    -------
-    array : np.ndarray(K_sph, K_sph, N)
-        Array associated with the atomic orbitals associated with the given set(s) of contracted
-        Cartesian Gaussians.
-        First and second indices of the array are associated with two contracted spherical Gaussians
-        (atomic orbitals). `K_sph` is the total number of spherical contractions within the
-        instance.
-
-    """
-    return PointChargeIntegral(basis).construct_array_spherical(
-        coords_points=coords_points, charges_points=charges_points
-    )
-
-
-def point_charge_mix(basis, coords_points, charges_points, coord_types):
-    """Return the point-charge interation integrals of basis set in the given coordinate systems.
-
-    Parameters
-    ----------
-    basis : list/tuple of GeneralizedContractionShell
-        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
-    coords_points : np.ndarray(3,)
-        Coordinate of the point charge.
-        Rows correspond to the different point charges and columns correspond to the x, y, and z
-        components.
-    charges_points : float
-        Charge of the point charge.
-    coord_types : list/tuple of str
-        Types of the coordinate system for each GeneralizedContractionShell.
-        Each entry must be one of "cartesian" or "spherical".
-
-    Returns
-    -------
-    array : np.ndarray(K_orbs, K_orbs)
-        Array whose first and second indices are associated with the linear combinations of the
-        contractions.
-        First and second indices of the array correspond to the linear combination of contractions.
-        `K_orbs` is the number of basis functions produced after the linear combinations.
-
-    """
-    return PointChargeIntegral(basis).construct_array_mix(
-        coord_types, coords_points=coords_points, charges_points=charges_points
-    )
-
-
-def point_charge_lincomb(basis, transform, coords_points, charges_points, coord_type="spherical"):
-    """Return the point-charge interaction integrals of the linera combination of basis set.
-
-    Parameters
-    ----------
-    basis : list/tuple of GeneralizedContractionShell
-        Contracted Cartesian Gaussians (of the same shell) that will be used to construct an array.
-    transform : np.ndarray(K_orbs, K_sph)
-        Array associated with the linear combinations of spherical Gaussians (LCAO's).
-        Transformation is applied to the left, i.e. the sum is over the second index of `transform`
-        and first index of the array for contracted spherical Gaussians.
-    coords_points : np.ndarray(N, 3)
-        Coordinates of the point charges.
-        Rows correspond to the different point charges and columns correspond to the x, y, and z
-        components.
-    charges_points : np.ndarray(N)
-        Charge of the point charges.
+        Charge at each given point.
+    transform : np.ndarray(K, K_cont)
+        Transformation matrix from the basis set in the given coordinate system (e.g. AO) to linear
+        combinations of contractions (e.g. MO).
+        Transformation is applied to the left, i.e. the sum is over the index 1 of `transform`
+        and index 0 of the array for contractions.
+        Default is no transformation.
     coord_type : {"cartesian", list/tuple of "cartesian" or "spherical", "spherical"}
         Types of the coordinate system for the contractions.
         If "cartesian", then all of the contractions are treated as Cartesian contractions.
@@ -379,13 +298,26 @@ def point_charge_lincomb(basis, transform, coords_points, charges_points, coord_
 
     Returns
     -------
-    array : np.ndarray(K_orbs, K_orbs, N)
-        Array whose first and second indices are associated with the linear combinations of the
-        contractions.
-        First and second indices of the array correspond to the linear combination of contractions.
-        `K_orbs` is the number of basis functions produced after the linear combinations.
+    eval_array : np.ndarray(K, N)
+        Evaluations of the basis functions at the given coordinates.
+        If keyword argument `transform` is provided, then the transformed basis functions will be
+        evaluted at the given points.
+        `K` is the total number of basis functions within the given basis set.
+        `N` is the number of coordinates at which the contractions are evaluated.
 
     """
-    return PointChargeIntegral(basis).construct_array_lincomb(
-        transform, coord_type, coords_points=coords_points, charges_points=charges_points
+    if transform is not None:
+        return PointChargeIntegral(basis).construct_array_lincomb(
+            transform, coord_type, coords_points=coords_points, charges_points=charges_points
+        )
+    if coord_type == "cartesian":
+        return PointChargeIntegral(basis).construct_array_cartesian(
+            coords_points=coords_points, charges_points=charges_points
+        )
+    if coord_type == "spherical":
+        return PointChargeIntegral(basis).construct_array_spherical(
+            coords_points=coords_points, charges_points=charges_points
+        )
+    return PointChargeIntegral(basis).construct_array_mix(
+        coord_type, coords_points=coords_points, charges_points=charges_points
     )

--- a/gbasis/stress_tensor.py
+++ b/gbasis/stress_tensor.py
@@ -9,7 +9,7 @@ import numpy as np
 
 # TODO: need to be tested against reference
 def eval_stress_tensor(
-    one_density_matrix, basis, coords, alpha=1, beta=0, transform=None, coord_type="spherical"
+    one_density_matrix, basis, points, alpha=1, beta=0, transform=None, coord_type="spherical"
 ):
     r"""Return the stress tensor evaluated at the given coordinates.
 
@@ -53,7 +53,7 @@ def eval_stress_tensor(
         be expressed with respect to the transformed basis set.
     basis : list/tuple of GeneralizedContractionShell
         Shells of generalized contractions.
-    coords : np.ndarray(N, 3)
+    points : np.ndarray(N, 3)
         Coordinates of the points in space (in atomic units) where the basis functions are
         evaluated.
         Rows correspond to the points and columns correspond to the x, y, and z components.
@@ -93,7 +93,7 @@ def eval_stress_tensor(
         raise TypeError("`alpha` must be an integer or a float.")
     if not isinstance(beta, (int, float)):
         raise TypeError("`beta` must be an integer or a float.")
-    output = np.zeros((3, 3, coords.shape[0]))
+    output = np.zeros((3, 3, points.shape[0]))
     for i, orders_two in enumerate(np.identity(3, dtype=int)):
         for j, orders_one in enumerate(np.identity(3, dtype=int)[i:]):
             j += i
@@ -103,7 +103,7 @@ def eval_stress_tensor(
                     orders_two,
                     one_density_matrix,
                     basis,
-                    coords,
+                    points,
                     transform=transform,
                     coord_type=coord_type,
                 )
@@ -113,7 +113,7 @@ def eval_stress_tensor(
                     np.array([0, 0, 0]),
                     one_density_matrix,
                     basis,
-                    coords,
+                    points,
                     transform=transform,
                     coord_type=coord_type,
                 )
@@ -124,7 +124,7 @@ def eval_stress_tensor(
                     * eval_density_laplacian(
                         one_density_matrix,
                         basis,
-                        coords,
+                        points,
                         transform=transform,
                         coord_type=coord_type,
                     )
@@ -135,7 +135,7 @@ def eval_stress_tensor(
 
 # TODO: need to be tested against reference
 def eval_ehrenfest_force(
-    one_density_matrix, basis, coords, alpha=1, beta=0, transform=None, coord_type="spherical"
+    one_density_matrix, basis, points, alpha=1, beta=0, transform=None, coord_type="spherical"
 ):
     r"""Return the Ehrenfest force.
 
@@ -178,7 +178,7 @@ def eval_ehrenfest_force(
         be expressed with respect to the transformed basis set.
     basis : list/tuple of GeneralizedContractionShell
         Shells of generalized contractions.
-    coords : np.ndarray(N, 3)
+    points : np.ndarray(N, 3)
         Coordinates of the points in space (in atomic units) where the basis functions are
         evaluated.
         Rows correspond to the points and columns correspond to the x, y, and z components.
@@ -218,7 +218,7 @@ def eval_ehrenfest_force(
         raise TypeError("`alpha` must be an integer or a float.")
     if not isinstance(beta, (int, float)):
         raise TypeError("`beta` must be an integer or a float.")
-    output = np.zeros((3, coords.shape[0]))
+    output = np.zeros((3, points.shape[0]))
     for i, orders_two in enumerate(np.identity(3, dtype=int)):
         for orders_one in np.identity(3, dtype=int):
             if alpha != 0:
@@ -227,7 +227,7 @@ def eval_ehrenfest_force(
                     orders_two,
                     one_density_matrix,
                     basis,
-                    coords,
+                    points,
                     transform=transform,
                     coord_type=coord_type,
                 )
@@ -237,7 +237,7 @@ def eval_ehrenfest_force(
                     np.array([0, 0, 0]),
                     one_density_matrix,
                     basis,
-                    coords,
+                    points,
                     transform=transform,
                     coord_type=coord_type,
                 )
@@ -247,7 +247,7 @@ def eval_ehrenfest_force(
                     orders_one,
                     one_density_matrix,
                     basis,
-                    coords,
+                    points,
                     transform=transform,
                     coord_type=coord_type,
                 )
@@ -259,7 +259,7 @@ def eval_ehrenfest_force(
                         2 * orders_one + orders_two,
                         one_density_matrix,
                         basis,
-                        coords,
+                        points,
                         transform=transform,
                         coord_type=coord_type,
                     )
@@ -271,7 +271,7 @@ def eval_ehrenfest_force(
 def eval_ehrenfest_hessian(
     one_density_matrix,
     basis,
-    coords,
+    points,
     alpha=1,
     beta=0,
     transform=None,
@@ -329,7 +329,7 @@ def eval_ehrenfest_hessian(
         be expressed with respect to the transformed basis set.
     basis : list/tuple of GeneralizedContractionShell
         Shells of generalized contractions.
-    coords : np.ndarray(N, 3)
+    points : np.ndarray(N, 3)
         Coordinates of the points in space (in atomic units) where the basis functions are
         evaluated.
         Rows correspond to the points and columns correspond to the x, y, and z components.
@@ -374,7 +374,7 @@ def eval_ehrenfest_hessian(
         raise TypeError("`alpha` must be an integer or a float.")
     if not isinstance(beta, (int, float)):
         raise TypeError("`beta` must be an integer or a float.")
-    output = np.zeros((3, 3, coords.shape[0]))
+    output = np.zeros((3, 3, points.shape[0]))
     for i, orders_two in enumerate(np.identity(3, dtype=int)):
         for j, orders_three in enumerate(np.identity(3, dtype=int)):
             for orders_one in np.identity(3, dtype=int):
@@ -384,7 +384,7 @@ def eval_ehrenfest_hessian(
                         orders_two,
                         one_density_matrix,
                         basis,
-                        coords,
+                        points,
                         transform=transform,
                         coord_type=coord_type,
                     )
@@ -393,7 +393,7 @@ def eval_ehrenfest_hessian(
                         orders_two + orders_three,
                         one_density_matrix,
                         basis,
-                        coords,
+                        points,
                         transform=transform,
                         coord_type=coord_type,
                     )
@@ -403,7 +403,7 @@ def eval_ehrenfest_hessian(
                         np.array([0, 0, 0]),
                         one_density_matrix,
                         basis,
-                        coords,
+                        points,
                         transform=transform,
                         coord_type=coord_type,
                     )
@@ -412,7 +412,7 @@ def eval_ehrenfest_hessian(
                         orders_three,
                         one_density_matrix,
                         basis,
-                        coords,
+                        points,
                         transform=transform,
                         coord_type=coord_type,
                     )
@@ -422,7 +422,7 @@ def eval_ehrenfest_hessian(
                         orders_one,
                         one_density_matrix,
                         basis,
-                        coords,
+                        points,
                         transform=transform,
                         coord_type=coord_type,
                     )
@@ -431,7 +431,7 @@ def eval_ehrenfest_hessian(
                         orders_one + orders_three,
                         one_density_matrix,
                         basis,
-                        coords,
+                        points,
                         transform=transform,
                         coord_type=coord_type,
                     )
@@ -443,7 +443,7 @@ def eval_ehrenfest_hessian(
                             2 * orders_one + orders_two + orders_three,
                             one_density_matrix,
                             basis,
-                            coords,
+                            points,
                             transform=transform,
                             coord_type=coord_type,
                         )

--- a/tests/test_angular_momentum.py
+++ b/tests/test_angular_momentum.py
@@ -1,13 +1,7 @@
 """Test gbasis.angular_momentum."""
 from gbasis._diff_operator_int import _compute_differential_operator_integrals_intermediate
 from gbasis._moment_int import _compute_multipole_moment_integrals_intermediate
-from gbasis.angular_momentum import (
-    angular_momentum_integral_cartesian,
-    angular_momentum_integral_lincomb,
-    angular_momentum_integral_mix,
-    angular_momentum_integral_spherical,
-    AngularMomentumIntegral,
-)
+from gbasis.angular_momentum import angular_momentum_integral, AngularMomentumIntegral
 from gbasis.contractions import GeneralizedContractionShell
 from gbasis.parsers import make_contractions, parse_nwchem
 import numpy as np
@@ -379,7 +373,7 @@ def test_angular_momentum_integral_cartesian():
     angular_momentum_integral_obj = AngularMomentumIntegral(basis)
     assert np.allclose(
         angular_momentum_integral_obj.construct_array_cartesian(),
-        angular_momentum_integral_cartesian(basis),
+        angular_momentum_integral(basis, coord_type="cartesian"),
     )
 
 
@@ -393,7 +387,7 @@ def test_angular_momentum_integral_spherical():
     angular_momentum_integral_obj = AngularMomentumIntegral(basis)
     assert np.allclose(
         angular_momentum_integral_obj.construct_array_spherical(),
-        angular_momentum_integral_spherical(basis),
+        angular_momentum_integral(basis, coord_type="spherical"),
     )
 
 
@@ -407,7 +401,7 @@ def test_angular_momentum_integral_mix():
     angular_momentum_integral_obj = AngularMomentumIntegral(basis)
     assert np.allclose(
         angular_momentum_integral_obj.construct_array_mix(["spherical"] * 8),
-        angular_momentum_integral_mix(basis, ["spherical"] * 8),
+        angular_momentum_integral(basis, coord_type=["spherical"] * 8),
     )
 
 
@@ -421,5 +415,5 @@ def test_angular_momentum_integral_lincomb():
     transform = np.random.rand(14, 18)
     assert np.allclose(
         angular_momentum_integral_obj.construct_array_lincomb(transform, "spherical"),
-        angular_momentum_integral_lincomb(basis, transform),
+        angular_momentum_integral(basis, transform, coord_type="spherical"),
     )

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -69,11 +69,11 @@ def test_eval_density():
     transform = np.random.rand(14, 18)
     density = np.random.rand(14, 14)
     density += density.T
-    coords = np.random.rand(10, 3)
+    points = np.random.rand(10, 3)
 
-    eval_orbs = evaluate_basis(basis, coords, transform)
+    eval_orbs = evaluate_basis(basis, points, transform)
     assert np.allclose(
-        eval_density(density, basis, coords, transform),
+        eval_density(density, basis, points, transform),
         np.einsum("ij,ik,jk->k", density, eval_orbs, eval_orbs),
     )
 
@@ -87,139 +87,139 @@ def test_eval_deriv_density():
     transform = np.random.rand(14, 18)
     density = np.random.rand(14, 14)
     density += density.T
-    coords = np.random.rand(10, 3)
+    points = np.random.rand(10, 3)
 
     assert np.allclose(
-        eval_deriv_density(np.array([1, 0, 0]), density, basis, coords, transform),
+        eval_deriv_density(np.array([1, 0, 0]), density, basis, points, transform),
         np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis(basis, coords, np.array([1, 0, 0]), transform),
-            evaluate_basis(basis, coords, transform),
+            evaluate_deriv_basis(basis, points, np.array([1, 0, 0]), transform),
+            evaluate_basis(basis, points, transform),
         )
         + np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_basis(basis, coords, transform),
-            evaluate_deriv_basis(basis, coords, np.array([1, 0, 0]), transform),
+            evaluate_basis(basis, points, transform),
+            evaluate_deriv_basis(basis, points, np.array([1, 0, 0]), transform),
         ),
     )
 
     assert np.allclose(
-        eval_deriv_density(np.array([0, 1, 0]), density, basis, coords, transform),
+        eval_deriv_density(np.array([0, 1, 0]), density, basis, points, transform),
         np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis(basis, coords, np.array([0, 1, 0]), transform),
-            evaluate_basis(basis, coords, transform),
+            evaluate_deriv_basis(basis, points, np.array([0, 1, 0]), transform),
+            evaluate_basis(basis, points, transform),
         )
         + np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_basis(basis, coords, transform),
-            evaluate_deriv_basis(basis, coords, np.array([0, 1, 0]), transform),
+            evaluate_basis(basis, points, transform),
+            evaluate_deriv_basis(basis, points, np.array([0, 1, 0]), transform),
         ),
     )
 
     assert np.allclose(
-        eval_deriv_density(np.array([0, 0, 1]), density, basis, coords, transform),
+        eval_deriv_density(np.array([0, 0, 1]), density, basis, points, transform),
         np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis(basis, coords, np.array([0, 0, 1]), transform),
-            evaluate_basis(basis, coords, transform),
+            evaluate_deriv_basis(basis, points, np.array([0, 0, 1]), transform),
+            evaluate_basis(basis, points, transform),
         )
         + np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_basis(basis, coords, transform),
-            evaluate_deriv_basis(basis, coords, np.array([0, 0, 1]), transform),
+            evaluate_basis(basis, points, transform),
+            evaluate_deriv_basis(basis, points, np.array([0, 0, 1]), transform),
         ),
     )
 
     assert np.allclose(
-        eval_deriv_density(np.array([2, 3, 0]), density, basis, coords, transform),
+        eval_deriv_density(np.array([2, 3, 0]), density, basis, points, transform),
         np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis(basis, coords, np.array([0, 0, 0]), transform),
-            evaluate_deriv_basis(basis, coords, np.array([2, 3, 0]), transform),
+            evaluate_deriv_basis(basis, points, np.array([0, 0, 0]), transform),
+            evaluate_deriv_basis(basis, points, np.array([2, 3, 0]), transform),
         )
         + 3
         * np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis(basis, coords, np.array([0, 1, 0]), transform),
-            evaluate_deriv_basis(basis, coords, np.array([2, 2, 0]), transform),
+            evaluate_deriv_basis(basis, points, np.array([0, 1, 0]), transform),
+            evaluate_deriv_basis(basis, points, np.array([2, 2, 0]), transform),
         )
         + 3
         * np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis(basis, coords, np.array([0, 2, 0]), transform),
-            evaluate_deriv_basis(basis, coords, np.array([2, 1, 0]), transform),
+            evaluate_deriv_basis(basis, points, np.array([0, 2, 0]), transform),
+            evaluate_deriv_basis(basis, points, np.array([2, 1, 0]), transform),
         )
         + np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis(basis, coords, np.array([0, 3, 0]), transform),
-            evaluate_deriv_basis(basis, coords, np.array([2, 0, 0]), transform),
+            evaluate_deriv_basis(basis, points, np.array([0, 3, 0]), transform),
+            evaluate_deriv_basis(basis, points, np.array([2, 0, 0]), transform),
         )
         + 2
         * np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis(basis, coords, np.array([1, 0, 0]), transform),
-            evaluate_deriv_basis(basis, coords, np.array([1, 3, 0]), transform),
+            evaluate_deriv_basis(basis, points, np.array([1, 0, 0]), transform),
+            evaluate_deriv_basis(basis, points, np.array([1, 3, 0]), transform),
         )
         + 2
         * 3
         * np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis(basis, coords, np.array([1, 1, 0]), transform),
-            evaluate_deriv_basis(basis, coords, np.array([1, 2, 0]), transform),
+            evaluate_deriv_basis(basis, points, np.array([1, 1, 0]), transform),
+            evaluate_deriv_basis(basis, points, np.array([1, 2, 0]), transform),
         )
         + 2
         * 3
         * np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis(basis, coords, np.array([1, 2, 0]), transform),
-            evaluate_deriv_basis(basis, coords, np.array([1, 1, 0]), transform),
+            evaluate_deriv_basis(basis, points, np.array([1, 2, 0]), transform),
+            evaluate_deriv_basis(basis, points, np.array([1, 1, 0]), transform),
         )
         + 2
         * np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis(basis, coords, np.array([1, 3, 0]), transform),
-            evaluate_deriv_basis(basis, coords, np.array([1, 0, 0]), transform),
+            evaluate_deriv_basis(basis, points, np.array([1, 3, 0]), transform),
+            evaluate_deriv_basis(basis, points, np.array([1, 0, 0]), transform),
         )
         + np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis(basis, coords, np.array([2, 0, 0]), transform),
-            evaluate_deriv_basis(basis, coords, np.array([0, 3, 0]), transform),
+            evaluate_deriv_basis(basis, points, np.array([2, 0, 0]), transform),
+            evaluate_deriv_basis(basis, points, np.array([0, 3, 0]), transform),
         )
         + 3
         * np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis(basis, coords, np.array([2, 1, 0]), transform),
-            evaluate_deriv_basis(basis, coords, np.array([0, 2, 0]), transform),
+            evaluate_deriv_basis(basis, points, np.array([2, 1, 0]), transform),
+            evaluate_deriv_basis(basis, points, np.array([0, 2, 0]), transform),
         )
         + 3
         * np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis(basis, coords, np.array([2, 2, 0]), transform),
-            evaluate_deriv_basis(basis, coords, np.array([0, 1, 0]), transform),
+            evaluate_deriv_basis(basis, points, np.array([2, 2, 0]), transform),
+            evaluate_deriv_basis(basis, points, np.array([0, 1, 0]), transform),
         )
         + np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis(basis, coords, np.array([2, 3, 0]), transform),
-            evaluate_deriv_basis(basis, coords, np.array([0, 0, 0]), transform),
+            evaluate_deriv_basis(basis, points, np.array([2, 3, 0]), transform),
+            evaluate_deriv_basis(basis, points, np.array([0, 0, 0]), transform),
         ),
     )
 
@@ -233,47 +233,47 @@ def test_eval_density_gradient():
     transform = np.random.rand(14, 18)
     density = np.random.rand(14, 14)
     density += density.T
-    coords = np.random.rand(10, 3)
+    points = np.random.rand(10, 3)
 
     np.allclose(
-        eval_density_gradient(density, basis, coords, transform).T,
+        eval_density_gradient(density, basis, points, transform).T,
         np.array(
             [
                 np.einsum(
                     "ij,ik,jk->k",
                     density,
-                    evaluate_deriv_basis(basis, coords, np.array([1, 0, 0]), transform),
-                    evaluate_basis(basis, coords, transform),
+                    evaluate_deriv_basis(basis, points, np.array([1, 0, 0]), transform),
+                    evaluate_basis(basis, points, transform),
                 )
                 + np.einsum(
                     "ij,ik,jk->k",
                     density,
-                    evaluate_basis(basis, coords, transform),
-                    evaluate_deriv_basis(basis, coords, np.array([1, 0, 0]), transform),
+                    evaluate_basis(basis, points, transform),
+                    evaluate_deriv_basis(basis, points, np.array([1, 0, 0]), transform),
                 ),
                 np.einsum(
                     "ij,ik,jk->k",
                     density,
-                    evaluate_deriv_basis(basis, coords, np.array([0, 1, 0]), transform),
-                    evaluate_basis(basis, coords, transform),
+                    evaluate_deriv_basis(basis, points, np.array([0, 1, 0]), transform),
+                    evaluate_basis(basis, points, transform),
                 )
                 + np.einsum(
                     "ij,ik,jk->k",
                     density,
-                    evaluate_basis(basis, coords, transform),
-                    evaluate_deriv_basis(basis, coords, np.array([0, 1, 0]), transform),
+                    evaluate_basis(basis, points, transform),
+                    evaluate_deriv_basis(basis, points, np.array([0, 1, 0]), transform),
                 ),
                 np.einsum(
                     "ij,ik,jk->k",
                     density,
-                    evaluate_deriv_basis(basis, coords, np.array([0, 0, 1]), transform),
-                    evaluate_basis(basis, coords, transform),
+                    evaluate_deriv_basis(basis, points, np.array([0, 0, 1]), transform),
+                    evaluate_basis(basis, points, transform),
                 )
                 + np.einsum(
                     "ij,ik,jk->k",
                     density,
-                    evaluate_basis(basis, coords, transform),
-                    evaluate_deriv_basis(basis, coords, np.array([0, 0, 1]), transform),
+                    evaluate_basis(basis, points, transform),
+                    evaluate_deriv_basis(basis, points, np.array([0, 0, 1]), transform),
                 ),
             ]
         ),
@@ -290,8 +290,8 @@ def test_eval_density_horton():
         test_basis = f.read()
     basis_dict = parse_nwchem(test_basis)
     # NOTE: used HORTON's conversion factor for angstroms to bohr
-    coords = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
-    basis = make_contractions(basis_dict, ["H", "He"], coords)
+    points = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
+    basis = make_contractions(basis_dict, ["H", "He"], points)
     basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps) for i in basis]
 
     horton_density = np.load(find_datafile("data_horton_hhe_sph_density.npy"))
@@ -315,8 +315,8 @@ def test_eval_density_gradient_horton():
         test_basis = f.read()
     basis_dict = parse_nwchem(test_basis)
     # NOTE: used HORTON's conversion factor for angstroms to bohr
-    coords = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
-    basis = make_contractions(basis_dict, ["H", "He"], coords)
+    points = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
+    basis = make_contractions(basis_dict, ["H", "He"], points)
     basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps) for i in basis]
 
     horton_density_gradient = np.load(find_datafile("data_horton_hhe_sph_density_gradient.npy"))
@@ -341,8 +341,8 @@ def test_eval_hessian_deriv_horton():
         test_basis = f.read()
     basis_dict = parse_nwchem(test_basis)
     # NOTE: used HORTON's conversion factor for angstroms to bohr
-    coords = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
-    basis = make_contractions(basis_dict, ["H", "He"], coords)
+    points = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
+    basis = make_contractions(basis_dict, ["H", "He"], points)
     basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps) for i in basis]
 
     horton_density_hessian = np.zeros((10 ** 3, 3, 3))
@@ -373,8 +373,8 @@ def test_eval_laplacian_deriv_horton():
         test_basis = f.read()
     basis_dict = parse_nwchem(test_basis)
     # NOTE: used HORTON's conversion factor for angstroms to bohr
-    coords = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
-    basis = make_contractions(basis_dict, ["H", "He"], coords)
+    points = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
+    basis = make_contractions(basis_dict, ["H", "He"], points)
     basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps) for i in basis]
 
     horton_density_laplacian = np.load(find_datafile("data_horton_hhe_sph_density_laplacian.npy"))
@@ -399,8 +399,8 @@ def test_eval_posdef_kinetic_energy_density():
         test_basis = f.read()
     basis_dict = parse_nwchem(test_basis)
     # NOTE: used HORTON's conversion factor for angstroms to bohr
-    coords = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
-    basis = make_contractions(basis_dict, ["H", "He"], coords)
+    points = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
+    basis = make_contractions(basis_dict, ["H", "He"], points)
     basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps) for i in basis]
 
     horton_density_kinetic_density = np.load(
@@ -429,8 +429,8 @@ def test_eval_general_kinetic_energy_density_horton():
         test_basis = f.read()
     basis_dict = parse_nwchem(test_basis)
     # NOTE: used HORTON's conversion factor for angstroms to bohr
-    coords = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
-    basis = make_contractions(basis_dict, ["H", "He"], coords)
+    points = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
+    basis = make_contractions(basis_dict, ["H", "He"], points)
     basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps) for i in basis]
 
     horton_density_kinetic_density = np.load(
@@ -452,8 +452,8 @@ def test_eval_general_kinetic_energy_density():
     with open(find_datafile("data_anorcc.nwchem"), "r") as f:
         test_basis = f.read()
     basis_dict = parse_nwchem(test_basis)
-    coords = np.array([[0, 0, 0]])
-    basis = make_contractions(basis_dict, ["H"], coords)
+    points = np.array([[0, 0, 0]])
+    basis = make_contractions(basis_dict, ["H"], points)
     points = np.random.rand(10, 3)
 
     with pytest.raises(TypeError):

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -9,8 +9,8 @@ from gbasis.density import (
     eval_general_kinetic_energy_density,
     eval_posdef_kinetic_energy_density,
 )
-from gbasis.eval import evaluate_basis_lincomb
-from gbasis.eval_deriv import evaluate_deriv_basis_lincomb
+from gbasis.eval import evaluate_basis
+from gbasis.eval_deriv import evaluate_deriv_basis
 from gbasis.parsers import make_contractions, parse_nwchem
 import numpy as np
 import pytest
@@ -71,7 +71,7 @@ def test_eval_density():
     density += density.T
     coords = np.random.rand(10, 3)
 
-    eval_orbs = evaluate_basis_lincomb(basis, coords, transform)
+    eval_orbs = evaluate_basis(basis, coords, transform)
     assert np.allclose(
         eval_density(density, basis, coords, transform),
         np.einsum("ij,ik,jk->k", density, eval_orbs, eval_orbs),
@@ -94,14 +94,14 @@ def test_eval_deriv_density():
         np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([1, 0, 0]), transform),
-            evaluate_basis_lincomb(basis, coords, transform),
+            evaluate_deriv_basis(basis, coords, np.array([1, 0, 0]), transform),
+            evaluate_basis(basis, coords, transform),
         )
         + np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_basis_lincomb(basis, coords, transform),
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([1, 0, 0]), transform),
+            evaluate_basis(basis, coords, transform),
+            evaluate_deriv_basis(basis, coords, np.array([1, 0, 0]), transform),
         ),
     )
 
@@ -110,14 +110,14 @@ def test_eval_deriv_density():
         np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([0, 1, 0]), transform),
-            evaluate_basis_lincomb(basis, coords, transform),
+            evaluate_deriv_basis(basis, coords, np.array([0, 1, 0]), transform),
+            evaluate_basis(basis, coords, transform),
         )
         + np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_basis_lincomb(basis, coords, transform),
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([0, 1, 0]), transform),
+            evaluate_basis(basis, coords, transform),
+            evaluate_deriv_basis(basis, coords, np.array([0, 1, 0]), transform),
         ),
     )
 
@@ -126,14 +126,14 @@ def test_eval_deriv_density():
         np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([0, 0, 1]), transform),
-            evaluate_basis_lincomb(basis, coords, transform),
+            evaluate_deriv_basis(basis, coords, np.array([0, 0, 1]), transform),
+            evaluate_basis(basis, coords, transform),
         )
         + np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_basis_lincomb(basis, coords, transform),
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([0, 0, 1]), transform),
+            evaluate_basis(basis, coords, transform),
+            evaluate_deriv_basis(basis, coords, np.array([0, 0, 1]), transform),
         ),
     )
 
@@ -142,84 +142,84 @@ def test_eval_deriv_density():
         np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([0, 0, 0]), transform),
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([2, 3, 0]), transform),
+            evaluate_deriv_basis(basis, coords, np.array([0, 0, 0]), transform),
+            evaluate_deriv_basis(basis, coords, np.array([2, 3, 0]), transform),
         )
         + 3
         * np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([0, 1, 0]), transform),
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([2, 2, 0]), transform),
+            evaluate_deriv_basis(basis, coords, np.array([0, 1, 0]), transform),
+            evaluate_deriv_basis(basis, coords, np.array([2, 2, 0]), transform),
         )
         + 3
         * np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([0, 2, 0]), transform),
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([2, 1, 0]), transform),
+            evaluate_deriv_basis(basis, coords, np.array([0, 2, 0]), transform),
+            evaluate_deriv_basis(basis, coords, np.array([2, 1, 0]), transform),
         )
         + np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([0, 3, 0]), transform),
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([2, 0, 0]), transform),
+            evaluate_deriv_basis(basis, coords, np.array([0, 3, 0]), transform),
+            evaluate_deriv_basis(basis, coords, np.array([2, 0, 0]), transform),
         )
         + 2
         * np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([1, 0, 0]), transform),
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([1, 3, 0]), transform),
+            evaluate_deriv_basis(basis, coords, np.array([1, 0, 0]), transform),
+            evaluate_deriv_basis(basis, coords, np.array([1, 3, 0]), transform),
         )
         + 2
         * 3
         * np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([1, 1, 0]), transform),
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([1, 2, 0]), transform),
+            evaluate_deriv_basis(basis, coords, np.array([1, 1, 0]), transform),
+            evaluate_deriv_basis(basis, coords, np.array([1, 2, 0]), transform),
         )
         + 2
         * 3
         * np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([1, 2, 0]), transform),
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([1, 1, 0]), transform),
+            evaluate_deriv_basis(basis, coords, np.array([1, 2, 0]), transform),
+            evaluate_deriv_basis(basis, coords, np.array([1, 1, 0]), transform),
         )
         + 2
         * np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([1, 3, 0]), transform),
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([1, 0, 0]), transform),
+            evaluate_deriv_basis(basis, coords, np.array([1, 3, 0]), transform),
+            evaluate_deriv_basis(basis, coords, np.array([1, 0, 0]), transform),
         )
         + np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([2, 0, 0]), transform),
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([0, 3, 0]), transform),
+            evaluate_deriv_basis(basis, coords, np.array([2, 0, 0]), transform),
+            evaluate_deriv_basis(basis, coords, np.array([0, 3, 0]), transform),
         )
         + 3
         * np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([2, 1, 0]), transform),
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([0, 2, 0]), transform),
+            evaluate_deriv_basis(basis, coords, np.array([2, 1, 0]), transform),
+            evaluate_deriv_basis(basis, coords, np.array([0, 2, 0]), transform),
         )
         + 3
         * np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([2, 2, 0]), transform),
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([0, 1, 0]), transform),
+            evaluate_deriv_basis(basis, coords, np.array([2, 2, 0]), transform),
+            evaluate_deriv_basis(basis, coords, np.array([0, 1, 0]), transform),
         )
         + np.einsum(
             "ij,ik,jk->k",
             density,
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([2, 3, 0]), transform),
-            evaluate_deriv_basis_lincomb(basis, coords, np.array([0, 0, 0]), transform),
+            evaluate_deriv_basis(basis, coords, np.array([2, 3, 0]), transform),
+            evaluate_deriv_basis(basis, coords, np.array([0, 0, 0]), transform),
         ),
     )
 
@@ -242,38 +242,38 @@ def test_eval_density_gradient():
                 np.einsum(
                     "ij,ik,jk->k",
                     density,
-                    evaluate_deriv_basis_lincomb(basis, coords, np.array([1, 0, 0]), transform),
-                    evaluate_basis_lincomb(basis, coords, transform),
+                    evaluate_deriv_basis(basis, coords, np.array([1, 0, 0]), transform),
+                    evaluate_basis(basis, coords, transform),
                 )
                 + np.einsum(
                     "ij,ik,jk->k",
                     density,
-                    evaluate_basis_lincomb(basis, coords, transform),
-                    evaluate_deriv_basis_lincomb(basis, coords, np.array([1, 0, 0]), transform),
+                    evaluate_basis(basis, coords, transform),
+                    evaluate_deriv_basis(basis, coords, np.array([1, 0, 0]), transform),
                 ),
                 np.einsum(
                     "ij,ik,jk->k",
                     density,
-                    evaluate_deriv_basis_lincomb(basis, coords, np.array([0, 1, 0]), transform),
-                    evaluate_basis_lincomb(basis, coords, transform),
+                    evaluate_deriv_basis(basis, coords, np.array([0, 1, 0]), transform),
+                    evaluate_basis(basis, coords, transform),
                 )
                 + np.einsum(
                     "ij,ik,jk->k",
                     density,
-                    evaluate_basis_lincomb(basis, coords, transform),
-                    evaluate_deriv_basis_lincomb(basis, coords, np.array([0, 1, 0]), transform),
+                    evaluate_basis(basis, coords, transform),
+                    evaluate_deriv_basis(basis, coords, np.array([0, 1, 0]), transform),
                 ),
                 np.einsum(
                     "ij,ik,jk->k",
                     density,
-                    evaluate_deriv_basis_lincomb(basis, coords, np.array([0, 0, 1]), transform),
-                    evaluate_basis_lincomb(basis, coords, transform),
+                    evaluate_deriv_basis(basis, coords, np.array([0, 0, 1]), transform),
+                    evaluate_basis(basis, coords, transform),
                 )
                 + np.einsum(
                     "ij,ik,jk->k",
                     density,
-                    evaluate_basis_lincomb(basis, coords, transform),
-                    evaluate_deriv_basis_lincomb(basis, coords, np.array([0, 0, 1]), transform),
+                    evaluate_basis(basis, coords, transform),
+                    evaluate_deriv_basis(basis, coords, np.array([0, 0, 1]), transform),
                 ),
             ]
         ),
@@ -442,7 +442,7 @@ def test_eval_general_kinetic_energy_density_horton():
     grid_3d = np.vstack([grid_x.ravel(), grid_y.ravel(), grid_z.ravel()]).T
 
     assert np.allclose(
-        eval_general_kinetic_energy_density(np.identity(88), basis, grid_3d, np.identity(88), 0),
+        eval_general_kinetic_energy_density(np.identity(88), basis, grid_3d, 0, np.identity(88)),
         horton_density_kinetic_density,
     )
 
@@ -461,9 +461,9 @@ def test_eval_general_kinetic_energy_density():
             np.identity(40), basis, points, np.identity(40), np.array(0)
         )
     with pytest.raises(TypeError):
-        eval_general_kinetic_energy_density(np.identity(40), basis, points, np.identity(40), None)
+        eval_general_kinetic_energy_density(np.identity(40), basis, points, None, np.identity(40))
     assert np.allclose(
-        eval_general_kinetic_energy_density(np.identity(40), basis, points, np.identity(40), 1),
+        eval_general_kinetic_energy_density(np.identity(40), basis, points, 1, np.identity(40)),
         eval_posdef_kinetic_energy_density(np.identity(40), basis, points, np.identity(40))
         + eval_density_laplacian(np.identity(40), basis, points, np.identity(40)),
     )

--- a/tests/test_electron_repulsion.py
+++ b/tests/test_electron_repulsion.py
@@ -4,13 +4,7 @@ from gbasis._two_elec_int import (
     _compute_two_elec_integrals_angmom_zero,
 )
 from gbasis.contractions import GeneralizedContractionShell
-from gbasis.electron_repulsion import (
-    electron_repulsion_cartesian,
-    electron_repulsion_lincomb,
-    electron_repulsion_mix,
-    electron_repulsion_spherical,
-    ElectronRepulsionIntegral,
-)
+from gbasis.electron_repulsion import electron_repulsion_integral, ElectronRepulsionIntegral
 from gbasis.parsers import make_contractions, parse_nwchem
 import numpy as np
 import pytest
@@ -108,7 +102,9 @@ def test_electron_repulsion_cartesian_horton_sto6g_bec():
     basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps) for i in basis]
 
     horton_elec_repulsion = np.load(find_datafile("data_horton_bec_cart_elec_repulsion.npy"))
-    assert np.allclose(horton_elec_repulsion, electron_repulsion_cartesian(basis))
+    assert np.allclose(
+        horton_elec_repulsion, electron_repulsion_integral(basis, coord_type="cartesian")
+    )
 
 
 def test_electron_repulsion_cartesian_horton_custom_hhe():
@@ -137,7 +133,9 @@ def test_electron_repulsion_cartesian_horton_custom_hhe():
     basis.pop(2)
 
     horton_elec_repulsion = np.load(find_datafile("data_horton_hhe_cart_elec_repulsion.npy"))
-    assert np.allclose(horton_elec_repulsion, electron_repulsion_cartesian(basis))
+    assert np.allclose(
+        horton_elec_repulsion, electron_repulsion_integral(basis, coord_type="cartesian")
+    )
 
 
 def test_electron_repulsion_cartesian():
@@ -150,14 +148,14 @@ def test_electron_repulsion_cartesian():
     erep_obj = ElectronRepulsionIntegral(basis)
     assert np.allclose(
         erep_obj.construct_array_cartesian(),
-        electron_repulsion_cartesian(basis, notation="chemist"),
+        electron_repulsion_integral(basis, notation="chemist", coord_type="cartesian"),
     )
     assert np.allclose(
         np.einsum("ijkl->ikjl", erep_obj.construct_array_cartesian()),
-        electron_repulsion_cartesian(basis, notation="physicist"),
+        electron_repulsion_integral(basis, notation="physicist", coord_type="cartesian"),
     )
     with pytest.raises(ValueError):
-        electron_repulsion_cartesian(basis, notation="bad")
+        electron_repulsion_integral(basis, notation="bad", coord_type="cartesian")
 
 
 def test_electron_repulsion_spherical():
@@ -170,14 +168,14 @@ def test_electron_repulsion_spherical():
     erep_obj = ElectronRepulsionIntegral(basis)
     assert np.allclose(
         erep_obj.construct_array_spherical(),
-        electron_repulsion_spherical(basis, notation="chemist"),
+        electron_repulsion_integral(basis, notation="chemist", coord_type="spherical"),
     )
     assert np.allclose(
         np.einsum("ijkl->ikjl", erep_obj.construct_array_spherical()),
-        electron_repulsion_spherical(basis, notation="physicist"),
+        electron_repulsion_integral(basis, notation="physicist", coord_type="spherical"),
     )
     with pytest.raises(ValueError):
-        electron_repulsion_spherical(basis, notation="bad")
+        electron_repulsion_integral(basis, notation="bad", coord_type="spherical")
 
 
 def test_electron_repulsion_mix():
@@ -190,14 +188,14 @@ def test_electron_repulsion_mix():
     erep_obj = ElectronRepulsionIntegral(basis)
     assert np.allclose(
         erep_obj.construct_array_mix(["spherical"] * 3),
-        electron_repulsion_mix(basis, ["spherical"] * 3, notation="chemist"),
+        electron_repulsion_integral(basis, notation="chemist", coord_type=["spherical"] * 3),
     )
     assert np.allclose(
         np.einsum("ijkl->ikjl", erep_obj.construct_array_mix(["spherical"] * 3)),
-        electron_repulsion_mix(basis, ["spherical"] * 3, notation="physicist"),
+        electron_repulsion_integral(basis, notation="physicist", coord_type=["spherical"] * 3),
     )
     with pytest.raises(ValueError):
-        electron_repulsion_mix(basis, ["spherical"] * 3, notation="bad")
+        electron_repulsion_integral(basis, notation="bad", coord_type=["spherical"] * 3)
 
 
 def test_electron_repulsion_lincomb():
@@ -211,11 +209,11 @@ def test_electron_repulsion_lincomb():
     transform = np.random.rand(3, 5)
     assert np.allclose(
         erep_obj.construct_array_lincomb(transform, "spherical"),
-        electron_repulsion_lincomb(basis, transform, notation="chemist"),
+        electron_repulsion_integral(basis, transform, notation="chemist", coord_type="spherical"),
     )
     assert np.allclose(
         np.einsum("ijkl->ikjl", erep_obj.construct_array_lincomb(transform, "spherical")),
-        electron_repulsion_lincomb(basis, transform, notation="physicist"),
+        electron_repulsion_integral(basis, transform, notation="physicist", coord_type="spherical"),
     )
     with pytest.raises(ValueError):
-        electron_repulsion_lincomb(basis, transform, notation="bad")
+        electron_repulsion_integral(basis, transform, notation="bad", coord_type="spherical")

--- a/tests/test_electrostatic_potential.py
+++ b/tests/test_electrostatic_potential.py
@@ -1,18 +1,13 @@
 """Tests for gbasis.electrostatic_potential."""
-from gbasis.electrostatic_potential import (
-    _electrostatic_potential_base,
-    electrostatic_potential_cartesian,
-    electrostatic_potential_mix,
-    electrostatic_potential_spherical,
-)
+from gbasis.electrostatic_potential import electrostatic_potential
 from gbasis.parsers import make_contractions, parse_nwchem
 import numpy as np
 import pytest
 from utils import find_datafile, HortonContractions
 
 
-def test_electrostatic_potential_base():
-    """Test gbasis.electrostatic_potential._electorstatic_potential_base.
+def test_electrostatic_potential():
+    """Test gbasis.electrostatic_potential.electorstatic_potential.
 
     Tested by using point_charge.point_charge_cartesian.
 
@@ -26,139 +21,139 @@ def test_electrostatic_potential_base():
 
     # check density_matrix type
     with pytest.raises(TypeError):
-        _electrostatic_potential_base(
+        electrostatic_potential(
             basis,
             np.identity(103).tolist(),
             np.random.rand(10, 3),
             np.random.rand(2, 3),
             np.array([1, 2]),
-            "cartesian",
+            coord_type="cartesian",
         )
     with pytest.raises(TypeError):
-        _electrostatic_potential_base(
+        electrostatic_potential(
             basis,
             np.identity(103).flatten(),
             np.random.rand(10, 3),
             np.random.rand(2, 3),
             np.array([1, 2]),
-            "cartesian",
+            coord_type="cartesian",
         )
     # check nuclear_coords
     with pytest.raises(TypeError):
-        _electrostatic_potential_base(
+        electrostatic_potential(
             basis,
             np.identity(103),
             np.random.rand(10, 3),
             np.random.rand(2, 3).tolist(),
             np.array([1, 2]),
-            "cartesian",
+            coord_type="cartesian",
         )
     with pytest.raises(TypeError):
-        _electrostatic_potential_base(
+        electrostatic_potential(
             basis,
             np.identity(103),
             np.random.rand(10, 3),
             np.random.rand(2, 4),
             np.array([1, 2]),
-            "cartesian",
+            coord_type="cartesian",
         )
     # check nuclear charges
     with pytest.raises(TypeError):
-        _electrostatic_potential_base(
+        electrostatic_potential(
             basis,
             np.identity(103),
             np.random.rand(10, 3),
             np.random.rand(2, 3),
             np.array([1, 2]).reshape(1, 2),
-            "cartesian",
+            coord_type="cartesian",
         )
     with pytest.raises(TypeError):
-        _electrostatic_potential_base(
+        electrostatic_potential(
             basis,
             np.identity(103),
             np.random.rand(10, 3),
             np.random.rand(2, 3),
             np.array([1, 2]).tolist(),
-            "cartesian",
+            coord_type="cartesian",
         )
     # check density_matrix symmetry
     with pytest.raises(ValueError):
-        _electrostatic_potential_base(
+        electrostatic_potential(
             basis,
             np.eye(103, 102),
             np.random.rand(10, 3),
             np.random.rand(2, 3),
             np.array([1, 2]),
-            "cartesian",
+            coord_type="cartesian",
         )
     # check nuclear_coords and nuclear_charges shapes
     with pytest.raises(ValueError):
-        _electrostatic_potential_base(
+        electrostatic_potential(
             basis,
             np.identity(103),
             np.random.rand(10, 3),
             np.random.rand(3, 3),
             np.array([1, 2]),
-            "cartesian",
+            coord_type="cartesian",
         )
     # check threshold_dist types
     with pytest.raises(TypeError):
-        _electrostatic_potential_base(
+        electrostatic_potential(
             basis,
             np.identity(103),
             np.random.rand(10, 3),
             np.random.rand(2, 3),
             np.array([1, 2]),
-            "cartesian",
+            coord_type="cartesian",
             threshold_dist=None,
         )
     # check threshold_dist value
     with pytest.raises(ValueError):
-        _electrostatic_potential_base(
+        electrostatic_potential(
             basis,
             np.identity(103),
             np.random.rand(10, 3),
             np.random.rand(2, 3),
             np.array([1, 2]),
-            "cartesian",
+            coord_type="cartesian",
             threshold_dist=-0.1,
         )
     # check coord_types type
     with pytest.raises(TypeError):
-        _electrostatic_potential_base(
+        electrostatic_potential(
             basis,
             np.identity(103),
             np.random.rand(10, 3),
             np.random.rand(2, 3),
             np.array([1, 2]),
-            "bad",
+            coord_type="bad",
         )
     with pytest.raises(ValueError):
-        _electrostatic_potential_base(
+        electrostatic_potential(
             basis,
             np.identity(88),
             np.random.rand(10, 3),
             np.random.rand(2, 3),
             np.array([1, 2]),
-            "cartesian",
+            coord_type="cartesian",
         )
     with pytest.raises(ValueError):
-        _electrostatic_potential_base(
+        electrostatic_potential(
             basis,
             np.identity(103),
             np.random.rand(10, 3),
             np.random.rand(2, 3),
             np.array([1, 2]),
-            "spherical",
+            coord_type="spherical",
         )
     with pytest.raises(ValueError):
-        _electrostatic_potential_base(
+        electrostatic_potential(
             basis,
             np.identity(103),
             np.random.rand(10, 3),
             np.random.rand(2, 3),
             np.array([1, 2]),
-            ["spherical"] * 9,
+            coord_type=["spherical"] * 9,
         )
 
 
@@ -183,8 +178,8 @@ def test_electrostatic_potential_cartesian():
 
     horton_nucattract = np.load(find_datafile("data_horton_hhe_cart_esp.npy"))
     assert np.allclose(
-        electrostatic_potential_cartesian(
-            basis, np.identity(103), grid_3d, coords, np.array([1, 2])
+        electrostatic_potential(
+            basis, np.identity(103), grid_3d, coords, np.array([1, 2]), coord_type="cartesian"
         ),
         horton_nucattract,
     )
@@ -211,8 +206,8 @@ def test_electrostatic_potential_spherical():
 
     horton_nucattract = np.load(find_datafile("data_horton_hhe_sph_esp.npy"))
     assert np.allclose(
-        electrostatic_potential_spherical(
-            basis, np.identity(88), grid_3d, coords, np.array([1, 2])
+        electrostatic_potential(
+            basis, np.identity(88), grid_3d, coords, np.array([1, 2]), coord_type="spherical"
         ),
         horton_nucattract,
     )
@@ -239,15 +234,15 @@ def test_electrostatic_potential_mix():
 
     horton_nucattract = np.load(find_datafile("data_horton_hhe_sph_esp.npy"))
     assert np.allclose(
-        electrostatic_potential_mix(
-            basis, np.identity(88), grid_3d, coords, np.array([1, 2]), ["spherical"] * 9
+        electrostatic_potential(
+            basis, np.identity(88), grid_3d, coords, np.array([1, 2]), coord_type=["spherical"] * 9
         ),
         horton_nucattract,
     )
     horton_nucattract = np.load(find_datafile("data_horton_hhe_cart_esp.npy"))
     assert np.allclose(
-        electrostatic_potential_mix(
-            basis, np.identity(103), grid_3d, coords, np.array([1, 2]), ["cartesian"] * 9
+        electrostatic_potential(
+            basis, np.identity(103), grid_3d, coords, np.array([1, 2]), coord_type=["cartesian"] * 9
         ),
         horton_nucattract,
     )

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,13 +1,7 @@
 """Test gbasis.eval."""
 from gbasis._deriv import _eval_deriv_contractions
 from gbasis.contractions import GeneralizedContractionShell
-from gbasis.eval import (
-    Eval,
-    evaluate_basis_cartesian,
-    evaluate_basis_lincomb,
-    evaluate_basis_mix,
-    evaluate_basis_spherical,
-)
+from gbasis.eval import Eval, evaluate_basis
 from gbasis.parsers import make_contractions, parse_nwchem
 import numpy as np
 import pytest
@@ -68,7 +62,7 @@ def test_evaluate_basis_cartesian():
     eval_obj = Eval(basis)
     assert np.allclose(
         eval_obj.construct_array_cartesian(coords=np.array([[0, 0, 0]])),
-        evaluate_basis_cartesian(basis, np.array([[0, 0, 0]])),
+        evaluate_basis(basis, np.array([[0, 0, 0]]), coord_type="cartesian"),
     )
 
 
@@ -83,21 +77,21 @@ def test_evaluate_basis_spherical():
     eval_obj = Eval(basis)
     assert np.allclose(
         eval_obj.construct_array_cartesian(coords=np.array([[0, 0, 0]])),
-        evaluate_basis_spherical(basis, np.array([[0, 0, 0]])),
+        evaluate_basis(basis, np.array([[0, 0, 0]]), coord_type="spherical"),
     )
     # p orbitals are zero at center
     basis = make_contractions(basis_dict, ["Li"], np.array([[0, 0, 0]]))
     eval_obj = Eval(basis)
     assert np.allclose(
         eval_obj.construct_array_cartesian(coords=np.array([[0, 0, 0]])),
-        evaluate_basis_spherical(basis, np.array([[0, 0, 0]])),
+        evaluate_basis(basis, np.array([[0, 0, 0]]), coord_type="spherical"),
     )
 
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     eval_obj = Eval(basis)
     assert np.allclose(
         eval_obj.construct_array_spherical(coords=np.array([[1, 1, 1]])),
-        evaluate_basis_spherical(basis, np.array([[1, 1, 1]])),
+        evaluate_basis(basis, np.array([[1, 1, 1]]), coord_type="spherical"),
     )
 
 
@@ -110,22 +104,22 @@ def test_evaluate_basis_mix():
     # cartesian and spherical are the same for s orbital
     basis = make_contractions(basis_dict, ["H"], np.array([[0, 0, 0]]))
     assert np.allclose(
-        evaluate_basis_spherical(basis, np.array([[0, 0, 0]])),
-        evaluate_basis_mix(basis, np.array([[0, 0, 0]]), ["spherical"]),
+        evaluate_basis(basis, np.array([[0, 0, 0]]), coord_type="spherical"),
+        evaluate_basis(basis, np.array([[0, 0, 0]]), coord_type=["spherical"]),
     )
     assert np.allclose(
-        evaluate_basis_cartesian(basis, np.array([[0, 0, 0]])),
-        evaluate_basis_mix(basis, np.array([[0, 0, 0]]), ["cartesian"]),
+        evaluate_basis(basis, np.array([[0, 0, 0]]), coord_type="cartesian"),
+        evaluate_basis(basis, np.array([[0, 0, 0]]), coord_type=["cartesian"]),
     )
 
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     assert np.allclose(
-        evaluate_basis_spherical(basis, np.array([[1, 1, 1]])),
-        evaluate_basis_mix(basis, np.array([[1, 1, 1]]), ["spherical"] * 8),
+        evaluate_basis(basis, np.array([[1, 1, 1]]), coord_type="spherical"),
+        evaluate_basis(basis, np.array([[1, 1, 1]]), coord_type=["spherical"] * 8),
     )
     assert np.allclose(
-        evaluate_basis_cartesian(basis, np.array([[1, 1, 1]])),
-        evaluate_basis_mix(basis, np.array([[1, 1, 1]]), ["cartesian"] * 8),
+        evaluate_basis(basis, np.array([[1, 1, 1]]), coord_type="cartesian"),
+        evaluate_basis(basis, np.array([[1, 1, 1]]), coord_type=["cartesian"] * 8),
     )
 
 
@@ -139,5 +133,5 @@ def test_evaluate_basis_lincomb():
     transform = np.random.rand(14, 18)
     assert np.allclose(
         eval_obj.construct_array_lincomb(transform, "spherical", coords=np.array([[1, 1, 1]])),
-        evaluate_basis_lincomb(basis, np.array([[1, 1, 1]]), transform, "spherical"),
+        evaluate_basis(basis, np.array([[1, 1, 1]]), transform=transform, coord_type="spherical"),
     )

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -40,17 +40,17 @@ def test_eval_construct_array_contraction():
         ]
     ).reshape(3, 1)
     assert np.allclose(
-        Eval.construct_array_contraction(coords=np.array([[2, 3, 4]]), contractions=test), answer
+        Eval.construct_array_contraction(points=np.array([[2, 3, 4]]), contractions=test), answer
     )
 
     with pytest.raises(TypeError):
-        Eval.construct_array_contraction(coords=np.array([[2, 3, 4]]), contractions=None)
+        Eval.construct_array_contraction(points=np.array([[2, 3, 4]]), contractions=None)
     with pytest.raises(TypeError):
-        Eval.construct_array_contraction(coords=np.array([[2, 3, 4]]), contractions={1: 2})
+        Eval.construct_array_contraction(points=np.array([[2, 3, 4]]), contractions={1: 2})
     with pytest.raises(TypeError):
-        Eval.construct_array_contraction(coords=np.array([2, 3, 4]), contractions=test)
+        Eval.construct_array_contraction(points=np.array([2, 3, 4]), contractions=test)
     with pytest.raises(TypeError):
-        Eval.construct_array_contraction(coords=np.array([[3, 4]]), contractions=test)
+        Eval.construct_array_contraction(points=np.array([[3, 4]]), contractions=test)
 
 
 def test_evaluate_basis_cartesian():
@@ -61,7 +61,7 @@ def test_evaluate_basis_cartesian():
     basis = make_contractions(basis_dict, ["H"], np.array([[0, 0, 0]]))
     eval_obj = Eval(basis)
     assert np.allclose(
-        eval_obj.construct_array_cartesian(coords=np.array([[0, 0, 0]])),
+        eval_obj.construct_array_cartesian(points=np.array([[0, 0, 0]])),
         evaluate_basis(basis, np.array([[0, 0, 0]]), coord_type="cartesian"),
     )
 
@@ -76,21 +76,21 @@ def test_evaluate_basis_spherical():
     basis = make_contractions(basis_dict, ["H"], np.array([[0, 0, 0]]))
     eval_obj = Eval(basis)
     assert np.allclose(
-        eval_obj.construct_array_cartesian(coords=np.array([[0, 0, 0]])),
+        eval_obj.construct_array_cartesian(points=np.array([[0, 0, 0]])),
         evaluate_basis(basis, np.array([[0, 0, 0]]), coord_type="spherical"),
     )
     # p orbitals are zero at center
     basis = make_contractions(basis_dict, ["Li"], np.array([[0, 0, 0]]))
     eval_obj = Eval(basis)
     assert np.allclose(
-        eval_obj.construct_array_cartesian(coords=np.array([[0, 0, 0]])),
+        eval_obj.construct_array_cartesian(points=np.array([[0, 0, 0]])),
         evaluate_basis(basis, np.array([[0, 0, 0]]), coord_type="spherical"),
     )
 
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     eval_obj = Eval(basis)
     assert np.allclose(
-        eval_obj.construct_array_spherical(coords=np.array([[1, 1, 1]])),
+        eval_obj.construct_array_spherical(points=np.array([[1, 1, 1]])),
         evaluate_basis(basis, np.array([[1, 1, 1]]), coord_type="spherical"),
     )
 
@@ -132,6 +132,6 @@ def test_evaluate_basis_lincomb():
     eval_obj = Eval(basis)
     transform = np.random.rand(14, 18)
     assert np.allclose(
-        eval_obj.construct_array_lincomb(transform, "spherical", coords=np.array([[1, 1, 1]])),
+        eval_obj.construct_array_lincomb(transform, "spherical", points=np.array([[1, 1, 1]])),
         evaluate_basis(basis, np.array([[1, 1, 1]]), transform=transform, coord_type="spherical"),
     )

--- a/tests/test_eval_deriv.py
+++ b/tests/test_eval_deriv.py
@@ -3,13 +3,7 @@ import itertools as it
 
 from gbasis._deriv import _eval_deriv_contractions
 from gbasis.contractions import GeneralizedContractionShell
-from gbasis.eval_deriv import (
-    EvalDeriv,
-    evaluate_deriv_basis_cartesian,
-    evaluate_deriv_basis_lincomb,
-    evaluate_deriv_basis_mix,
-    evaluate_deriv_basis_spherical,
-)
+from gbasis.eval_deriv import EvalDeriv, evaluate_deriv_basis
 from gbasis.parsers import make_contractions, parse_nwchem
 import numpy as np
 import pytest
@@ -145,13 +139,17 @@ def test_evaluate_deriv_basis_cartesian():
         eval_obj.construct_array_cartesian(
             coords=np.array([[1, 1, 1]]), orders=np.array([0, 0, 0])
         ),
-        evaluate_deriv_basis_cartesian(basis, np.array([[1, 1, 1]]), orders=np.array([0, 0, 0])),
+        evaluate_deriv_basis(
+            basis, np.array([[1, 1, 1]]), orders=np.array([0, 0, 0]), coord_type="cartesian"
+        ),
     )
     assert np.allclose(
         eval_obj.construct_array_cartesian(
             coords=np.array([[1, 1, 1]]), orders=np.array([2, 1, 0])
         ),
-        evaluate_deriv_basis_cartesian(basis, np.array([[1, 1, 1]]), orders=np.array([2, 1, 0])),
+        evaluate_deriv_basis(
+            basis, np.array([[1, 1, 1]]), orders=np.array([2, 1, 0]), coord_type="cartesian"
+        ),
     )
 
 
@@ -166,13 +164,17 @@ def test_evaluate_deriv_basis_spherical():
         eval_obj.construct_array_spherical(
             coords=np.array([[1, 1, 1]]), orders=np.array([0, 0, 0])
         ),
-        evaluate_deriv_basis_spherical(basis, np.array([[1, 1, 1]]), np.array([0, 0, 0])),
+        evaluate_deriv_basis(
+            basis, np.array([[1, 1, 1]]), np.array([0, 0, 0]), coord_type="spherical"
+        ),
     )
     assert np.allclose(
         eval_obj.construct_array_spherical(
             coords=np.array([[1, 1, 1]]), orders=np.array([2, 1, 0])
         ),
-        evaluate_deriv_basis_spherical(basis, np.array([[1, 1, 1]]), np.array([2, 1, 0])),
+        evaluate_deriv_basis(
+            basis, np.array([[1, 1, 1]]), np.array([2, 1, 0]), coord_type="spherical"
+        ),
     )
 
 
@@ -187,16 +189,16 @@ def test_evaluate_deriv_basis_mix():
         eval_obj.construct_array_mix(
             ["cartesian"] * 8, coords=np.array([[1, 1, 1]]), orders=np.array([0, 0, 0])
         ),
-        evaluate_deriv_basis_mix(
-            basis, np.array([[1, 1, 1]]), np.array([0, 0, 0]), ["cartesian"] * 8
+        evaluate_deriv_basis(
+            basis, np.array([[1, 1, 1]]), np.array([0, 0, 0]), coord_type=["cartesian"] * 8
         ),
     )
     assert np.allclose(
         eval_obj.construct_array_mix(
             ["spherical"] * 8, coords=np.array([[1, 1, 1]]), orders=np.array([2, 1, 0])
         ),
-        evaluate_deriv_basis_mix(
-            basis, np.array([[1, 1, 1]]), np.array([2, 1, 0]), ["spherical"] * 8
+        evaluate_deriv_basis(
+            basis, np.array([[1, 1, 1]]), np.array([2, 1, 0]), coord_type=["spherical"] * 8
         ),
     )
 
@@ -214,15 +216,19 @@ def test_evaluate_deriv_basis_lincomb():
         eval_obj.construct_array_lincomb(
             cart_transform, "cartesian", coords=np.array([[1, 1, 1]]), orders=np.array([0, 0, 0])
         ),
-        evaluate_deriv_basis_lincomb(
-            basis, np.array([[1, 1, 1]]), np.array([0, 0, 0]), cart_transform, "cartesian"
+        evaluate_deriv_basis(
+            basis,
+            np.array([[1, 1, 1]]),
+            np.array([0, 0, 0]),
+            cart_transform,
+            coord_type="cartesian",
         ),
     )
     assert np.allclose(
         eval_obj.construct_array_lincomb(
             sph_transform, "spherical", coords=np.array([[1, 1, 1]]), orders=np.array([2, 1, 0])
         ),
-        evaluate_deriv_basis_lincomb(
-            basis, np.array([[1, 1, 1]]), np.array([2, 1, 0]), sph_transform, "spherical"
+        evaluate_deriv_basis(
+            basis, np.array([[1, 1, 1]]), np.array([2, 1, 0]), sph_transform, coord_type="spherical"
         ),
     )

--- a/tests/test_eval_deriv.py
+++ b/tests/test_eval_deriv.py
@@ -13,38 +13,38 @@ from utils import find_datafile
 
 def test_eval_deriv_construct_array_contraction():
     """Test gbasis.eval_deriv.EvalDeriv.construct_array_contraction."""
-    coords = np.array([[2, 3, 4]])
+    points = np.array([[2, 3, 4]])
     orders = np.array([0, 0, 0])
     contractions = GeneralizedContractionShell(
         1, np.array([0.5, 1, 1.5]), np.array([1.0, 2.0]), np.array([0.1, 0.01])
     )
     with pytest.raises(TypeError):
         EvalDeriv.construct_array_contraction(
-            coords=[[2, 3, 4]], orders=orders, contractions=contractions
+            points=[[2, 3, 4]], orders=orders, contractions=contractions
         )
     with pytest.raises(TypeError):
         EvalDeriv.construct_array_contraction(
-            coords=coords, orders=[0, 0, 0], contractions=contractions
+            points=points, orders=[0, 0, 0], contractions=contractions
         )
     with pytest.raises(TypeError):
         EvalDeriv.construct_array_contraction(
-            coords=coords, orders=orders, contractions=contractions.__dict__
+            points=points, orders=orders, contractions=contractions.__dict__
         )
     with pytest.raises(TypeError):
         EvalDeriv.construct_array_contraction(
-            coords=coords.reshape(3, 1), orders=orders, contractions=contractions
+            points=points.reshape(3, 1), orders=orders, contractions=contractions
         )
     with pytest.raises(TypeError):
         EvalDeriv.construct_array_contraction(
-            coords=coords, orders=orders.reshape(1, 3), contractions=contractions
+            points=points, orders=orders.reshape(1, 3), contractions=contractions
         )
     with pytest.raises(ValueError):
         EvalDeriv.construct_array_contraction(
-            coords=coords, orders=np.array([-1, 0, 0]), contractions=contractions
+            points=points, orders=np.array([-1, 0, 0]), contractions=contractions
         )
     with pytest.raises(ValueError):
         EvalDeriv.construct_array_contraction(
-            coords=coords, orders=np.array([0.0, 0, 0]), contractions=contractions
+            points=points, orders=np.array([0.0, 0, 0]), contractions=contractions
         )
 
     # first order
@@ -82,7 +82,7 @@ def test_eval_deriv_construct_array_contraction():
         ).reshape(3, 1)
         assert np.allclose(
             EvalDeriv.construct_array_contraction(
-                coords=np.array([[2, 3, 4]]), orders=orders, contractions=test
+                points=np.array([[2, 3, 4]]), orders=orders, contractions=test
             ),
             answer,
         )
@@ -122,7 +122,7 @@ def test_eval_deriv_construct_array_contraction():
         ).reshape(3, 1)
         assert np.allclose(
             EvalDeriv.construct_array_contraction(
-                coords=np.array([[2, 3, 4]]), orders=orders, contractions=test
+                points=np.array([[2, 3, 4]]), orders=orders, contractions=test
             ),
             answer,
         )
@@ -137,7 +137,7 @@ def test_evaluate_deriv_basis_cartesian():
     eval_obj = EvalDeriv(basis)
     assert np.allclose(
         eval_obj.construct_array_cartesian(
-            coords=np.array([[1, 1, 1]]), orders=np.array([0, 0, 0])
+            points=np.array([[1, 1, 1]]), orders=np.array([0, 0, 0])
         ),
         evaluate_deriv_basis(
             basis, np.array([[1, 1, 1]]), orders=np.array([0, 0, 0]), coord_type="cartesian"
@@ -145,7 +145,7 @@ def test_evaluate_deriv_basis_cartesian():
     )
     assert np.allclose(
         eval_obj.construct_array_cartesian(
-            coords=np.array([[1, 1, 1]]), orders=np.array([2, 1, 0])
+            points=np.array([[1, 1, 1]]), orders=np.array([2, 1, 0])
         ),
         evaluate_deriv_basis(
             basis, np.array([[1, 1, 1]]), orders=np.array([2, 1, 0]), coord_type="cartesian"
@@ -162,7 +162,7 @@ def test_evaluate_deriv_basis_spherical():
     eval_obj = EvalDeriv(basis)
     assert np.allclose(
         eval_obj.construct_array_spherical(
-            coords=np.array([[1, 1, 1]]), orders=np.array([0, 0, 0])
+            points=np.array([[1, 1, 1]]), orders=np.array([0, 0, 0])
         ),
         evaluate_deriv_basis(
             basis, np.array([[1, 1, 1]]), np.array([0, 0, 0]), coord_type="spherical"
@@ -170,7 +170,7 @@ def test_evaluate_deriv_basis_spherical():
     )
     assert np.allclose(
         eval_obj.construct_array_spherical(
-            coords=np.array([[1, 1, 1]]), orders=np.array([2, 1, 0])
+            points=np.array([[1, 1, 1]]), orders=np.array([2, 1, 0])
         ),
         evaluate_deriv_basis(
             basis, np.array([[1, 1, 1]]), np.array([2, 1, 0]), coord_type="spherical"
@@ -187,7 +187,7 @@ def test_evaluate_deriv_basis_mix():
     eval_obj = EvalDeriv(basis)
     assert np.allclose(
         eval_obj.construct_array_mix(
-            ["cartesian"] * 8, coords=np.array([[1, 1, 1]]), orders=np.array([0, 0, 0])
+            ["cartesian"] * 8, points=np.array([[1, 1, 1]]), orders=np.array([0, 0, 0])
         ),
         evaluate_deriv_basis(
             basis, np.array([[1, 1, 1]]), np.array([0, 0, 0]), coord_type=["cartesian"] * 8
@@ -195,7 +195,7 @@ def test_evaluate_deriv_basis_mix():
     )
     assert np.allclose(
         eval_obj.construct_array_mix(
-            ["spherical"] * 8, coords=np.array([[1, 1, 1]]), orders=np.array([2, 1, 0])
+            ["spherical"] * 8, points=np.array([[1, 1, 1]]), orders=np.array([2, 1, 0])
         ),
         evaluate_deriv_basis(
             basis, np.array([[1, 1, 1]]), np.array([2, 1, 0]), coord_type=["spherical"] * 8
@@ -214,7 +214,7 @@ def test_evaluate_deriv_basis_lincomb():
     sph_transform = np.random.rand(14, 18)
     assert np.allclose(
         eval_obj.construct_array_lincomb(
-            cart_transform, "cartesian", coords=np.array([[1, 1, 1]]), orders=np.array([0, 0, 0])
+            cart_transform, "cartesian", points=np.array([[1, 1, 1]]), orders=np.array([0, 0, 0])
         ),
         evaluate_deriv_basis(
             basis,
@@ -226,7 +226,7 @@ def test_evaluate_deriv_basis_lincomb():
     )
     assert np.allclose(
         eval_obj.construct_array_lincomb(
-            sph_transform, "spherical", coords=np.array([[1, 1, 1]]), orders=np.array([2, 1, 0])
+            sph_transform, "spherical", points=np.array([[1, 1, 1]]), orders=np.array([2, 1, 0])
         ),
         evaluate_deriv_basis(
             basis, np.array([[1, 1, 1]]), np.array([2, 1, 0]), sph_transform, coord_type="spherical"

--- a/tests/test_kinetic_energy.py
+++ b/tests/test_kinetic_energy.py
@@ -1,13 +1,7 @@
 """Test gbasis.kinetic_energy."""
 from gbasis._diff_operator_int import _compute_differential_operator_integrals
 from gbasis.contractions import GeneralizedContractionShell
-from gbasis.kinetic_energy import (
-    kinetic_energy_integral_cartesian,
-    kinetic_energy_integral_lincomb,
-    kinetic_energy_integral_mix,
-    kinetic_energy_integral_spherical,
-    KineticEnergyIntegral,
-)
+from gbasis.kinetic_energy import kinetic_energy_integral, KineticEnergyIntegral
 from gbasis.parsers import make_contractions, parse_nwchem
 import numpy as np
 import pytest
@@ -172,7 +166,7 @@ def test_kinetic_energy_integral_cartesian():
     kinetic_energy_integral_obj = KineticEnergyIntegral(basis)
     assert np.allclose(
         kinetic_energy_integral_obj.construct_array_cartesian(),
-        kinetic_energy_integral_cartesian(basis),
+        kinetic_energy_integral(basis, coord_type="cartesian"),
     )
 
 
@@ -186,7 +180,7 @@ def test_kinetic_energy_integral_spherical():
     kinetic_energy_integral_obj = KineticEnergyIntegral(basis)
     assert np.allclose(
         kinetic_energy_integral_obj.construct_array_spherical(),
-        kinetic_energy_integral_spherical(basis),
+        kinetic_energy_integral(basis, coord_type="spherical"),
     )
 
 
@@ -200,7 +194,7 @@ def test_kinetic_energy_integral_mix():
     kinetic_energy_integral_obj = KineticEnergyIntegral(basis)
     assert np.allclose(
         kinetic_energy_integral_obj.construct_array_mix(["spherical"] * 8),
-        kinetic_energy_integral_mix(basis, ["spherical"] * 8),
+        kinetic_energy_integral(basis, coord_type=["spherical"] * 8),
     )
 
 
@@ -214,7 +208,7 @@ def test_kinetic_energy_integral_lincomb():
     transform = np.random.rand(14, 18)
     assert np.allclose(
         kinetic_energy_integral_obj.construct_array_lincomb(transform, "spherical"),
-        kinetic_energy_integral_lincomb(basis, transform),
+        kinetic_energy_integral(basis, transform, coord_type="spherical"),
     )
 
 
@@ -236,7 +230,9 @@ def test_kinetic_energy_integral_horton_anorcc_hhe():
     horton_kinetic_energy_integral = np.load(
         find_datafile("data_horton_hhe_cart_kinetic_energy_integral.npy")
     )
-    assert np.allclose(kinetic_energy_integral_cartesian(basis), horton_kinetic_energy_integral)
+    assert np.allclose(
+        kinetic_energy_integral(basis, coord_type="cartesian"), horton_kinetic_energy_integral
+    )
 
 
 def test_kinetic_energy_integral_horton_anorcc_bec():
@@ -257,4 +253,6 @@ def test_kinetic_energy_integral_horton_anorcc_bec():
     horton_kinetic_energy_integral = np.load(
         find_datafile("data_horton_bec_cart_kinetic_energy_integral.npy")
     )
-    assert np.allclose(kinetic_energy_integral_cartesian(basis), horton_kinetic_energy_integral)
+    assert np.allclose(
+        kinetic_energy_integral(basis, coord_type="cartesian"), horton_kinetic_energy_integral
+    )

--- a/tests/test_moment.py
+++ b/tests/test_moment.py
@@ -1,7 +1,7 @@
 """Test gbasis.moment."""
 from gbasis._moment_int import _compute_multipole_moment_integrals
 from gbasis.contractions import GeneralizedContractionShell
-from gbasis.moment import Moment, moment_cartesian, moment_lincomb, moment_mix, moment_spherical
+from gbasis.moment import Moment, moment_integral
 from gbasis.parsers import make_contractions, parse_nwchem
 import numpy as np
 import pytest
@@ -157,7 +157,7 @@ def test_moment_cartesian():
                 ]
             ),
         ),
-        moment_cartesian(
+        moment_integral(
             basis,
             np.zeros(3),
             np.array(
@@ -174,6 +174,7 @@ def test_moment_cartesian():
                     [0, 1, 1],
                 ]
             ),
+            coord_type="cartesian",
         ),
     )
 
@@ -204,7 +205,7 @@ def test_moment_spherical():
                 ]
             ),
         ),
-        moment_spherical(
+        moment_integral(
             basis,
             np.zeros(3),
             np.array(
@@ -221,6 +222,7 @@ def test_moment_spherical():
                     [0, 1, 1],
                 ]
             ),
+            coord_type="spherical",
         ),
     )
 
@@ -252,7 +254,7 @@ def test_moment_mix():
                 ]
             ),
         ),
-        moment_mix(
+        moment_integral(
             basis,
             np.zeros(3),
             np.array(
@@ -269,7 +271,7 @@ def test_moment_mix():
                     [0, 1, 1],
                 ]
             ),
-            ["spherical"] * 8,
+            coord_type=["spherical"] * 8,
         ),
     )
 
@@ -302,9 +304,8 @@ def test_moment_spherical_lincomb():
                 ]
             ),
         ),
-        moment_lincomb(
+        moment_integral(
             basis,
-            transform,
             np.zeros(3),
             np.array(
                 [
@@ -320,5 +321,6 @@ def test_moment_spherical_lincomb():
                     [0, 1, 1],
                 ]
             ),
+            transform=transform,
         ),
     )

--- a/tests/test_momentum.py
+++ b/tests/test_momentum.py
@@ -1,13 +1,7 @@
 """Test gbasis.momentum."""
 from gbasis._diff_operator_int import _compute_differential_operator_integrals
 from gbasis.contractions import GeneralizedContractionShell
-from gbasis.momentum import (
-    momentum_integral_cartesian,
-    momentum_integral_lincomb,
-    momentum_integral_mix,
-    momentum_integral_spherical,
-    MomentumIntegral,
-)
+from gbasis.momentum import momentum_integral, MomentumIntegral
 from gbasis.parsers import make_contractions, parse_nwchem
 import numpy as np
 import pytest
@@ -173,7 +167,8 @@ def test_momentum_integral_cartesian():
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     momentum_integral_obj = MomentumIntegral(basis)
     assert np.allclose(
-        momentum_integral_obj.construct_array_cartesian(), momentum_integral_cartesian(basis)
+        momentum_integral_obj.construct_array_cartesian(),
+        momentum_integral(basis, coord_type="cartesian"),
     )
 
 
@@ -186,7 +181,8 @@ def test_momentum_integral_spherical():
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     momentum_integral_obj = MomentumIntegral(basis)
     assert np.allclose(
-        momentum_integral_obj.construct_array_spherical(), momentum_integral_spherical(basis)
+        momentum_integral_obj.construct_array_spherical(),
+        momentum_integral(basis, coord_type="spherical"),
     )
 
 
@@ -200,7 +196,7 @@ def test_momentum_integral_mix():
     momentum_integral_obj = MomentumIntegral(basis)
     assert np.allclose(
         momentum_integral_obj.construct_array_mix(["spherical"] * 8),
-        momentum_integral_mix(basis, ["spherical"] * 8),
+        momentum_integral(basis, coord_type=["spherical"] * 8),
     )
 
 
@@ -214,5 +210,5 @@ def test_momentum_integral_lincomb():
     transform = np.random.rand(14, 18)
     assert np.allclose(
         momentum_integral_obj.construct_array_lincomb(transform, "spherical"),
-        momentum_integral_lincomb(basis, transform),
+        momentum_integral(basis, transform=transform, coord_type="spherical"),
     )

--- a/tests/test_nuclear_electron_attraction.py
+++ b/tests/test_nuclear_electron_attraction.py
@@ -1,17 +1,7 @@
 """Test gbasis.nuclear_electron_attraction."""
-from gbasis.nuclear_electron_attraction import (
-    nuclear_electron_attraction_cartesian,
-    nuclear_electron_attraction_lincomb,
-    nuclear_electron_attraction_mix,
-    nuclear_electron_attraction_spherical,
-)
+from gbasis.nuclear_electron_attraction import nuclear_electron_attraction_integral
 from gbasis.parsers import make_contractions, parse_nwchem
-from gbasis.point_charge import (
-    point_charge_cartesian,
-    point_charge_lincomb,
-    point_charge_mix,
-    point_charge_spherical,
-)
+from gbasis.point_charge import point_charge_integral
 import numpy as np
 from utils import find_datafile, HortonContractions
 
@@ -32,7 +22,10 @@ def test_nuclear_electron_attraction_horton_anorcc_hhe():
 
     horton_nucattract = np.load(find_datafile("data_horton_hhe_cart_nucattract.npy"))
     assert np.allclose(
-        nuclear_electron_attraction_cartesian(basis, coords, np.array([1, 2])), horton_nucattract
+        nuclear_electron_attraction_integral(
+            basis, coords, np.array([1, 2]), coord_type="cartesian"
+        ),
+        horton_nucattract,
     )
 
 
@@ -52,7 +45,10 @@ def test_nuclear_electron_attraction_horton_anorcc_bec():
 
     horton_nucattract = np.load(find_datafile("data_horton_bec_cart_nucattract.npy"))
     assert np.allclose(
-        nuclear_electron_attraction_cartesian(basis, coords, np.array([4, 6])), horton_nucattract
+        nuclear_electron_attraction_integral(
+            basis, coords, np.array([4, 6]), coord_type="cartesian"
+        ),
+        horton_nucattract,
     )
 
 
@@ -65,10 +61,12 @@ def test_nuclear_electron_attraction_cartesian():
 
     nuclear_coords = np.random.rand(5, 3)
     nuclear_charges = np.random.rand(5)
-    ref = point_charge_cartesian(basis, nuclear_coords, nuclear_charges)
+    ref = point_charge_integral(basis, nuclear_coords, nuclear_charges, coord_type="cartesian")
     assert np.allclose(
         ref[:, :, 0] + ref[:, :, 1] + ref[:, :, 2] + ref[:, :, 3] + ref[:, :, 4],
-        nuclear_electron_attraction_cartesian(basis, nuclear_coords, nuclear_charges),
+        nuclear_electron_attraction_integral(
+            basis, nuclear_coords, nuclear_charges, coord_type="cartesian"
+        ),
     )
 
 
@@ -81,10 +79,12 @@ def test_nuclear_electron_attraction_spherical():
 
     nuclear_coords = np.random.rand(5, 3)
     nuclear_charges = np.random.rand(5)
-    ref = point_charge_spherical(basis, nuclear_coords, nuclear_charges)
+    ref = point_charge_integral(basis, nuclear_coords, nuclear_charges, coord_type="spherical")
     assert np.allclose(
         ref[:, :, 0] + ref[:, :, 1] + ref[:, :, 2] + ref[:, :, 3] + ref[:, :, 4],
-        nuclear_electron_attraction_spherical(basis, nuclear_coords, nuclear_charges),
+        nuclear_electron_attraction_integral(
+            basis, nuclear_coords, nuclear_charges, coord_type="spherical"
+        ),
     )
 
 
@@ -97,10 +97,14 @@ def test_nuclear_electron_attraction_mix():
 
     nuclear_coords = np.random.rand(5, 3)
     nuclear_charges = np.random.rand(5)
-    ref = point_charge_mix(basis, nuclear_coords, nuclear_charges, ["spherical"] * 8)
+    ref = point_charge_integral(
+        basis, nuclear_coords, nuclear_charges, coord_type=["spherical"] * 8
+    )
     assert np.allclose(
         ref[:, :, 0] + ref[:, :, 1] + ref[:, :, 2] + ref[:, :, 3] + ref[:, :, 4],
-        nuclear_electron_attraction_mix(basis, nuclear_coords, nuclear_charges, ["spherical"] * 8),
+        nuclear_electron_attraction_integral(
+            basis, nuclear_coords, nuclear_charges, coord_type=["spherical"] * 8
+        ),
     )
 
 
@@ -114,8 +118,10 @@ def test_nuclear_electron_attraction_lincomb():
     nuclear_coords = np.random.rand(5, 3)
     nuclear_charges = np.random.rand(5)
     transform = np.random.rand(14, 18)
-    ref = point_charge_lincomb(basis, transform, nuclear_coords, nuclear_charges)
+    ref = point_charge_integral(basis, nuclear_coords, nuclear_charges, transform=transform)
     assert np.allclose(
         ref[:, :, 0] + ref[:, :, 1] + ref[:, :, 2] + ref[:, :, 3] + ref[:, :, 4],
-        nuclear_electron_attraction_lincomb(basis, transform, nuclear_coords, nuclear_charges),
+        nuclear_electron_attraction_integral(
+            basis, nuclear_coords, nuclear_charges, transform=transform
+        ),
     )

--- a/tests/test_overlap.py
+++ b/tests/test_overlap.py
@@ -1,13 +1,7 @@
 """Test gbasis.overlap."""
 from gbasis._moment_int import _compute_multipole_moment_integrals
 from gbasis.contractions import GeneralizedContractionShell
-from gbasis.overlap import (
-    Overlap,
-    overlap_cartesian,
-    overlap_lincomb,
-    overlap_mix,
-    overlap_spherical,
-)
+from gbasis.overlap import Overlap, overlap_integral
 from gbasis.parsers import make_contractions, parse_nwchem
 import numpy as np
 import pytest
@@ -84,7 +78,9 @@ def test_overlap_cartesian():
     basis_dict = parse_nwchem(test_basis)
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     overlap_obj = Overlap(basis)
-    assert np.allclose(overlap_obj.construct_array_cartesian(), overlap_cartesian(basis))
+    assert np.allclose(
+        overlap_obj.construct_array_cartesian(), overlap_integral(basis, coord_type="cartesian")
+    )
 
 
 def test_overlap_spherical():
@@ -95,7 +91,9 @@ def test_overlap_spherical():
 
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     overlap_obj = Overlap(basis)
-    assert np.allclose(overlap_obj.construct_array_spherical(), overlap_spherical(basis))
+    assert np.allclose(
+        overlap_obj.construct_array_spherical(), overlap_integral(basis, coord_type="spherical")
+    )
 
 
 def test_overlap_mix():
@@ -107,7 +105,8 @@ def test_overlap_mix():
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     overlap_obj = Overlap(basis)
     assert np.allclose(
-        overlap_obj.construct_array_mix(["spherical"] * 8), overlap_mix(basis, ["spherical"] * 8)
+        overlap_obj.construct_array_mix(["spherical"] * 8),
+        overlap_integral(basis, coord_type=["spherical"] * 8),
     )
 
 
@@ -121,7 +120,7 @@ def test_overlap_lincomb():
     transform = np.random.rand(14, 18)
     assert np.allclose(
         overlap_obj.construct_array_lincomb(transform, "spherical"),
-        overlap_lincomb(basis, transform),
+        overlap_integral(basis, transform=transform, coord_type="spherical"),
     )
 
 
@@ -207,7 +206,7 @@ def test_overlap_horton_anorcc_hhe():
     basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps) for i in basis]
 
     horton_overlap = np.load(find_datafile("data_horton_hhe_cart_overlap.npy"))
-    assert np.allclose(overlap_cartesian(basis), horton_overlap)
+    assert np.allclose(overlap_integral(basis, coord_type="cartesian"), horton_overlap)
 
 
 def test_overlap_horton_anorcc_bec():
@@ -226,4 +225,4 @@ def test_overlap_horton_anorcc_bec():
     basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps) for i in basis]
 
     horton_overlap = np.load(find_datafile("data_horton_bec_cart_overlap.npy"))
-    assert np.allclose(overlap_cartesian(basis), horton_overlap)
+    assert np.allclose(overlap_integral(basis, coord_type="cartesian"), horton_overlap)

--- a/tests/test_point_charge.py
+++ b/tests/test_point_charge.py
@@ -124,16 +124,16 @@ def test_point_charge_cartesian():
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     point_charge_obj = PointChargeIntegral(basis)
 
-    coords_points = np.random.rand(5, 3)
-    charges_points = np.random.rand(5)
+    points_coords = np.random.rand(5, 3)
+    points_charges = np.random.rand(5)
     assert np.allclose(
         point_charge_obj.construct_array_cartesian(
-            coords_points=coords_points, charges_points=charges_points
+            points_coords=points_coords, points_charges=points_charges
         ),
         point_charge_integral(
             basis,
-            coords_points=coords_points,
-            charges_points=charges_points,
+            points_coords=points_coords,
+            points_charges=points_charges,
             coord_type="cartesian",
         ),
     )
@@ -147,16 +147,16 @@ def test_point_charge_spherical():
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     point_charge_obj = PointChargeIntegral(basis)
 
-    coords_points = np.random.rand(5, 3)
-    charges_points = np.random.rand(5)
+    points_coords = np.random.rand(5, 3)
+    points_charges = np.random.rand(5)
     assert np.allclose(
         point_charge_obj.construct_array_spherical(
-            coords_points=coords_points, charges_points=charges_points
+            points_coords=points_coords, points_charges=points_charges
         ),
         point_charge_integral(
             basis,
-            coords_points=coords_points,
-            charges_points=charges_points,
+            points_coords=points_coords,
+            points_charges=points_charges,
             coord_type="spherical",
         ),
     )
@@ -170,13 +170,13 @@ def test_point_charge_mix():
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     point_charge_obj = PointChargeIntegral(basis)
 
-    coords_points = np.random.rand(5, 3)
-    charges_points = np.random.rand(5)
+    points_coords = np.random.rand(5, 3)
+    points_charges = np.random.rand(5)
     assert np.allclose(
         point_charge_obj.construct_array_mix(
-            ["spherical"] * 8, coords_points=coords_points, charges_points=charges_points
+            ["spherical"] * 8, points_coords=points_coords, points_charges=points_charges
         ),
-        point_charge_integral(basis, coords_points, charges_points, coord_type=["spherical"] * 8),
+        point_charge_integral(basis, points_coords, points_charges, coord_type=["spherical"] * 8),
     )
 
 
@@ -188,14 +188,14 @@ def test_point_charge_lincomb():
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     point_charge_obj = PointChargeIntegral(basis)
 
-    coords_points = np.random.rand(5, 3)
-    charges_points = np.random.rand(5)
+    points_coords = np.random.rand(5, 3)
+    points_charges = np.random.rand(5)
     transform = np.random.rand(14, 18)
     assert np.allclose(
         point_charge_obj.construct_array_lincomb(
-            transform, "spherical", coords_points=coords_points, charges_points=charges_points
+            transform, "spherical", points_coords=points_coords, points_charges=points_charges
         ),
         point_charge_integral(
-            basis, coords_points=coords_points, charges_points=charges_points, transform=transform
+            basis, points_coords=points_coords, points_charges=points_charges, transform=transform
         ),
     )

--- a/tests/test_point_charge.py
+++ b/tests/test_point_charge.py
@@ -1,13 +1,7 @@
 """Test gbasis.point_charge."""
 from gbasis.contractions import GeneralizedContractionShell
 from gbasis.parsers import make_contractions, parse_nwchem
-from gbasis.point_charge import (
-    point_charge_cartesian,
-    point_charge_lincomb,
-    point_charge_mix,
-    point_charge_spherical,
-    PointChargeIntegral,
-)
+from gbasis.point_charge import point_charge_integral, PointChargeIntegral
 import numpy as np
 import pytest
 from scipy.special import factorial
@@ -136,7 +130,12 @@ def test_point_charge_cartesian():
         point_charge_obj.construct_array_cartesian(
             coords_points=coords_points, charges_points=charges_points
         ),
-        point_charge_cartesian(basis, coords_points=coords_points, charges_points=charges_points),
+        point_charge_integral(
+            basis,
+            coords_points=coords_points,
+            charges_points=charges_points,
+            coord_type="cartesian",
+        ),
     )
 
 
@@ -154,7 +153,12 @@ def test_point_charge_spherical():
         point_charge_obj.construct_array_spherical(
             coords_points=coords_points, charges_points=charges_points
         ),
-        point_charge_spherical(basis, coords_points=coords_points, charges_points=charges_points),
+        point_charge_integral(
+            basis,
+            coords_points=coords_points,
+            charges_points=charges_points,
+            coord_type="spherical",
+        ),
     )
 
 
@@ -172,7 +176,7 @@ def test_point_charge_mix():
         point_charge_obj.construct_array_mix(
             ["spherical"] * 8, coords_points=coords_points, charges_points=charges_points
         ),
-        point_charge_mix(basis, coords_points, charges_points, ["spherical"] * 8),
+        point_charge_integral(basis, coords_points, charges_points, coord_type=["spherical"] * 8),
     )
 
 
@@ -189,9 +193,9 @@ def test_point_charge_lincomb():
     transform = np.random.rand(14, 18)
     assert np.allclose(
         point_charge_obj.construct_array_lincomb(
-            transform, ["spherical"] * 8, coords_points=coords_points, charges_points=charges_points
+            transform, "spherical", coords_points=coords_points, charges_points=charges_points
         ),
-        point_charge_lincomb(
-            basis, transform, coords_points=coords_points, charges_points=charges_points
+        point_charge_integral(
+            basis, coords_points=coords_points, charges_points=charges_points, transform=transform
         ),
     )

--- a/tests/test_stress_tensor.py
+++ b/tests/test_stress_tensor.py
@@ -1,5 +1,9 @@
 """Test gbasis.stress_tensor."""
-from gbasis.density import eval_density_laplacian, eval_deriv_density, eval_deriv_density_matrix
+from gbasis.density import (
+    eval_density_laplacian,
+    eval_deriv_density,
+    eval_deriv_reduced_density_matrix,
+)
 from gbasis.parsers import make_contractions, parse_nwchem
 from gbasis.stress_tensor import eval_ehrenfest_force, eval_ehrenfest_hessian, eval_stress_tensor
 import numpy as np
@@ -17,16 +21,16 @@ def test_eval_stress_tensor():
     points = np.random.rand(10, 3)
 
     with pytest.raises(TypeError):
-        eval_stress_tensor(np.identity(40), basis, points, np.identity(40), np.array(0), 0)
+        eval_stress_tensor(np.identity(40), basis, points, np.array(0), 0, np.identity(40))
     with pytest.raises(TypeError):
-        eval_stress_tensor(np.identity(40), basis, points, np.identity(40), 1, None)
+        eval_stress_tensor(np.identity(40), basis, points, 1, None, np.identity(40))
     with pytest.raises(TypeError):
-        eval_stress_tensor(np.identity(40), basis, points, np.identity(40), 1, 0j)
+        eval_stress_tensor(np.identity(40), basis, points, 1, 0j, np.identity(40))
 
-    test_a = eval_stress_tensor(np.identity(40), basis, points, np.identity(40), 0, 0)
-    test_b = eval_stress_tensor(np.identity(40), basis, points, np.identity(40), 1, 0)
-    test_c = eval_stress_tensor(np.identity(40), basis, points, np.identity(40), 1, 2)
-    test_d = eval_stress_tensor(np.identity(40), basis, points, np.identity(40), 0.5, 2)
+    test_a = eval_stress_tensor(np.identity(40), basis, points, 0, 0, np.identity(40))
+    test_b = eval_stress_tensor(np.identity(40), basis, points, 1, 0, np.identity(40))
+    test_c = eval_stress_tensor(np.identity(40), basis, points, 1, 2, np.identity(40))
+    test_d = eval_stress_tensor(np.identity(40), basis, points, 0.5, 2, np.identity(40))
     for i in range(3):
         for j in range(3):
             orders_i = np.array([0, 0, 0])
@@ -34,13 +38,13 @@ def test_eval_stress_tensor():
             orders_j = np.array([0, 0, 0])
             orders_j[j] += 1
 
-            temp1 = eval_deriv_density_matrix(
+            temp1 = eval_deriv_reduced_density_matrix(
                 orders_i, orders_j, np.identity(40), basis, points, np.identity(40)
             )
-            temp2 = eval_deriv_density_matrix(
+            temp2 = eval_deriv_reduced_density_matrix(
                 orders_j, orders_i, np.identity(40), basis, points, np.identity(40)
             )
-            temp3 = eval_deriv_density_matrix(
+            temp3 = eval_deriv_reduced_density_matrix(
                 orders_i + orders_j,
                 np.array([0, 0, 0]),
                 np.identity(40),
@@ -48,7 +52,7 @@ def test_eval_stress_tensor():
                 points,
                 np.identity(40),
             )
-            temp4 = eval_deriv_density_matrix(
+            temp4 = eval_deriv_reduced_density_matrix(
                 orders_i + orders_j,
                 np.array([0, 0, 0]),
                 np.identity(40),
@@ -78,16 +82,16 @@ def test_eval_ehrenfest_force():
     points = np.random.rand(10, 3)
 
     with pytest.raises(TypeError):
-        eval_ehrenfest_force(np.identity(40), basis, points, np.identity(40), np.array(0), 0)
+        eval_ehrenfest_force(np.identity(40), basis, points, np.array(0), 0, np.identity(40))
     with pytest.raises(TypeError):
-        eval_ehrenfest_force(np.identity(40), basis, points, np.identity(40), 1, None)
+        eval_ehrenfest_force(np.identity(40), basis, points, 1, None, np.identity(40))
     with pytest.raises(TypeError):
-        eval_ehrenfest_force(np.identity(40), basis, points, np.identity(40), 1, 0j)
+        eval_ehrenfest_force(np.identity(40), basis, points, 1, 0j, np.identity(40))
 
-    test_a = eval_ehrenfest_force(np.identity(40), basis, points, np.identity(40), 0, 0)
-    test_b = eval_ehrenfest_force(np.identity(40), basis, points, np.identity(40), 1, 0)
-    test_c = eval_ehrenfest_force(np.identity(40), basis, points, np.identity(40), 0.5, 0)
-    test_d = eval_ehrenfest_force(np.identity(40), basis, points, np.identity(40), 0, 2)
+    test_a = eval_ehrenfest_force(np.identity(40), basis, points, 0, 0, np.identity(40))
+    test_b = eval_ehrenfest_force(np.identity(40), basis, points, 1, 0, np.identity(40))
+    test_c = eval_ehrenfest_force(np.identity(40), basis, points, 0.5, 0, np.identity(40))
+    test_d = eval_ehrenfest_force(np.identity(40), basis, points, 0, 2, np.identity(40))
     for j in range(3):
         ref_a = np.zeros(points.shape[0])
         ref_b = np.zeros(points.shape[0])
@@ -100,13 +104,13 @@ def test_eval_ehrenfest_force():
             orders_i = np.array([0, 0, 0])
             orders_i[i] += 1
 
-            temp1 = eval_deriv_density_matrix(
+            temp1 = eval_deriv_reduced_density_matrix(
                 2 * orders_i, orders_j, np.identity(40), basis, points, np.identity(40)
             )
-            temp2 = eval_deriv_density_matrix(
+            temp2 = eval_deriv_reduced_density_matrix(
                 orders_i, orders_i + orders_j, np.identity(40), basis, points, np.identity(40)
             )
-            temp3 = eval_deriv_density_matrix(
+            temp3 = eval_deriv_reduced_density_matrix(
                 2 * orders_i + orders_j,
                 np.array([0, 0, 0]),
                 np.identity(40),
@@ -114,7 +118,7 @@ def test_eval_ehrenfest_force():
                 points,
                 np.identity(40),
             )
-            temp4 = eval_deriv_density_matrix(
+            temp4 = eval_deriv_reduced_density_matrix(
                 orders_i + orders_j, orders_i, np.identity(40), basis, points, np.identity(40)
             )
             temp5 = eval_deriv_density(
@@ -143,16 +147,16 @@ def test_eval_ehrenfest_hessian():
     points = np.random.rand(10, 3)
 
     with pytest.raises(TypeError):
-        eval_ehrenfest_hessian(np.identity(40), basis, points, np.identity(40), np.array(0), 0)
+        eval_ehrenfest_hessian(np.identity(40), basis, points, np.array(0), 0, np.identity(40))
     with pytest.raises(TypeError):
-        eval_ehrenfest_hessian(np.identity(40), basis, points, np.identity(40), 1, None)
+        eval_ehrenfest_hessian(np.identity(40), basis, points, 1, None, np.identity(40))
     with pytest.raises(TypeError):
-        eval_ehrenfest_hessian(np.identity(40), basis, points, np.identity(40), 1, 0j)
+        eval_ehrenfest_hessian(np.identity(40), basis, points, 1, 0j, np.identity(40))
 
-    test_a = eval_ehrenfest_hessian(np.identity(40), basis, points, np.identity(40), 0, 0)
-    test_b = eval_ehrenfest_hessian(np.identity(40), basis, points, np.identity(40), 1, 0)
-    test_c = eval_ehrenfest_hessian(np.identity(40), basis, points, np.identity(40), 0.5, 0)
-    test_d = eval_ehrenfest_hessian(np.identity(40), basis, points, np.identity(40), 0, 2)
+    test_a = eval_ehrenfest_hessian(np.identity(40), basis, points, 0, 0, np.identity(40))
+    test_b = eval_ehrenfest_hessian(np.identity(40), basis, points, 1, 0, np.identity(40))
+    test_c = eval_ehrenfest_hessian(np.identity(40), basis, points, 0.5, 0, np.identity(40))
+    test_d = eval_ehrenfest_hessian(np.identity(40), basis, points, 0, 2, np.identity(40))
     for j in range(3):
         for k in range(3):
             ref_a = np.zeros(points.shape[0])
@@ -168,7 +172,7 @@ def test_eval_ehrenfest_hessian():
                 orders_i = np.array([0, 0, 0])
                 orders_i[i] += 1
 
-                temp1 = eval_deriv_density_matrix(
+                temp1 = eval_deriv_reduced_density_matrix(
                     2 * orders_i + orders_k,
                     orders_j,
                     np.identity(40),
@@ -176,7 +180,7 @@ def test_eval_ehrenfest_hessian():
                     points,
                     np.identity(40),
                 )
-                temp2 = eval_deriv_density_matrix(
+                temp2 = eval_deriv_reduced_density_matrix(
                     2 * orders_i,
                     orders_j + orders_k,
                     np.identity(40),
@@ -184,7 +188,7 @@ def test_eval_ehrenfest_hessian():
                     points,
                     np.identity(40),
                 )
-                temp3 = eval_deriv_density_matrix(
+                temp3 = eval_deriv_reduced_density_matrix(
                     orders_i + orders_k,
                     orders_i + orders_j,
                     np.identity(40),
@@ -192,7 +196,7 @@ def test_eval_ehrenfest_hessian():
                     points,
                     np.identity(40),
                 )
-                temp4 = eval_deriv_density_matrix(
+                temp4 = eval_deriv_reduced_density_matrix(
                     orders_i,
                     orders_i + orders_j + orders_k,
                     np.identity(40),
@@ -200,7 +204,7 @@ def test_eval_ehrenfest_hessian():
                     points,
                     np.identity(40),
                 )
-                temp5 = eval_deriv_density_matrix(
+                temp5 = eval_deriv_reduced_density_matrix(
                     2 * orders_i + orders_j + orders_k,
                     np.array([0, 0, 0]),
                     np.identity(40),
@@ -208,7 +212,7 @@ def test_eval_ehrenfest_hessian():
                     points,
                     np.identity(40),
                 )
-                temp6 = eval_deriv_density_matrix(
+                temp6 = eval_deriv_reduced_density_matrix(
                     2 * orders_i + orders_j,
                     orders_k,
                     np.identity(40),
@@ -216,7 +220,7 @@ def test_eval_ehrenfest_hessian():
                     points,
                     np.identity(40),
                 )
-                temp7 = eval_deriv_density_matrix(
+                temp7 = eval_deriv_reduced_density_matrix(
                     orders_i + orders_j + orders_k,
                     orders_i,
                     np.identity(40),
@@ -224,7 +228,7 @@ def test_eval_ehrenfest_hessian():
                     points,
                     np.identity(40),
                 )
-                temp8 = eval_deriv_density_matrix(
+                temp8 = eval_deriv_reduced_density_matrix(
                     orders_i + orders_j,
                     orders_i + orders_k,
                     np.identity(40),
@@ -259,12 +263,12 @@ def test_eval_ehrenfest_hessian():
             assert np.allclose(test_d[:, j, k], ref_d)
     assert np.allclose(
         eval_ehrenfest_hessian(
-            np.identity(40), basis, points, np.identity(40), 0, 0, symmetric=True
+            np.identity(40), basis, points, 0, 0, np.identity(40), symmetric=True
         ),
         (
-            eval_ehrenfest_hessian(np.identity(40), basis, points, np.identity(40), 0, 0)
+            eval_ehrenfest_hessian(np.identity(40), basis, points, 0, 0, np.identity(40))
             + np.swapaxes(
-                eval_ehrenfest_hessian(np.identity(40), basis, points, np.identity(40), 0, 0), 1, 2
+                eval_ehrenfest_hessian(np.identity(40), basis, points, 0, 0, np.identity(40)), 1, 2
             )
         )
         / 2,


### PR DESCRIPTION
1. There used to be three to four copies of each high-level function: cartesian, spherical, mix, and lincomb. These have been combined into a single function.
2. Change names of functions
3. Change argument name (mainly coords to points)
4. Clean up docstring along the way
5. Make appropriate changes to modules/test that call the high level functions