### PR TITLE
Change names of evaluation functions from eval_ to evaluate_

### DIFF
--- a/gbasis/density.py
+++ b/gbasis/density.py
@@ -5,7 +5,7 @@ import numpy as np
 from scipy.special import comb
 
 
-def eval_density_using_evaluated_orbs(one_density_matrix, orb_eval):
+def evaluate_density_using_evaluated_orbs(one_density_matrix, orb_eval):
     """Return the evaluation of the density given the evaluated orbitals.
 
     Parameters
@@ -61,7 +61,7 @@ def eval_density_using_evaluated_orbs(one_density_matrix, orb_eval):
     return np.sum(density, axis=0)
 
 
-def eval_density(one_density_matrix, basis, points, transform=None, coord_type="spherical"):
+def evaluate_density(one_density_matrix, basis, points, transform=None, coord_type="spherical"):
     """Return the density of the given basis set at the given coordinates.
 
     Parameters
@@ -97,10 +97,10 @@ def eval_density(one_density_matrix, basis, points, transform=None, coord_type="
 
     """
     orb_eval = evaluate_basis(basis, points, transform=transform, coord_type=coord_type)
-    return eval_density_using_evaluated_orbs(one_density_matrix, orb_eval)
+    return evaluate_density_using_evaluated_orbs(one_density_matrix, orb_eval)
 
 
-def eval_deriv_reduced_density_matrix(
+def evaluate_deriv_reduced_density_matrix(
     orders_one,
     orders_two,
     one_density_matrix,
@@ -182,7 +182,7 @@ def eval_deriv_reduced_density_matrix(
     return density
 
 
-def eval_deriv_density(
+def evaluate_deriv_density(
     orders, one_density_matrix, basis, points, transform=None, coord_type="spherical"
 ):
     """Return the derivative of density of the given transformed basis set at the given coordinates.
@@ -239,7 +239,7 @@ def eval_deriv_density(
                 num_occurence = comb(total_l_x, l_x) * comb(total_l_y, l_y) * comb(total_l_z, l_z)
                 orders_one = np.array([l_x, l_y, l_z])
                 orders_two = orders - orders_one
-                density = eval_deriv_reduced_density_matrix(
+                density = evaluate_deriv_reduced_density_matrix(
                     orders_one,
                     orders_two,
                     one_density_matrix,
@@ -252,7 +252,7 @@ def eval_deriv_density(
     return output
 
 
-def eval_density_gradient(
+def evaluate_density_gradient(
     one_density_matrix, basis, points, transform=None, coord_type="spherical"
 ):
     """Return the gradient of the density evaluated at the given coordinates.
@@ -291,7 +291,7 @@ def eval_density_gradient(
     """
     return np.array(
         [
-            eval_deriv_density(
+            evaluate_deriv_density(
                 np.array([1, 0, 0]),
                 one_density_matrix,
                 basis,
@@ -299,7 +299,7 @@ def eval_density_gradient(
                 transform=transform,
                 coord_type=coord_type,
             ),
-            eval_deriv_density(
+            evaluate_deriv_density(
                 np.array([0, 1, 0]),
                 one_density_matrix,
                 basis,
@@ -307,7 +307,7 @@ def eval_density_gradient(
                 transform=transform,
                 coord_type=coord_type,
             ),
-            eval_deriv_density(
+            evaluate_deriv_density(
                 np.array([0, 0, 1]),
                 one_density_matrix,
                 basis,
@@ -319,7 +319,7 @@ def eval_density_gradient(
     ).T
 
 
-def eval_density_laplacian(
+def evaluate_density_laplacian(
     one_density_matrix, basis, points, transform=None, coord_type="spherical"
 ):
     """Return the Laplacian of the density evaluated at the given coordinates.
@@ -356,7 +356,7 @@ def eval_density_laplacian(
         Laplacian of the density evaluated at the given coordinates.
 
     """
-    output = eval_deriv_density(
+    output = evaluate_deriv_density(
         np.array([2, 0, 0]),
         one_density_matrix,
         basis,
@@ -364,7 +364,7 @@ def eval_density_laplacian(
         transform=transform,
         coord_type=coord_type,
     )
-    output += eval_deriv_density(
+    output += evaluate_deriv_density(
         np.array([0, 2, 0]),
         one_density_matrix,
         basis,
@@ -372,7 +372,7 @@ def eval_density_laplacian(
         transform=transform,
         coord_type=coord_type,
     )
-    output += eval_deriv_density(
+    output += evaluate_deriv_density(
         np.array([0, 0, 2]),
         one_density_matrix,
         basis,
@@ -383,7 +383,9 @@ def eval_density_laplacian(
     return output
 
 
-def eval_density_hessian(one_density_matrix, basis, points, transform=None, coord_type="spherical"):
+def evaluate_density_hessian(
+    one_density_matrix, basis, points, transform=None, coord_type="spherical"
+):
     """Return the Hessian of the density evaluated at the given coordinates.
 
     Parameters
@@ -423,7 +425,7 @@ def eval_density_hessian(one_density_matrix, basis, points, transform=None, coor
     return np.array(
         [
             [
-                eval_deriv_density(
+                evaluate_deriv_density(
                     orders_one + orders_two,
                     one_density_matrix,
                     basis,
@@ -438,7 +440,7 @@ def eval_density_hessian(one_density_matrix, basis, points, transform=None, coor
     ).T
 
 
-def eval_posdef_kinetic_energy_density(
+def evaluate_posdef_kinetic_energy_density(
     one_density_matrix, basis, points, transform=None, coord_type="spherical"
 ):
     r"""Return evaluations of positive definite kinetic energy density.
@@ -490,7 +492,7 @@ def eval_posdef_kinetic_energy_density(
     """
     output = np.zeros(points.shape[0])
     for orders in np.identity(3, dtype=int):
-        output += eval_deriv_reduced_density_matrix(
+        output += evaluate_deriv_reduced_density_matrix(
             orders,
             orders,
             one_density_matrix,
@@ -503,7 +505,7 @@ def eval_posdef_kinetic_energy_density(
 
 
 # TODO: test against a reference
-def eval_general_kinetic_energy_density(
+def evaluate_general_kinetic_energy_density(
     one_density_matrix, basis, points, alpha, transform=None, coord_type="spherical"
 ):
     r"""Return evaluations of general form of the kinetic energy density.
@@ -557,11 +559,11 @@ def eval_general_kinetic_energy_density(
     if not isinstance(alpha, (int, float)):
         raise TypeError("`alpha` must be an int or float.")
 
-    general_kinetic_energy_density = eval_posdef_kinetic_energy_density(
+    general_kinetic_energy_density = evaluate_posdef_kinetic_energy_density(
         one_density_matrix, basis, points, transform=transform, coord_type=coord_type
     )
     if alpha != 0:
-        general_kinetic_energy_density += alpha * eval_density_laplacian(
+        general_kinetic_energy_density += alpha * evaluate_density_laplacian(
             one_density_matrix, basis, points, transform=transform, coord_type=coord_type
         )
     return general_kinetic_energy_density

--- a/gbasis/parsers.py
+++ b/gbasis/parsers.py
@@ -97,7 +97,7 @@ def parse_gbs(gbs_basis):
     data = re.split(r"\n\s*(\w[\w]?)\s+\w+\s*\n", gbs_basis)
     dict_angmom = {"s": 0, "p": 1, "d": 2, "f": 3, "g": 4, "h": 5, "i": 6, "k": 7}
     # remove first part
-    if "\n" in data[0]:
+    if "\n" in data[0]:  # pragma: no branch
         data = data[1:]
 
     atoms = data[::2]

--- a/gbasis/stress_tensor.py
+++ b/gbasis/stress_tensor.py
@@ -1,14 +1,14 @@
 """Module for computing properties related to stress tensor."""
 from gbasis.density import (
-    eval_density_laplacian,
-    eval_deriv_density,
-    eval_deriv_reduced_density_matrix,
+    evaluate_density_laplacian,
+    evaluate_deriv_density,
+    evaluate_deriv_reduced_density_matrix,
 )
 import numpy as np
 
 
 # TODO: need to be tested against reference
-def eval_stress_tensor(
+def evaluate_stress_tensor(
     one_density_matrix, basis, points, alpha=1, beta=0, transform=None, coord_type="spherical"
 ):
     r"""Return the stress tensor evaluated at the given coordinates.
@@ -98,7 +98,7 @@ def eval_stress_tensor(
         for j, orders_one in enumerate(np.identity(3, dtype=int)[i:]):
             j += i
             if alpha != 0:
-                output[i, j] -= alpha * eval_deriv_reduced_density_matrix(
+                output[i, j] -= alpha * evaluate_deriv_reduced_density_matrix(
                     orders_one,
                     orders_two,
                     one_density_matrix,
@@ -108,7 +108,7 @@ def eval_stress_tensor(
                     coord_type=coord_type,
                 )
             if alpha != 1:
-                output[i, j] += (1 - alpha) * eval_deriv_reduced_density_matrix(
+                output[i, j] += (1 - alpha) * evaluate_deriv_reduced_density_matrix(
                     orders_one + orders_two,
                     np.array([0, 0, 0]),
                     one_density_matrix,
@@ -121,7 +121,7 @@ def eval_stress_tensor(
                 output[i, j] -= (
                     0.5
                     * beta
-                    * eval_density_laplacian(
+                    * evaluate_density_laplacian(
                         one_density_matrix,
                         basis,
                         points,
@@ -134,7 +134,7 @@ def eval_stress_tensor(
 
 
 # TODO: need to be tested against reference
-def eval_ehrenfest_force(
+def evaluate_ehrenfest_force(
     one_density_matrix, basis, points, alpha=1, beta=0, transform=None, coord_type="spherical"
 ):
     r"""Return the Ehrenfest force.
@@ -222,7 +222,7 @@ def eval_ehrenfest_force(
     for i, orders_two in enumerate(np.identity(3, dtype=int)):
         for orders_one in np.identity(3, dtype=int):
             if alpha != 0:
-                output[i] -= alpha * eval_deriv_reduced_density_matrix(
+                output[i] -= alpha * evaluate_deriv_reduced_density_matrix(
                     2 * orders_one,
                     orders_two,
                     one_density_matrix,
@@ -232,7 +232,7 @@ def eval_ehrenfest_force(
                     coord_type=coord_type,
                 )
             if alpha != 1:
-                output[i] += (1 - alpha) * eval_deriv_reduced_density_matrix(
+                output[i] += (1 - alpha) * evaluate_deriv_reduced_density_matrix(
                     2 * orders_one + orders_two,
                     np.array([0, 0, 0]),
                     one_density_matrix,
@@ -242,7 +242,7 @@ def eval_ehrenfest_force(
                     coord_type=coord_type,
                 )
             if alpha != 0.5:
-                output[i] += (1 - 2 * alpha) * eval_deriv_reduced_density_matrix(
+                output[i] += (1 - 2 * alpha) * evaluate_deriv_reduced_density_matrix(
                     orders_one + orders_two,
                     orders_one,
                     one_density_matrix,
@@ -255,7 +255,7 @@ def eval_ehrenfest_force(
                 output[i] -= (
                     0.5
                     * beta
-                    * eval_deriv_density(
+                    * evaluate_deriv_density(
                         2 * orders_one + orders_two,
                         one_density_matrix,
                         basis,
@@ -268,7 +268,7 @@ def eval_ehrenfest_force(
 
 
 # TODO: need to be tested against reference
-def eval_ehrenfest_hessian(
+def evaluate_ehrenfest_hessian(
     one_density_matrix,
     basis,
     points,
@@ -379,7 +379,7 @@ def eval_ehrenfest_hessian(
         for j, orders_three in enumerate(np.identity(3, dtype=int)):
             for orders_one in np.identity(3, dtype=int):
                 if alpha != 0:
-                    output[i, j] -= alpha * eval_deriv_reduced_density_matrix(
+                    output[i, j] -= alpha * evaluate_deriv_reduced_density_matrix(
                         2 * orders_one + orders_three,
                         orders_two,
                         one_density_matrix,
@@ -388,7 +388,7 @@ def eval_ehrenfest_hessian(
                         transform=transform,
                         coord_type=coord_type,
                     )
-                    output[i, j] -= alpha * eval_deriv_reduced_density_matrix(
+                    output[i, j] -= alpha * evaluate_deriv_reduced_density_matrix(
                         2 * orders_one,
                         orders_two + orders_three,
                         one_density_matrix,
@@ -398,7 +398,7 @@ def eval_ehrenfest_hessian(
                         coord_type=coord_type,
                     )
                 if alpha != 1:
-                    output[i, j] += (1 - alpha) * eval_deriv_reduced_density_matrix(
+                    output[i, j] += (1 - alpha) * evaluate_deriv_reduced_density_matrix(
                         2 * orders_one + orders_two + orders_three,
                         np.array([0, 0, 0]),
                         one_density_matrix,
@@ -407,7 +407,7 @@ def eval_ehrenfest_hessian(
                         transform=transform,
                         coord_type=coord_type,
                     )
-                    output[i, j] += (1 - alpha) * eval_deriv_reduced_density_matrix(
+                    output[i, j] += (1 - alpha) * evaluate_deriv_reduced_density_matrix(
                         2 * orders_one + orders_two,
                         orders_three,
                         one_density_matrix,
@@ -417,7 +417,7 @@ def eval_ehrenfest_hessian(
                         coord_type=coord_type,
                     )
                 if alpha != 0.5:
-                    output[i, j] += (1 - 2 * alpha) * eval_deriv_reduced_density_matrix(
+                    output[i, j] += (1 - 2 * alpha) * evaluate_deriv_reduced_density_matrix(
                         orders_one + orders_two + orders_three,
                         orders_one,
                         one_density_matrix,
@@ -426,7 +426,7 @@ def eval_ehrenfest_hessian(
                         transform=transform,
                         coord_type=coord_type,
                     )
-                    output[i, j] += (1 - 2 * alpha) * eval_deriv_reduced_density_matrix(
+                    output[i, j] += (1 - 2 * alpha) * evaluate_deriv_reduced_density_matrix(
                         orders_one + orders_two,
                         orders_one + orders_three,
                         one_density_matrix,
@@ -439,7 +439,7 @@ def eval_ehrenfest_hessian(
                     output[i, j] -= (
                         0.5
                         * beta
-                        * eval_deriv_density(
+                        * evaluate_deriv_density(
                             2 * orders_one + orders_two + orders_three,
                             one_density_matrix,
                             basis,

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -1,13 +1,13 @@
 """Test gbasis.density."""
 from gbasis.density import (
-    eval_density,
-    eval_density_gradient,
-    eval_density_hessian,
-    eval_density_laplacian,
-    eval_density_using_evaluated_orbs,
-    eval_deriv_density,
-    eval_general_kinetic_energy_density,
-    eval_posdef_kinetic_energy_density,
+    evaluate_density,
+    evaluate_density_gradient,
+    evaluate_density_hessian,
+    evaluate_density_laplacian,
+    evaluate_density_using_evaluated_orbs,
+    evaluate_deriv_density,
+    evaluate_general_kinetic_energy_density,
+    evaluate_posdef_kinetic_energy_density,
 )
 from gbasis.eval import evaluate_basis
 from gbasis.eval_deriv import evaluate_deriv_basis
@@ -17,51 +17,51 @@ import pytest
 from utils import find_datafile, HortonContractions
 
 
-def test_eval_density_using_evaluated_orbs():
-    """Test gbasis.density.eval_density_using_evaluated_orbs."""
+def test_evaluate_density_using_evaluated_orbs():
+    """Test gbasis.density.evaluate_density_using_evaluated_orbs."""
     density_mat = np.array([[1.0, 2.0], [2.0, 3.0]])
     orb_eval = np.array([[1.0], [2.0]])
     assert np.allclose(
-        eval_density_using_evaluated_orbs(density_mat, orb_eval),
+        evaluate_density_using_evaluated_orbs(density_mat, orb_eval),
         np.einsum("ij,ik,jk->k", density_mat, orb_eval, orb_eval),
     )
     density_mat = np.array([[1.0, 2.0], [2.0, 3.0]])
     orb_eval = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
     assert np.allclose(
-        eval_density_using_evaluated_orbs(density_mat, orb_eval),
+        evaluate_density_using_evaluated_orbs(density_mat, orb_eval),
         np.einsum("ij,ik,jk->k", density_mat, orb_eval, orb_eval),
     )
 
     with pytest.raises(TypeError):
         orb_eval = [[1.0, 2.0], [1.0, 2.0]]
-        eval_density_using_evaluated_orbs(density_mat, orb_eval)
+        evaluate_density_using_evaluated_orbs(density_mat, orb_eval)
     with pytest.raises(TypeError):
         orb_eval = np.array([[1, 2], [1, 2]], dtype=bool)
-        eval_density_using_evaluated_orbs(density_mat, orb_eval)
+        evaluate_density_using_evaluated_orbs(density_mat, orb_eval)
 
     orb_eval = np.array([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]])
     with pytest.raises(TypeError):
         density_mat = [[1.0, 2.0], [1.0, 2.0]]
-        eval_density_using_evaluated_orbs(density_mat, orb_eval)
+        evaluate_density_using_evaluated_orbs(density_mat, orb_eval)
     with pytest.raises(TypeError):
         density_mat = np.array([[1, 2], [1, 2]], dtype=bool)
-        eval_density_using_evaluated_orbs(density_mat, orb_eval)
+        evaluate_density_using_evaluated_orbs(density_mat, orb_eval)
     with pytest.raises(TypeError):
         density_mat = np.array([1.0, 2.0, 3.0])
-        eval_density_using_evaluated_orbs(density_mat, orb_eval)
+        evaluate_density_using_evaluated_orbs(density_mat, orb_eval)
     with pytest.raises(ValueError):
         density_mat = np.array([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]])
-        eval_density_using_evaluated_orbs(density_mat, orb_eval)
+        evaluate_density_using_evaluated_orbs(density_mat, orb_eval)
     with pytest.raises(ValueError):
         density_mat = np.array([[1.0, 2.0, 3.0], [2.0, 4.0, 5.0], [3.0, 5.0, 6.0]])
-        eval_density_using_evaluated_orbs(density_mat, orb_eval)
+        evaluate_density_using_evaluated_orbs(density_mat, orb_eval)
     with pytest.raises(ValueError):
         density_mat = np.array([[1.0, 2.0], [3.0, 4.0]])
-        eval_density_using_evaluated_orbs(density_mat, orb_eval)
+        evaluate_density_using_evaluated_orbs(density_mat, orb_eval)
 
 
-def test_eval_density():
-    """Test gbasis.density.eval_density."""
+def test_evaluate_density():
+    """Test gbasis.density.evaluate_density."""
     with open(find_datafile("data_sto6g.nwchem"), "r") as f:
         test_basis = f.read()
     basis_dict = parse_nwchem(test_basis)
@@ -71,15 +71,15 @@ def test_eval_density():
     density += density.T
     points = np.random.rand(10, 3)
 
-    eval_orbs = evaluate_basis(basis, points, transform)
+    evaluate_orbs = evaluate_basis(basis, points, transform)
     assert np.allclose(
-        eval_density(density, basis, points, transform),
-        np.einsum("ij,ik,jk->k", density, eval_orbs, eval_orbs),
+        evaluate_density(density, basis, points, transform),
+        np.einsum("ij,ik,jk->k", density, evaluate_orbs, evaluate_orbs),
     )
 
 
-def test_eval_deriv_density():
-    """Test gbasis.density.eval_deriv_density."""
+def test_evaluate_deriv_density():
+    """Test gbasis.density.evaluate_deriv_density."""
     with open(find_datafile("data_sto6g.nwchem"), "r") as f:
         test_basis = f.read()
     basis_dict = parse_nwchem(test_basis)
@@ -90,7 +90,7 @@ def test_eval_deriv_density():
     points = np.random.rand(10, 3)
 
     assert np.allclose(
-        eval_deriv_density(np.array([1, 0, 0]), density, basis, points, transform),
+        evaluate_deriv_density(np.array([1, 0, 0]), density, basis, points, transform),
         np.einsum(
             "ij,ik,jk->k",
             density,
@@ -106,7 +106,7 @@ def test_eval_deriv_density():
     )
 
     assert np.allclose(
-        eval_deriv_density(np.array([0, 1, 0]), density, basis, points, transform),
+        evaluate_deriv_density(np.array([0, 1, 0]), density, basis, points, transform),
         np.einsum(
             "ij,ik,jk->k",
             density,
@@ -122,7 +122,7 @@ def test_eval_deriv_density():
     )
 
     assert np.allclose(
-        eval_deriv_density(np.array([0, 0, 1]), density, basis, points, transform),
+        evaluate_deriv_density(np.array([0, 0, 1]), density, basis, points, transform),
         np.einsum(
             "ij,ik,jk->k",
             density,
@@ -138,7 +138,7 @@ def test_eval_deriv_density():
     )
 
     assert np.allclose(
-        eval_deriv_density(np.array([2, 3, 0]), density, basis, points, transform),
+        evaluate_deriv_density(np.array([2, 3, 0]), density, basis, points, transform),
         np.einsum(
             "ij,ik,jk->k",
             density,
@@ -224,8 +224,8 @@ def test_eval_deriv_density():
     )
 
 
-def test_eval_density_gradient():
-    """Test gbasis.density.eval_density_gradient."""
+def test_evaluate_density_gradient():
+    """Test gbasis.density.evaluate_density_gradient."""
     with open(find_datafile("data_sto6g.nwchem"), "r") as f:
         test_basis = f.read()
     basis_dict = parse_nwchem(test_basis)
@@ -236,7 +236,7 @@ def test_eval_density_gradient():
     points = np.random.rand(10, 3)
 
     np.allclose(
-        eval_density_gradient(density, basis, points, transform).T,
+        evaluate_density_gradient(density, basis, points, transform).T,
         np.array(
             [
                 np.einsum(
@@ -280,8 +280,8 @@ def test_eval_density_gradient():
     )
 
 
-def test_eval_density_horton():
-    """Test gbasis.density.eval_density against result from HORTON.
+def test_evaluate_density_horton():
+    """Test gbasis.density.evaluate_density against result from HORTON.
 
     The test case is diatomic with H and He separated by 0.8 angstroms with basis set ANO-RCC.
 
@@ -301,12 +301,12 @@ def test_eval_density_horton():
     grid_3d = np.vstack([grid_x.ravel(), grid_y.ravel(), grid_z.ravel()]).T
 
     assert np.allclose(
-        eval_density(np.identity(88), basis, grid_3d, np.identity(88)), horton_density
+        evaluate_density(np.identity(88), basis, grid_3d, np.identity(88)), horton_density
     )
 
 
-def test_eval_density_gradient_horton():
-    """Test gbasis.density.eval_density_gradient against result from HORTON.
+def test_evaluate_density_gradient_horton():
+    """Test gbasis.density.evaluate_density_gradient against result from HORTON.
 
     The test case is diatomic with H and He separated by 0.8 angstroms with basis set ANO-RCC.
 
@@ -326,13 +326,13 @@ def test_eval_density_gradient_horton():
     grid_3d = np.vstack([grid_x.ravel(), grid_y.ravel(), grid_z.ravel()]).T
 
     assert np.allclose(
-        eval_density_gradient(np.identity(88), basis, grid_3d, np.identity(88)),
+        evaluate_density_gradient(np.identity(88), basis, grid_3d, np.identity(88)),
         horton_density_gradient,
     )
 
 
-def test_eval_hessian_deriv_horton():
-    """Test gbasis.density.eval_density_hessian against result from HORTON.
+def test_evaluate_hessian_deriv_horton():
+    """Test gbasis.density.evaluate_density_hessian against result from HORTON.
 
     The test case is diatomic with H and He separated by 0.8 angstroms with basis set ANO-RCC.
 
@@ -358,13 +358,13 @@ def test_eval_hessian_deriv_horton():
     grid_3d = np.vstack([grid_x.ravel(), grid_y.ravel(), grid_z.ravel()]).T
 
     assert np.allclose(
-        eval_density_hessian(np.identity(88), basis, grid_3d, np.identity(88)),
+        evaluate_density_hessian(np.identity(88), basis, grid_3d, np.identity(88)),
         horton_density_hessian,
     )
 
 
-def test_eval_laplacian_deriv_horton():
-    """Test gbasis.density.eval_density_laplacian against result from HORTON.
+def test_evaluate_laplacian_deriv_horton():
+    """Test gbasis.density.evaluate_density_laplacian against result from HORTON.
 
     The test case is diatomic with H and He separated by 0.8 angstroms with basis set ANO-RCC.
 
@@ -384,13 +384,13 @@ def test_eval_laplacian_deriv_horton():
     grid_3d = np.vstack([grid_x.ravel(), grid_y.ravel(), grid_z.ravel()]).T
 
     assert np.allclose(
-        eval_density_laplacian(np.identity(88), basis, grid_3d, np.identity(88)),
+        evaluate_density_laplacian(np.identity(88), basis, grid_3d, np.identity(88)),
         horton_density_laplacian,
     )
 
 
-def test_eval_posdef_kinetic_energy_density():
-    """Test gbasis.kinetic_energy.eval_posdef_kinetic_energy_density against results from HORTON.
+def test_evaluate_posdef_kinetic_energy_density():
+    """Test gbasis.kinetic_energy.evaluate_posdef_kinetic_energy_density against results from HORTON.
 
     The test case is diatomic with H and He separated by 0.8 angstroms with basis set ANO-RCC.
 
@@ -412,13 +412,13 @@ def test_eval_posdef_kinetic_energy_density():
     grid_3d = np.vstack([grid_x.ravel(), grid_y.ravel(), grid_z.ravel()]).T
 
     assert np.allclose(
-        eval_posdef_kinetic_energy_density(np.identity(88), basis, grid_3d, np.identity(88)),
+        evaluate_posdef_kinetic_energy_density(np.identity(88), basis, grid_3d, np.identity(88)),
         horton_density_kinetic_density,
     )
 
 
-def test_eval_general_kinetic_energy_density_horton():
-    """Test gbasis.kinetic_energy.eval_general_kinetic_energy_density against results from HORTON.
+def test_evaluate_general_kinetic_energy_density_horton():
+    """Test gbasis.kinetic_energy.evaluate_general_kinetic_energy_density against results from HORTON.
 
     The test case is diatomic with H and He separated by 0.8 angstroms with basis set ANO-RCC.
 
@@ -442,13 +442,15 @@ def test_eval_general_kinetic_energy_density_horton():
     grid_3d = np.vstack([grid_x.ravel(), grid_y.ravel(), grid_z.ravel()]).T
 
     assert np.allclose(
-        eval_general_kinetic_energy_density(np.identity(88), basis, grid_3d, 0, np.identity(88)),
+        evaluate_general_kinetic_energy_density(
+            np.identity(88), basis, grid_3d, 0, np.identity(88)
+        ),
         horton_density_kinetic_density,
     )
 
 
-def test_eval_general_kinetic_energy_density():
-    """Test gbasis.kinetic_energy.eval_general_kinetic_energy_density."""
+def test_evaluate_general_kinetic_energy_density():
+    """Test gbasis.kinetic_energy.evaluate_general_kinetic_energy_density."""
     with open(find_datafile("data_anorcc.nwchem"), "r") as f:
         test_basis = f.read()
     basis_dict = parse_nwchem(test_basis)
@@ -457,13 +459,15 @@ def test_eval_general_kinetic_energy_density():
     points = np.random.rand(10, 3)
 
     with pytest.raises(TypeError):
-        eval_general_kinetic_energy_density(
+        evaluate_general_kinetic_energy_density(
             np.identity(40), basis, points, np.identity(40), np.array(0)
         )
     with pytest.raises(TypeError):
-        eval_general_kinetic_energy_density(np.identity(40), basis, points, None, np.identity(40))
+        evaluate_general_kinetic_energy_density(
+            np.identity(40), basis, points, None, np.identity(40)
+        )
     assert np.allclose(
-        eval_general_kinetic_energy_density(np.identity(40), basis, points, 1, np.identity(40)),
-        eval_posdef_kinetic_energy_density(np.identity(40), basis, points, np.identity(40))
-        + eval_density_laplacian(np.identity(40), basis, points, np.identity(40)),
+        evaluate_general_kinetic_energy_density(np.identity(40), basis, points, 1, np.identity(40)),
+        evaluate_posdef_kinetic_energy_density(np.identity(40), basis, points, np.identity(40))
+        + evaluate_density_laplacian(np.identity(40), basis, points, np.identity(40)),
     )

--- a/tests/test_deriv.py
+++ b/tests/test_deriv.py
@@ -6,7 +6,7 @@ import numpy as np
 from utils import partial_deriv_finite_diff
 
 
-def eval_deriv_prim(coord, orders, center, angmom_comps, alpha):
+def evaluate_deriv_prim(coord, orders, center, angmom_comps, alpha):
     """Return the evaluation of the derivative of a Gaussian primitive.
 
     Parameters
@@ -31,7 +31,7 @@ def eval_deriv_prim(coord, orders, center, angmom_comps, alpha):
     Note
     ----
     If you want to evaluate the derivative of the contractions of the primitive, then use
-    `gbasis._deriv.eval_deriv_contraction` instead.
+    `gbasis._deriv.evaluate_deriv_contraction` instead.
 
     """
     return _eval_deriv_contractions(
@@ -45,7 +45,7 @@ def eval_deriv_prim(coord, orders, center, angmom_comps, alpha):
     )[0]
 
 
-def eval_prim(coord, center, angmom_comps, alpha):
+def evaluate_prim(coord, center, angmom_comps, alpha):
     """Return the evaluation of a Gaussian primitive.
 
     Parameters
@@ -67,57 +67,58 @@ def eval_prim(coord, center, angmom_comps, alpha):
     Note
     ----
     If you want to evaluate the contractions of the primitive, then use
-    `gbasis._deriv.eval_contraction` instead.
+    `gbasis._deriv.evaluate_contraction` instead.
 
     """
-    return eval_deriv_prim(coord, np.zeros(angmom_comps.shape), center, angmom_comps, alpha)
+    return evaluate_deriv_prim(coord, np.zeros(angmom_comps.shape), center, angmom_comps, alpha)
 
 
-def test_eval_prim():
-    """Test gbasis._deriv.eval_prim.
+def test_evaluate_prim():
+    """Test gbasis._deriv.evaluate_prim.
 
-    Note that this also tests the no derivative case of gbasis._deriv.eval_deriv_prim.
+    Note that this also tests the no derivative case of gbasis._deriv.evaluate_deriv_prim.
     """
     # angular momentum: 0
     assert np.allclose(
-        eval_prim(np.array([0, 0, 0]), np.array([0, 0, 0]), np.array([0, 0, 0]), 1), 1
+        evaluate_prim(np.array([0, 0, 0]), np.array([0, 0, 0]), np.array([0, 0, 0]), 1), 1
     )
     assert np.allclose(
-        eval_prim(np.array([1.0, 0, 0]), np.array([0, 0, 0]), np.array([0, 0, 0]), 1), np.exp(-1)
+        evaluate_prim(np.array([1.0, 0, 0]), np.array([0, 0, 0]), np.array([0, 0, 0]), 1),
+        np.exp(-1),
     )
     assert np.allclose(
-        eval_prim(np.array([1.0, 2.0, 0]), np.array([0, 0, 0]), np.array([0, 0, 0]), 1),
+        evaluate_prim(np.array([1.0, 2.0, 0]), np.array([0, 0, 0]), np.array([0, 0, 0]), 1),
         np.exp(-1) * np.exp(-4),
     )
     assert np.allclose(
-        eval_prim(np.array([1.0, 2.0, 3.0]), np.array([0, 0, 0]), np.array([0, 0, 0]), 1),
+        evaluate_prim(np.array([1.0, 2.0, 3.0]), np.array([0, 0, 0]), np.array([0, 0, 0]), 1),
         np.exp(-1) * np.exp(-4) * np.exp(-9),
     )
     # angular momentum 1
     assert np.allclose(
-        eval_prim(np.array([2.0, 0, 0]), np.array([0, 0, 0]), np.array([1, 0, 0]), 1),
+        evaluate_prim(np.array([2.0, 0, 0]), np.array([0, 0, 0]), np.array([1, 0, 0]), 1),
         2 * np.exp(-2 ** 2),
     )
     # other angular momentum
     assert np.allclose(
-        eval_prim(np.array([2.0, 0, 0]), np.array([0, 3, 4]), np.array([2, 1, 3]), 1),
+        evaluate_prim(np.array([2.0, 0, 0]), np.array([0, 3, 4]), np.array([2, 1, 3]), 1),
         4 * 3 * 4 ** 3 * np.exp(-(2 ** 2 + 3 ** 2 + 4 ** 2)),
     )
 
 
-def test_eval_deriv_prim():
-    """Test gbasis._deriv.eval_deriv_prim."""
+def test_evaluate_deriv_prim():
+    """Test gbasis._deriv.evaluate_deriv_prim."""
     # first order
     for k in range(3):
         orders = np.zeros(3, dtype=int)
         orders[k] = 1
         for x, y, z in it.product(range(3), range(3), range(3)):
             assert np.allclose(
-                eval_deriv_prim(
+                evaluate_deriv_prim(
                     np.array([2, 3, 4]), orders, np.array([0.5, 1, 1.5]), np.array([x, y, z]), 1
                 ),
                 partial_deriv_finite_diff(
-                    lambda xyz: eval_prim(xyz, np.array([0.5, 1, 1.5]), np.array([x, y, z]), 1),
+                    lambda xyz: evaluate_prim(xyz, np.array([0.5, 1, 1.5]), np.array([x, y, z]), 1),
                     np.array([2, 3, 4]),
                     orders,
                 ),
@@ -129,11 +130,11 @@ def test_eval_deriv_prim():
         orders[l] += 1
         for x, y, z in it.product(range(4), range(4), range(4)):
             assert np.allclose(
-                eval_deriv_prim(
+                evaluate_deriv_prim(
                     np.array([2, 3, 4]), orders, np.array([0.5, 1, 1.5]), np.array([x, y, z]), 1
                 ),
                 partial_deriv_finite_diff(
-                    lambda xyz: eval_prim(xyz, np.array([0.5, 1, 1.5]), np.array([x, y, z]), 1),
+                    lambda xyz: evaluate_prim(xyz, np.array([0.5, 1, 1.5]), np.array([x, y, z]), 1),
                     np.array([2, 3, 4]),
                     orders,
                     epsilon=1e-5,
@@ -142,8 +143,8 @@ def test_eval_deriv_prim():
             )
 
 
-def test_eval_contractions():
-    """Test gbasis._deriv._eval_deriv_contraction without derivatization."""
+def test_evaluate_contractions():
+    """Test gbasis._deriv._evaluate_deriv_contraction without derivatization."""
     # angular momentum: 0
     assert np.allclose(
         _eval_deriv_contractions(
@@ -276,11 +277,11 @@ def test_eval_deriv_contractions():
                     np.array([[1, 1]]),
                 ),
                 3
-                * eval_deriv_prim(
+                * evaluate_deriv_prim(
                     np.array([2, 3, 4]), orders, np.array([0.5, 1, 1.5]), np.array([x, y, z]), 1
                 )
                 + 4
-                * eval_deriv_prim(
+                * evaluate_deriv_prim(
                     np.array([2, 3, 4]), orders, np.array([0.5, 1, 1.5]), np.array([x, y, z]), 2
                 ),
             )
@@ -297,15 +298,15 @@ def test_eval_deriv_contractions():
                 ),
                 [
                     3
-                    * eval_deriv_prim(
+                    * evaluate_deriv_prim(
                         np.array([2, 3, 4]), orders, np.array([0.5, 1, 1.5]), np.array([x, y, z]), 1
                     )
                     + 4
-                    * eval_deriv_prim(
+                    * evaluate_deriv_prim(
                         np.array([2, 3, 4]), orders, np.array([0.5, 1, 1.5]), np.array([x, y, z]), 2
                     ),
                     3
-                    * eval_deriv_prim(
+                    * evaluate_deriv_prim(
                         np.array([2, 3, 4]),
                         orders,
                         np.array([0.5, 1, 1.5]),
@@ -313,7 +314,7 @@ def test_eval_deriv_contractions():
                         1,
                     )
                     + 4
-                    * eval_deriv_prim(
+                    * evaluate_deriv_prim(
                         np.array([2, 3, 4]),
                         orders,
                         np.array([0.5, 1, 1.5]),
@@ -338,7 +339,7 @@ def test_eval_deriv_contractions():
                     np.array([1]),
                     np.array([[1]]),
                 ),
-                eval_deriv_prim(
+                evaluate_deriv_prim(
                     np.array([2, 3, 4]), orders, np.array([0.5, 1, 1.5]), np.array([x, y, z]), 1
                 ),
             )
@@ -354,11 +355,11 @@ def test_eval_deriv_contractions():
                     np.array([[1, 1]]),
                 ),
                 3
-                * eval_deriv_prim(
+                * evaluate_deriv_prim(
                     np.array([2, 3, 4]), orders, np.array([0.5, 1, 1.5]), np.array([x, y, z]), 1
                 )
                 + 4
-                * eval_deriv_prim(
+                * evaluate_deriv_prim(
                     np.array([2, 3, 4]), orders, np.array([0.5, 1, 1.5]), np.array([x, y, z]), 2
                 ),
             )
@@ -375,15 +376,15 @@ def test_eval_deriv_contractions():
                 ),
                 [
                     3
-                    * eval_deriv_prim(
+                    * evaluate_deriv_prim(
                         np.array([2, 3, 4]), orders, np.array([0.5, 1, 1.5]), np.array([x, y, z]), 1
                     )
                     + 4
-                    * eval_deriv_prim(
+                    * evaluate_deriv_prim(
                         np.array([2, 3, 4]), orders, np.array([0.5, 1, 1.5]), np.array([x, y, z]), 2
                     ),
                     3
-                    * eval_deriv_prim(
+                    * evaluate_deriv_prim(
                         np.array([2, 3, 4]),
                         orders,
                         np.array([0.5, 1, 1.5]),
@@ -391,7 +392,7 @@ def test_eval_deriv_contractions():
                         1,
                     )
                     + 4
-                    * eval_deriv_prim(
+                    * evaluate_deriv_prim(
                         np.array([2, 3, 4]),
                         orders,
                         np.array([0.5, 1, 1.5]),
@@ -402,7 +403,7 @@ def test_eval_deriv_contractions():
             )
 
 
-def test_eval_deriv_generalized_contraction():
+def test_evaluate_deriv_generalized_contraction():
     """Test gbasis._deriv._eval_deriv_contractions for generalized contractions."""
     for k, l in it.product(range(3), range(3)):
         orders = np.zeros(3, dtype=int)
@@ -423,7 +424,7 @@ def test_eval_deriv_generalized_contraction():
                 np.array(
                     [
                         3
-                        * eval_deriv_prim(
+                        * evaluate_deriv_prim(
                             np.array([2, 3, 4]),
                             orders,
                             np.array([0.5, 1, 1.5]),
@@ -431,7 +432,7 @@ def test_eval_deriv_generalized_contraction():
                             1,
                         )
                         + 6
-                        * eval_deriv_prim(
+                        * evaluate_deriv_prim(
                             np.array([2, 3, 4]),
                             orders,
                             np.array([0.5, 1, 1.5]),
@@ -439,7 +440,7 @@ def test_eval_deriv_generalized_contraction():
                             2,
                         ),
                         4
-                        * eval_deriv_prim(
+                        * evaluate_deriv_prim(
                             np.array([2, 3, 4]),
                             orders,
                             np.array([0.5, 1, 1.5]),
@@ -447,7 +448,7 @@ def test_eval_deriv_generalized_contraction():
                             1,
                         )
                         + 7
-                        * eval_deriv_prim(
+                        * evaluate_deriv_prim(
                             np.array([2, 3, 4]),
                             orders,
                             np.array([0.5, 1, 1.5]),
@@ -455,7 +456,7 @@ def test_eval_deriv_generalized_contraction():
                             2,
                         ),
                         5
-                        * eval_deriv_prim(
+                        * evaluate_deriv_prim(
                             np.array([2, 3, 4]),
                             orders,
                             np.array([0.5, 1, 1.5]),
@@ -463,7 +464,7 @@ def test_eval_deriv_generalized_contraction():
                             1,
                         )
                         + 8
-                        * eval_deriv_prim(
+                        * evaluate_deriv_prim(
                             np.array([2, 3, 4]),
                             orders,
                             np.array([0.5, 1, 1.5]),
@@ -488,7 +489,7 @@ def test_eval_deriv_generalized_contraction():
                     [
                         [
                             3
-                            * eval_deriv_prim(
+                            * evaluate_deriv_prim(
                                 np.array([2, 3, 4]),
                                 orders,
                                 np.array([0.5, 1, 1.5]),
@@ -496,7 +497,7 @@ def test_eval_deriv_generalized_contraction():
                                 1,
                             )
                             + 6
-                            * eval_deriv_prim(
+                            * evaluate_deriv_prim(
                                 np.array([2, 3, 4]),
                                 orders,
                                 np.array([0.5, 1, 1.5]),
@@ -504,7 +505,7 @@ def test_eval_deriv_generalized_contraction():
                                 2,
                             ),
                             3
-                            * eval_deriv_prim(
+                            * evaluate_deriv_prim(
                                 np.array([2, 3, 4]),
                                 orders,
                                 np.array([0.5, 1, 1.5]),
@@ -512,7 +513,7 @@ def test_eval_deriv_generalized_contraction():
                                 1,
                             )
                             + 6
-                            * eval_deriv_prim(
+                            * evaluate_deriv_prim(
                                 np.array([2, 3, 4]),
                                 orders,
                                 np.array([0.5, 1, 1.5]),
@@ -522,7 +523,7 @@ def test_eval_deriv_generalized_contraction():
                         ],
                         [
                             4
-                            * eval_deriv_prim(
+                            * evaluate_deriv_prim(
                                 np.array([2, 3, 4]),
                                 orders,
                                 np.array([0.5, 1, 1.5]),
@@ -530,7 +531,7 @@ def test_eval_deriv_generalized_contraction():
                                 1,
                             )
                             + 7
-                            * eval_deriv_prim(
+                            * evaluate_deriv_prim(
                                 np.array([2, 3, 4]),
                                 orders,
                                 np.array([0.5, 1, 1.5]),
@@ -538,7 +539,7 @@ def test_eval_deriv_generalized_contraction():
                                 2,
                             ),
                             4
-                            * eval_deriv_prim(
+                            * evaluate_deriv_prim(
                                 np.array([2, 3, 4]),
                                 orders,
                                 np.array([0.5, 1, 1.5]),
@@ -546,7 +547,7 @@ def test_eval_deriv_generalized_contraction():
                                 1,
                             )
                             + 7
-                            * eval_deriv_prim(
+                            * evaluate_deriv_prim(
                                 np.array([2, 3, 4]),
                                 orders,
                                 np.array([0.5, 1, 1.5]),
@@ -556,7 +557,7 @@ def test_eval_deriv_generalized_contraction():
                         ],
                         [
                             5
-                            * eval_deriv_prim(
+                            * evaluate_deriv_prim(
                                 np.array([2, 3, 4]),
                                 orders,
                                 np.array([0.5, 1, 1.5]),
@@ -564,7 +565,7 @@ def test_eval_deriv_generalized_contraction():
                                 1,
                             )
                             + 8
-                            * eval_deriv_prim(
+                            * evaluate_deriv_prim(
                                 np.array([2, 3, 4]),
                                 orders,
                                 np.array([0.5, 1, 1.5]),
@@ -572,7 +573,7 @@ def test_eval_deriv_generalized_contraction():
                                 2,
                             ),
                             5
-                            * eval_deriv_prim(
+                            * evaluate_deriv_prim(
                                 np.array([2, 3, 4]),
                                 orders,
                                 np.array([0.5, 1, 1.5]),
@@ -580,7 +581,7 @@ def test_eval_deriv_generalized_contraction():
                                 1,
                             )
                             + 8
-                            * eval_deriv_prim(
+                            * evaluate_deriv_prim(
                                 np.array([2, 3, 4]),
                                 orders,
                                 np.array([0.5, 1, 1.5]),

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -9,7 +9,7 @@ from scipy.special import factorial2
 from utils import find_datafile
 
 
-def test_eval_construct_array_contraction():
+def test_evaluate_construct_array_contraction():
     """Test gbasis.eval.Eval.construct_array_contraction."""
     test = GeneralizedContractionShell(
         1, np.array([0.5, 1, 1.5]), np.array([1.0, 2.0]), np.array([0.1, 0.01])
@@ -59,9 +59,9 @@ def test_evaluate_basis_cartesian():
         test_basis = f.read()
     basis_dict = parse_nwchem(test_basis)
     basis = make_contractions(basis_dict, ["H"], np.array([[0, 0, 0]]))
-    eval_obj = Eval(basis)
+    evaluate_obj = Eval(basis)
     assert np.allclose(
-        eval_obj.construct_array_cartesian(points=np.array([[0, 0, 0]])),
+        evaluate_obj.construct_array_cartesian(points=np.array([[0, 0, 0]])),
         evaluate_basis(basis, np.array([[0, 0, 0]]), coord_type="cartesian"),
     )
 
@@ -74,23 +74,23 @@ def test_evaluate_basis_spherical():
 
     # cartesian and spherical are the same for s orbital
     basis = make_contractions(basis_dict, ["H"], np.array([[0, 0, 0]]))
-    eval_obj = Eval(basis)
+    evaluate_obj = Eval(basis)
     assert np.allclose(
-        eval_obj.construct_array_cartesian(points=np.array([[0, 0, 0]])),
+        evaluate_obj.construct_array_cartesian(points=np.array([[0, 0, 0]])),
         evaluate_basis(basis, np.array([[0, 0, 0]]), coord_type="spherical"),
     )
     # p orbitals are zero at center
     basis = make_contractions(basis_dict, ["Li"], np.array([[0, 0, 0]]))
-    eval_obj = Eval(basis)
+    evaluate_obj = Eval(basis)
     assert np.allclose(
-        eval_obj.construct_array_cartesian(points=np.array([[0, 0, 0]])),
+        evaluate_obj.construct_array_cartesian(points=np.array([[0, 0, 0]])),
         evaluate_basis(basis, np.array([[0, 0, 0]]), coord_type="spherical"),
     )
 
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
-    eval_obj = Eval(basis)
+    evaluate_obj = Eval(basis)
     assert np.allclose(
-        eval_obj.construct_array_spherical(points=np.array([[1, 1, 1]])),
+        evaluate_obj.construct_array_spherical(points=np.array([[1, 1, 1]])),
         evaluate_basis(basis, np.array([[1, 1, 1]]), coord_type="spherical"),
     )
 
@@ -129,9 +129,9 @@ def test_evaluate_basis_lincomb():
         test_basis = f.read()
     basis_dict = parse_nwchem(test_basis)
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
-    eval_obj = Eval(basis)
+    evaluate_obj = Eval(basis)
     transform = np.random.rand(14, 18)
     assert np.allclose(
-        eval_obj.construct_array_lincomb(transform, "spherical", points=np.array([[1, 1, 1]])),
+        evaluate_obj.construct_array_lincomb(transform, "spherical", points=np.array([[1, 1, 1]])),
         evaluate_basis(basis, np.array([[1, 1, 1]]), transform=transform, coord_type="spherical"),
     )

--- a/tests/test_eval_deriv.py
+++ b/tests/test_eval_deriv.py
@@ -1,4 +1,4 @@
-"""Test gbasis.eval_deriv."""
+"""Test gbasis.evaluate_deriv."""
 import itertools as it
 
 from gbasis._deriv import _eval_deriv_contractions
@@ -11,8 +11,8 @@ from scipy.special import factorial2
 from utils import find_datafile
 
 
-def test_eval_deriv_construct_array_contraction():
-    """Test gbasis.eval_deriv.EvalDeriv.construct_array_contraction."""
+def test_evaluate_deriv_construct_array_contraction():
+    """Test gbasis.evaluate_deriv.EvalDeriv.construct_array_contraction."""
     points = np.array([[2, 3, 4]])
     orders = np.array([0, 0, 0])
     contractions = GeneralizedContractionShell(
@@ -134,9 +134,9 @@ def test_evaluate_deriv_basis_cartesian():
         test_basis = f.read()
     basis_dict = parse_nwchem(test_basis)
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
-    eval_obj = EvalDeriv(basis)
+    evaluate_obj = EvalDeriv(basis)
     assert np.allclose(
-        eval_obj.construct_array_cartesian(
+        evaluate_obj.construct_array_cartesian(
             points=np.array([[1, 1, 1]]), orders=np.array([0, 0, 0])
         ),
         evaluate_deriv_basis(
@@ -144,7 +144,7 @@ def test_evaluate_deriv_basis_cartesian():
         ),
     )
     assert np.allclose(
-        eval_obj.construct_array_cartesian(
+        evaluate_obj.construct_array_cartesian(
             points=np.array([[1, 1, 1]]), orders=np.array([2, 1, 0])
         ),
         evaluate_deriv_basis(
@@ -159,9 +159,9 @@ def test_evaluate_deriv_basis_spherical():
         test_basis = f.read()
     basis_dict = parse_nwchem(test_basis)
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
-    eval_obj = EvalDeriv(basis)
+    evaluate_obj = EvalDeriv(basis)
     assert np.allclose(
-        eval_obj.construct_array_spherical(
+        evaluate_obj.construct_array_spherical(
             points=np.array([[1, 1, 1]]), orders=np.array([0, 0, 0])
         ),
         evaluate_deriv_basis(
@@ -169,7 +169,7 @@ def test_evaluate_deriv_basis_spherical():
         ),
     )
     assert np.allclose(
-        eval_obj.construct_array_spherical(
+        evaluate_obj.construct_array_spherical(
             points=np.array([[1, 1, 1]]), orders=np.array([2, 1, 0])
         ),
         evaluate_deriv_basis(
@@ -184,9 +184,9 @@ def test_evaluate_deriv_basis_mix():
         test_basis = f.read()
     basis_dict = parse_nwchem(test_basis)
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
-    eval_obj = EvalDeriv(basis)
+    evaluate_obj = EvalDeriv(basis)
     assert np.allclose(
-        eval_obj.construct_array_mix(
+        evaluate_obj.construct_array_mix(
             ["cartesian"] * 8, points=np.array([[1, 1, 1]]), orders=np.array([0, 0, 0])
         ),
         evaluate_deriv_basis(
@@ -194,7 +194,7 @@ def test_evaluate_deriv_basis_mix():
         ),
     )
     assert np.allclose(
-        eval_obj.construct_array_mix(
+        evaluate_obj.construct_array_mix(
             ["spherical"] * 8, points=np.array([[1, 1, 1]]), orders=np.array([2, 1, 0])
         ),
         evaluate_deriv_basis(
@@ -209,11 +209,11 @@ def test_evaluate_deriv_basis_lincomb():
         test_basis = f.read()
     basis_dict = parse_nwchem(test_basis)
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
-    eval_obj = EvalDeriv(basis)
+    evaluate_obj = EvalDeriv(basis)
     cart_transform = np.random.rand(14, 19)
     sph_transform = np.random.rand(14, 18)
     assert np.allclose(
-        eval_obj.construct_array_lincomb(
+        evaluate_obj.construct_array_lincomb(
             cart_transform, "cartesian", points=np.array([[1, 1, 1]]), orders=np.array([0, 0, 0])
         ),
         evaluate_deriv_basis(
@@ -225,7 +225,7 @@ def test_evaluate_deriv_basis_lincomb():
         ),
     )
     assert np.allclose(
-        eval_obj.construct_array_lincomb(
+        evaluate_obj.construct_array_lincomb(
             sph_transform, "spherical", points=np.array([[1, 1, 1]]), orders=np.array([2, 1, 0])
         ),
         evaluate_deriv_basis(

--- a/tests/test_stress_tensor.py
+++ b/tests/test_stress_tensor.py
@@ -1,18 +1,22 @@
 """Test gbasis.stress_tensor."""
 from gbasis.density import (
-    eval_density_laplacian,
-    eval_deriv_density,
-    eval_deriv_reduced_density_matrix,
+    evaluate_density_laplacian,
+    evaluate_deriv_density,
+    evaluate_deriv_reduced_density_matrix,
 )
 from gbasis.parsers import make_contractions, parse_nwchem
-from gbasis.stress_tensor import eval_ehrenfest_force, eval_ehrenfest_hessian, eval_stress_tensor
+from gbasis.stress_tensor import (
+    evaluate_ehrenfest_force,
+    evaluate_ehrenfest_hessian,
+    evaluate_stress_tensor,
+)
 import numpy as np
 import pytest
 from utils import find_datafile, HortonContractions
 
 
-def test_eval_stress_tensor():
-    """Test gbasis.stress_tensor.eval_stress_tensor."""
+def test_evaluate_stress_tensor():
+    """Test gbasis.stress_tensor.evaluate_stress_tensor."""
     with open(find_datafile("data_anorcc.nwchem"), "r") as f:
         test_basis = f.read()
     basis_dict = parse_nwchem(test_basis)
@@ -21,16 +25,16 @@ def test_eval_stress_tensor():
     points = np.random.rand(10, 3)
 
     with pytest.raises(TypeError):
-        eval_stress_tensor(np.identity(40), basis, points, np.array(0), 0, np.identity(40))
+        evaluate_stress_tensor(np.identity(40), basis, points, np.array(0), 0, np.identity(40))
     with pytest.raises(TypeError):
-        eval_stress_tensor(np.identity(40), basis, points, 1, None, np.identity(40))
+        evaluate_stress_tensor(np.identity(40), basis, points, 1, None, np.identity(40))
     with pytest.raises(TypeError):
-        eval_stress_tensor(np.identity(40), basis, points, 1, 0j, np.identity(40))
+        evaluate_stress_tensor(np.identity(40), basis, points, 1, 0j, np.identity(40))
 
-    test_a = eval_stress_tensor(np.identity(40), basis, points, 0, 0, np.identity(40))
-    test_b = eval_stress_tensor(np.identity(40), basis, points, 1, 0, np.identity(40))
-    test_c = eval_stress_tensor(np.identity(40), basis, points, 1, 2, np.identity(40))
-    test_d = eval_stress_tensor(np.identity(40), basis, points, 0.5, 2, np.identity(40))
+    test_a = evaluate_stress_tensor(np.identity(40), basis, points, 0, 0, np.identity(40))
+    test_b = evaluate_stress_tensor(np.identity(40), basis, points, 1, 0, np.identity(40))
+    test_c = evaluate_stress_tensor(np.identity(40), basis, points, 1, 2, np.identity(40))
+    test_d = evaluate_stress_tensor(np.identity(40), basis, points, 0.5, 2, np.identity(40))
     for i in range(3):
         for j in range(3):
             orders_i = np.array([0, 0, 0])
@@ -38,13 +42,13 @@ def test_eval_stress_tensor():
             orders_j = np.array([0, 0, 0])
             orders_j[j] += 1
 
-            temp1 = eval_deriv_reduced_density_matrix(
+            temp1 = evaluate_deriv_reduced_density_matrix(
                 orders_i, orders_j, np.identity(40), basis, points, np.identity(40)
             )
-            temp2 = eval_deriv_reduced_density_matrix(
+            temp2 = evaluate_deriv_reduced_density_matrix(
                 orders_j, orders_i, np.identity(40), basis, points, np.identity(40)
             )
-            temp3 = eval_deriv_reduced_density_matrix(
+            temp3 = evaluate_deriv_reduced_density_matrix(
                 orders_i + orders_j,
                 np.array([0, 0, 0]),
                 np.identity(40),
@@ -52,7 +56,7 @@ def test_eval_stress_tensor():
                 points,
                 np.identity(40),
             )
-            temp4 = eval_deriv_reduced_density_matrix(
+            temp4 = evaluate_deriv_reduced_density_matrix(
                 orders_i + orders_j,
                 np.array([0, 0, 0]),
                 np.identity(40),
@@ -61,7 +65,7 @@ def test_eval_stress_tensor():
                 np.identity(40),
             )
             if i == j:
-                temp5 = eval_density_laplacian(np.identity(40), basis, points, np.identity(40))
+                temp5 = evaluate_density_laplacian(np.identity(40), basis, points, np.identity(40))
             else:
                 temp5 = 0
             assert np.allclose(test_a[:, i, j], 0.5 * temp3 + 0.5 * temp4)
@@ -72,8 +76,8 @@ def test_eval_stress_tensor():
             )
 
 
-def test_eval_ehrenfest_force():
-    """Test gbasis.stress_tensor.eval_ehrenfest_force."""
+def test_evaluate_ehrenfest_force():
+    """Test gbasis.stress_tensor.evaluate_ehrenfest_force."""
     with open(find_datafile("data_anorcc.nwchem"), "r") as f:
         test_basis = f.read()
     basis_dict = parse_nwchem(test_basis)
@@ -82,16 +86,16 @@ def test_eval_ehrenfest_force():
     points = np.random.rand(10, 3)
 
     with pytest.raises(TypeError):
-        eval_ehrenfest_force(np.identity(40), basis, points, np.array(0), 0, np.identity(40))
+        evaluate_ehrenfest_force(np.identity(40), basis, points, np.array(0), 0, np.identity(40))
     with pytest.raises(TypeError):
-        eval_ehrenfest_force(np.identity(40), basis, points, 1, None, np.identity(40))
+        evaluate_ehrenfest_force(np.identity(40), basis, points, 1, None, np.identity(40))
     with pytest.raises(TypeError):
-        eval_ehrenfest_force(np.identity(40), basis, points, 1, 0j, np.identity(40))
+        evaluate_ehrenfest_force(np.identity(40), basis, points, 1, 0j, np.identity(40))
 
-    test_a = eval_ehrenfest_force(np.identity(40), basis, points, 0, 0, np.identity(40))
-    test_b = eval_ehrenfest_force(np.identity(40), basis, points, 1, 0, np.identity(40))
-    test_c = eval_ehrenfest_force(np.identity(40), basis, points, 0.5, 0, np.identity(40))
-    test_d = eval_ehrenfest_force(np.identity(40), basis, points, 0, 2, np.identity(40))
+    test_a = evaluate_ehrenfest_force(np.identity(40), basis, points, 0, 0, np.identity(40))
+    test_b = evaluate_ehrenfest_force(np.identity(40), basis, points, 1, 0, np.identity(40))
+    test_c = evaluate_ehrenfest_force(np.identity(40), basis, points, 0.5, 0, np.identity(40))
+    test_d = evaluate_ehrenfest_force(np.identity(40), basis, points, 0, 2, np.identity(40))
     for j in range(3):
         ref_a = np.zeros(points.shape[0])
         ref_b = np.zeros(points.shape[0])
@@ -104,13 +108,13 @@ def test_eval_ehrenfest_force():
             orders_i = np.array([0, 0, 0])
             orders_i[i] += 1
 
-            temp1 = eval_deriv_reduced_density_matrix(
+            temp1 = evaluate_deriv_reduced_density_matrix(
                 2 * orders_i, orders_j, np.identity(40), basis, points, np.identity(40)
             )
-            temp2 = eval_deriv_reduced_density_matrix(
+            temp2 = evaluate_deriv_reduced_density_matrix(
                 orders_i, orders_i + orders_j, np.identity(40), basis, points, np.identity(40)
             )
-            temp3 = eval_deriv_reduced_density_matrix(
+            temp3 = evaluate_deriv_reduced_density_matrix(
                 2 * orders_i + orders_j,
                 np.array([0, 0, 0]),
                 np.identity(40),
@@ -118,10 +122,10 @@ def test_eval_ehrenfest_force():
                 points,
                 np.identity(40),
             )
-            temp4 = eval_deriv_reduced_density_matrix(
+            temp4 = evaluate_deriv_reduced_density_matrix(
                 orders_i + orders_j, orders_i, np.identity(40), basis, points, np.identity(40)
             )
-            temp5 = eval_deriv_density(
+            temp5 = evaluate_deriv_density(
                 2 * orders_i + orders_j, np.identity(40), basis, points, np.identity(40)
             )
 
@@ -135,8 +139,8 @@ def test_eval_ehrenfest_force():
         assert np.allclose(test_d[:, j], ref_d)
 
 
-def test_eval_ehrenfest_hessian():
-    """Test gbasis.stress_tensor.eval_ehrenfest_hessian."""
+def test_evaluate_ehrenfest_hessian():
+    """Test gbasis.stress_tensor.evaluate_ehrenfest_hessian."""
     with open(find_datafile("data_anorcc.nwchem"), "r") as f:
         test_basis = f.read()
     basis_dict = parse_nwchem(test_basis)
@@ -147,16 +151,16 @@ def test_eval_ehrenfest_hessian():
     points = np.random.rand(10, 3)
 
     with pytest.raises(TypeError):
-        eval_ehrenfest_hessian(np.identity(40), basis, points, np.array(0), 0, np.identity(40))
+        evaluate_ehrenfest_hessian(np.identity(40), basis, points, np.array(0), 0, np.identity(40))
     with pytest.raises(TypeError):
-        eval_ehrenfest_hessian(np.identity(40), basis, points, 1, None, np.identity(40))
+        evaluate_ehrenfest_hessian(np.identity(40), basis, points, 1, None, np.identity(40))
     with pytest.raises(TypeError):
-        eval_ehrenfest_hessian(np.identity(40), basis, points, 1, 0j, np.identity(40))
+        evaluate_ehrenfest_hessian(np.identity(40), basis, points, 1, 0j, np.identity(40))
 
-    test_a = eval_ehrenfest_hessian(np.identity(40), basis, points, 0, 0, np.identity(40))
-    test_b = eval_ehrenfest_hessian(np.identity(40), basis, points, 1, 0, np.identity(40))
-    test_c = eval_ehrenfest_hessian(np.identity(40), basis, points, 0.5, 0, np.identity(40))
-    test_d = eval_ehrenfest_hessian(np.identity(40), basis, points, 0, 2, np.identity(40))
+    test_a = evaluate_ehrenfest_hessian(np.identity(40), basis, points, 0, 0, np.identity(40))
+    test_b = evaluate_ehrenfest_hessian(np.identity(40), basis, points, 1, 0, np.identity(40))
+    test_c = evaluate_ehrenfest_hessian(np.identity(40), basis, points, 0.5, 0, np.identity(40))
+    test_d = evaluate_ehrenfest_hessian(np.identity(40), basis, points, 0, 2, np.identity(40))
     for j in range(3):
         for k in range(3):
             ref_a = np.zeros(points.shape[0])
@@ -172,7 +176,7 @@ def test_eval_ehrenfest_hessian():
                 orders_i = np.array([0, 0, 0])
                 orders_i[i] += 1
 
-                temp1 = eval_deriv_reduced_density_matrix(
+                temp1 = evaluate_deriv_reduced_density_matrix(
                     2 * orders_i + orders_k,
                     orders_j,
                     np.identity(40),
@@ -180,7 +184,7 @@ def test_eval_ehrenfest_hessian():
                     points,
                     np.identity(40),
                 )
-                temp2 = eval_deriv_reduced_density_matrix(
+                temp2 = evaluate_deriv_reduced_density_matrix(
                     2 * orders_i,
                     orders_j + orders_k,
                     np.identity(40),
@@ -188,7 +192,7 @@ def test_eval_ehrenfest_hessian():
                     points,
                     np.identity(40),
                 )
-                temp3 = eval_deriv_reduced_density_matrix(
+                temp3 = evaluate_deriv_reduced_density_matrix(
                     orders_i + orders_k,
                     orders_i + orders_j,
                     np.identity(40),
@@ -196,7 +200,7 @@ def test_eval_ehrenfest_hessian():
                     points,
                     np.identity(40),
                 )
-                temp4 = eval_deriv_reduced_density_matrix(
+                temp4 = evaluate_deriv_reduced_density_matrix(
                     orders_i,
                     orders_i + orders_j + orders_k,
                     np.identity(40),
@@ -204,7 +208,7 @@ def test_eval_ehrenfest_hessian():
                     points,
                     np.identity(40),
                 )
-                temp5 = eval_deriv_reduced_density_matrix(
+                temp5 = evaluate_deriv_reduced_density_matrix(
                     2 * orders_i + orders_j + orders_k,
                     np.array([0, 0, 0]),
                     np.identity(40),
@@ -212,7 +216,7 @@ def test_eval_ehrenfest_hessian():
                     points,
                     np.identity(40),
                 )
-                temp6 = eval_deriv_reduced_density_matrix(
+                temp6 = evaluate_deriv_reduced_density_matrix(
                     2 * orders_i + orders_j,
                     orders_k,
                     np.identity(40),
@@ -220,7 +224,7 @@ def test_eval_ehrenfest_hessian():
                     points,
                     np.identity(40),
                 )
-                temp7 = eval_deriv_reduced_density_matrix(
+                temp7 = evaluate_deriv_reduced_density_matrix(
                     orders_i + orders_j + orders_k,
                     orders_i,
                     np.identity(40),
@@ -228,7 +232,7 @@ def test_eval_ehrenfest_hessian():
                     points,
                     np.identity(40),
                 )
-                temp8 = eval_deriv_reduced_density_matrix(
+                temp8 = evaluate_deriv_reduced_density_matrix(
                     orders_i + orders_j,
                     orders_i + orders_k,
                     np.identity(40),
@@ -236,7 +240,7 @@ def test_eval_ehrenfest_hessian():
                     points,
                     np.identity(40),
                 )
-                temp9 = eval_deriv_density(
+                temp9 = evaluate_deriv_density(
                     2 * orders_i + orders_j + orders_k,
                     np.identity(40),
                     basis,
@@ -262,13 +266,15 @@ def test_eval_ehrenfest_hessian():
             assert np.allclose(test_c[:, j, k], ref_c)
             assert np.allclose(test_d[:, j, k], ref_d)
     assert np.allclose(
-        eval_ehrenfest_hessian(
+        evaluate_ehrenfest_hessian(
             np.identity(40), basis, points, 0, 0, np.identity(40), symmetric=True
         ),
         (
-            eval_ehrenfest_hessian(np.identity(40), basis, points, 0, 0, np.identity(40))
+            evaluate_ehrenfest_hessian(np.identity(40), basis, points, 0, 0, np.identity(40))
             + np.swapaxes(
-                eval_ehrenfest_hessian(np.identity(40), basis, points, 0, 0, np.identity(40)), 1, 2
+                evaluate_ehrenfest_hessian(np.identity(40), basis, points, 0, 0, np.identity(40)),
+                1,
+                2,
             )
         )
         / 2,


### PR DESCRIPTION
For consistency, evaluate_ is used to denote functions that evaluate across a
set of points, rather than eval_. (because evaluate_ is more readable)