### PR TITLE
Change input of parsers from file content to file path

### DIFF
--- a/docs/notes.tex
+++ b/docs/notes.tex
@@ -334,18 +334,14 @@ Supposed we have the following system:
   \begin{lstlisting}[xleftmargin=-25pt]
 from gbasis.parsers import parse_gbs, make_contractions
 
-with open("from_basissetexchange.gbs", "r")as f:
-all_basis = f.read()
-all_basis_dict = parse_gbs(all_basis)
+all_basis_dict = parse_gbs("./path/to/from_basissetexchange.gbs")
 basis = make_contractions(all_basis_dict, atoms, coords)
 \end{lstlisting}
 \item To build a basis set from nwchem file for the given atoms and coordinates,
   \begin{lstlisting}[xleftmargin=-25pt]
 from gbasis.parsers import parse_nwchem, make_contractions
 
-with open("from_basissetexchange.nwchem", "r")as f:
-all_basis = f.read()
-all_basis_dict = parse_gbs(all_basis)
+all_basis_dict = parse_nwchem("./path/to/from_basissetexchange.nwchem")
 basis = make_contractions(all_basis_dict, atoms, coords)
 \end{lstlisting}
 \end{itemize}

--- a/gbasis/parsers.py
+++ b/gbasis/parsers.py
@@ -5,13 +5,13 @@ from gbasis.contractions import GeneralizedContractionShell
 import numpy as np
 
 
-def parse_nwchem(nwchem_basis):
+def parse_nwchem(nwchem_basis_file):
     """Parse nwchem basis set file.
 
     Parameters
     ----------
-    nwchem_basis : str
-        Contents of the nwchem basis set file.
+    nwchem_basis_file : str
+        Path to the nwchem basis set file.
 
     Returns
     -------
@@ -26,6 +26,9 @@ def parse_nwchem(nwchem_basis):
 
     """
     # pylint: disable=R0914
+    with open(nwchem_basis_file, "r") as basis_fh:
+        nwchem_basis = basis_fh.read()
+
     data = re.split(r"\n\s*(\w[\w]?)[ ]+(\w+)\s*\n", nwchem_basis)
     dict_angmom = {"s": 0, "p": 1, "d": 2, "f": 3, "g": 4, "h": 5, "i": 6, "k": 7}
     # remove first part
@@ -68,13 +71,13 @@ def parse_nwchem(nwchem_basis):
     return output
 
 
-def parse_gbs(gbs_basis):
+def parse_gbs(gbs_basis_file):
     """Parse Gaussian94 basis set file.
 
     Parameters
     ----------
-    gbs_basis : str
-        Contents of the Gaussian94 basis set file.
+    gbs_basis_file : str
+        Path to the Gaussian94 basis set file.
 
     Returns
     -------
@@ -94,6 +97,9 @@ def parse_gbs(gbs_basis):
 
     """
     # pylint: disable=R0914
+    with open(gbs_basis_file, "r") as basis_fh:
+        gbs_basis = basis_fh.read()
+
     data = re.split(r"\n\s*(\w[\w]?)\s+\w+\s*\n", gbs_basis)
     dict_angmom = {"s": 0, "p": 1, "d": 2, "f": 3, "g": 4, "h": 5, "i": 6, "k": 7}
     # remove first part

--- a/tests/test_angular_momentum.py
+++ b/tests/test_angular_momentum.py
@@ -366,9 +366,7 @@ def test_angular_momentum_construct_array_contraction():
 
 def test_angular_momentum_integral_cartesian():
     """Test gbasis.angular_momentum.angular_momentum_integral_cartesian."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     angular_momentum_integral_obj = AngularMomentumIntegral(basis)
     assert np.allclose(
@@ -379,9 +377,7 @@ def test_angular_momentum_integral_cartesian():
 
 def test_angular_momentum_integral_spherical():
     """Test gbasis.angular_momentum.angular_momentum_integral_spherical."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
 
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     angular_momentum_integral_obj = AngularMomentumIntegral(basis)
@@ -393,9 +389,7 @@ def test_angular_momentum_integral_spherical():
 
 def test_angular_momentum_integral_mix():
     """Test gbasis.angular_momentum.angular_momentum_integral_mix."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
 
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     angular_momentum_integral_obj = AngularMomentumIntegral(basis)
@@ -407,9 +401,7 @@ def test_angular_momentum_integral_mix():
 
 def test_angular_momentum_integral_lincomb():
     """Test gbasis.angular_momentum.angular_momentum_integral_lincomb."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     angular_momentum_integral_obj = AngularMomentumIntegral(basis)
     transform = np.random.rand(14, 18)

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -62,9 +62,7 @@ def test_evaluate_density_using_evaluated_orbs():
 
 def test_evaluate_density():
     """Test gbasis.density.evaluate_density."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     transform = np.random.rand(14, 18)
     density = np.random.rand(14, 14)
@@ -80,9 +78,7 @@ def test_evaluate_density():
 
 def test_evaluate_deriv_density():
     """Test gbasis.density.evaluate_deriv_density."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     transform = np.random.rand(14, 18)
     density = np.random.rand(14, 14)
@@ -226,9 +222,7 @@ def test_evaluate_deriv_density():
 
 def test_evaluate_density_gradient():
     """Test gbasis.density.evaluate_density_gradient."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     transform = np.random.rand(14, 18)
     density = np.random.rand(14, 14)
@@ -286,9 +280,7 @@ def test_evaluate_density_horton():
     The test case is diatomic with H and He separated by 0.8 angstroms with basis set ANO-RCC.
 
     """
-    with open(find_datafile("data_anorcc.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_anorcc.nwchem"))
     # NOTE: used HORTON's conversion factor for angstroms to bohr
     points = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
     basis = make_contractions(basis_dict, ["H", "He"], points)
@@ -311,9 +303,7 @@ def test_evaluate_density_gradient_horton():
     The test case is diatomic with H and He separated by 0.8 angstroms with basis set ANO-RCC.
 
     """
-    with open(find_datafile("data_anorcc.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_anorcc.nwchem"))
     # NOTE: used HORTON's conversion factor for angstroms to bohr
     points = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
     basis = make_contractions(basis_dict, ["H", "He"], points)
@@ -337,9 +327,7 @@ def test_evaluate_hessian_deriv_horton():
     The test case is diatomic with H and He separated by 0.8 angstroms with basis set ANO-RCC.
 
     """
-    with open(find_datafile("data_anorcc.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_anorcc.nwchem"))
     # NOTE: used HORTON's conversion factor for angstroms to bohr
     points = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
     basis = make_contractions(basis_dict, ["H", "He"], points)
@@ -369,9 +357,7 @@ def test_evaluate_laplacian_deriv_horton():
     The test case is diatomic with H and He separated by 0.8 angstroms with basis set ANO-RCC.
 
     """
-    with open(find_datafile("data_anorcc.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_anorcc.nwchem"))
     # NOTE: used HORTON's conversion factor for angstroms to bohr
     points = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
     basis = make_contractions(basis_dict, ["H", "He"], points)
@@ -395,9 +381,7 @@ def test_evaluate_posdef_kinetic_energy_density():
     The test case is diatomic with H and He separated by 0.8 angstroms with basis set ANO-RCC.
 
     """
-    with open(find_datafile("data_anorcc.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_anorcc.nwchem"))
     # NOTE: used HORTON's conversion factor for angstroms to bohr
     points = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
     basis = make_contractions(basis_dict, ["H", "He"], points)
@@ -425,9 +409,7 @@ def test_evaluate_general_kinetic_energy_density_horton():
     It's actually just testing posdef part.
 
     """
-    with open(find_datafile("data_anorcc.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_anorcc.nwchem"))
     # NOTE: used HORTON's conversion factor for angstroms to bohr
     points = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
     basis = make_contractions(basis_dict, ["H", "He"], points)
@@ -451,9 +433,7 @@ def test_evaluate_general_kinetic_energy_density_horton():
 
 def test_evaluate_general_kinetic_energy_density():
     """Test gbasis.kinetic_energy.evaluate_general_kinetic_energy_density."""
-    with open(find_datafile("data_anorcc.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_anorcc.nwchem"))
     points = np.array([[0, 0, 0]])
     basis = make_contractions(basis_dict, ["H"], points)
     points = np.random.rand(10, 3)

--- a/tests/test_electron_repulsion.py
+++ b/tests/test_electron_repulsion.py
@@ -94,9 +94,7 @@ def test_electron_repulsion_cartesian_horton_sto6g_bec():
     that ano-rcc was not used because it results in overflow in the _compute_two_electron_integrals.
 
     """
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     coords = np.array([[0, 0, 0], [1.0, 0, 0]])
     basis = make_contractions(basis_dict, ["Be", "C"], coords)
     basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps) for i in basis]
@@ -117,9 +115,7 @@ def test_electron_repulsion_cartesian_horton_custom_hhe():
     This test is also slow.
 
     """
-    with open(find_datafile("data_anorcc.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_anorcc.nwchem"))
     coords = np.array([[0, 0, 0], [0.8, 0, 0]])
     basis = make_contractions(basis_dict, ["H", "He"], coords)
     basis = [HortonContractions(i.angmom, i.coord, i.coeffs[:, 0], i.exps) for i in basis[:8]]
@@ -140,9 +136,7 @@ def test_electron_repulsion_cartesian_horton_custom_hhe():
 
 def test_electron_repulsion_cartesian():
     """Test gbasis.electron_repulsion.electron_repulsion_cartesian."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["C"], np.array([[0, 0, 0]]))
 
     erep_obj = ElectronRepulsionIntegral(basis)
@@ -160,9 +154,7 @@ def test_electron_repulsion_cartesian():
 
 def test_electron_repulsion_spherical():
     """Test gbasis.electron_repulsion.electron_repulsion_spherical."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["C"], np.array([[0, 0, 0]]))
 
     erep_obj = ElectronRepulsionIntegral(basis)
@@ -180,9 +172,7 @@ def test_electron_repulsion_spherical():
 
 def test_electron_repulsion_mix():
     """Test gbasis.electron_repulsion.electron_repulsion_mix."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["C"], np.array([[0, 0, 0]]))
 
     erep_obj = ElectronRepulsionIntegral(basis)
@@ -200,9 +190,7 @@ def test_electron_repulsion_mix():
 
 def test_electron_repulsion_lincomb():
     """Test gbasis.electron_repulsion.electron_repulsion_lincomb."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["C"], np.array([[0, 0, 0]]))
 
     erep_obj = ElectronRepulsionIntegral(basis)

--- a/tests/test_electrostatic_potential.py
+++ b/tests/test_electrostatic_potential.py
@@ -12,9 +12,7 @@ def test_electrostatic_potential():
     Tested by using point_charge.point_charge_cartesian.
 
     """
-    with open(find_datafile("data_anorcc.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_anorcc.nwchem"))
     coords = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
     basis = make_contractions(basis_dict, ["H", "He"], coords)
     basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps) for i in basis]
@@ -164,9 +162,7 @@ def test_electrostatic_potential_cartesian():
     Density matrix is an identity matrix.
 
     """
-    with open(find_datafile("data_anorcc.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_anorcc.nwchem"))
     # NOTE: used HORTON's conversion factor for angstroms to bohr
     coords = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
     basis = make_contractions(basis_dict, ["H", "He"], coords)
@@ -192,9 +188,7 @@ def test_electrostatic_potential_spherical():
     Density matrix is an identity matrix.
 
     """
-    with open(find_datafile("data_anorcc.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_anorcc.nwchem"))
     # NOTE: used HORTON's conversion factor for angstroms to bohr
     coords = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
     basis = make_contractions(basis_dict, ["H", "He"], coords)
@@ -220,9 +214,7 @@ def test_electrostatic_potential_mix():
     Density matrix is an identity matrix.
 
     """
-    with open(find_datafile("data_anorcc.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_anorcc.nwchem"))
     # NOTE: used HORTON's conversion factor for angstroms to bohr
     coords = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
     basis = make_contractions(basis_dict, ["H", "He"], coords)

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -55,9 +55,7 @@ def test_evaluate_construct_array_contraction():
 
 def test_evaluate_basis_cartesian():
     """Test gbasis.eval.evaluate_basis_cartesian."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["H"], np.array([[0, 0, 0]]))
     evaluate_obj = Eval(basis)
     assert np.allclose(
@@ -68,9 +66,7 @@ def test_evaluate_basis_cartesian():
 
 def test_evaluate_basis_spherical():
     """Test gbasis.eval.evaluate_basis_spherical."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
 
     # cartesian and spherical are the same for s orbital
     basis = make_contractions(basis_dict, ["H"], np.array([[0, 0, 0]]))
@@ -97,9 +93,7 @@ def test_evaluate_basis_spherical():
 
 def test_evaluate_basis_mix():
     """Test gbasis.eval.evaluate_basis_mix."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
 
     # cartesian and spherical are the same for s orbital
     basis = make_contractions(basis_dict, ["H"], np.array([[0, 0, 0]]))
@@ -125,9 +119,7 @@ def test_evaluate_basis_mix():
 
 def test_evaluate_basis_lincomb():
     """Test gbasis.eval.evaluate_basis_lincomb."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     evaluate_obj = Eval(basis)
     transform = np.random.rand(14, 18)

--- a/tests/test_eval_deriv.py
+++ b/tests/test_eval_deriv.py
@@ -130,9 +130,7 @@ def test_evaluate_deriv_construct_array_contraction():
 
 def test_evaluate_deriv_basis_cartesian():
     """Test gbasis.eval.evaluate_deriv_basis_cartesian."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     evaluate_obj = EvalDeriv(basis)
     assert np.allclose(
@@ -155,9 +153,7 @@ def test_evaluate_deriv_basis_cartesian():
 
 def test_evaluate_deriv_basis_spherical():
     """Test gbasis.eval.evaluate_deriv_basis_spherical."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     evaluate_obj = EvalDeriv(basis)
     assert np.allclose(
@@ -180,9 +176,7 @@ def test_evaluate_deriv_basis_spherical():
 
 def test_evaluate_deriv_basis_mix():
     """Test gbasis.eval.evaluate_deriv_basis_mix."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     evaluate_obj = EvalDeriv(basis)
     assert np.allclose(
@@ -205,9 +199,7 @@ def test_evaluate_deriv_basis_mix():
 
 def test_evaluate_deriv_basis_lincomb():
     """Test gbasis.eval.evaluate_deriv_basis_lincomb."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     evaluate_obj = EvalDeriv(basis)
     cart_transform = np.random.rand(14, 19)

--- a/tests/test_kinetic_energy.py
+++ b/tests/test_kinetic_energy.py
@@ -159,9 +159,7 @@ def test_kinetic_energy_construct_array_contraction():
 
 def test_kinetic_energy_integral_cartesian():
     """Test gbasis.kinetic_energy.kinetic_energy_integral_cartesian."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     kinetic_energy_integral_obj = KineticEnergyIntegral(basis)
     assert np.allclose(
@@ -172,9 +170,7 @@ def test_kinetic_energy_integral_cartesian():
 
 def test_kinetic_energy_integral_spherical():
     """Test gbasis.kinetic_energy.kinetic_energy_integral_spherical."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
 
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     kinetic_energy_integral_obj = KineticEnergyIntegral(basis)
@@ -186,9 +182,7 @@ def test_kinetic_energy_integral_spherical():
 
 def test_kinetic_energy_integral_mix():
     """Test gbasis.kinetic_energy.kinetic_energy_integral_mix."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
 
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     kinetic_energy_integral_obj = KineticEnergyIntegral(basis)
@@ -200,9 +194,7 @@ def test_kinetic_energy_integral_mix():
 
 def test_kinetic_energy_integral_lincomb():
     """Test gbasis.kinetic_energy.kinetic_energy_integral_lincomb."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     kinetic_energy_integral_obj = KineticEnergyIntegral(basis)
     transform = np.random.rand(14, 18)
@@ -218,9 +210,7 @@ def test_kinetic_energy_integral_horton_anorcc_hhe():
     The test case is diatomic with H and He separated by 0.8 angstroms with basis set ANO-RCC.
 
     """
-    with open(find_datafile("data_anorcc.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_anorcc.nwchem"))
     # NOTE: used HORTON's conversion factor for angstroms to bohr
     basis = make_contractions(
         basis_dict, ["H", "He"], np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
@@ -241,9 +231,7 @@ def test_kinetic_energy_integral_horton_anorcc_bec():
     The test case is diatomic with Be and C separated by 1.0 angstroms with basis set ANO-RCC.
 
     """
-    with open(find_datafile("data_anorcc.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_anorcc.nwchem"))
     # NOTE: used HORTON's conversion factor for angstroms to bohr
     basis = make_contractions(
         basis_dict, ["Be", "C"], np.array([[0, 0, 0], [1.0 * 1.0 / 0.5291772083, 0, 0]])

--- a/tests/test_moment.py
+++ b/tests/test_moment.py
@@ -133,9 +133,7 @@ def test_moment_construct_array_contraction():
 
 def test_moment_cartesian():
     """Test gbasis.moment.moment_cartesian."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     moment_obj = Moment(basis)
 
@@ -181,9 +179,7 @@ def test_moment_cartesian():
 
 def test_moment_spherical():
     """Test gbasis.moment.moment_spherical."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
 
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     moment_obj = Moment(basis)
@@ -229,9 +225,7 @@ def test_moment_spherical():
 
 def test_moment_mix():
     """Test gbasis.moment.moment_mix."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
 
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     moment_obj = Moment(basis)
@@ -278,9 +272,7 @@ def test_moment_mix():
 
 def test_moment_spherical_lincomb():
     """Test gbasis.moment.moment_spherical_lincomb."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     moment_obj = Moment(basis)
     transform = np.random.rand(14, 18)

--- a/tests/test_momentum.py
+++ b/tests/test_momentum.py
@@ -161,9 +161,7 @@ def test_momentum_construct_array_contraction():
 
 def test_momentum_integral_cartesian():
     """Test gbasis.momentum.momentum_integral_cartesian."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     momentum_integral_obj = MomentumIntegral(basis)
     assert np.allclose(
@@ -174,9 +172,7 @@ def test_momentum_integral_cartesian():
 
 def test_momentum_integral_spherical():
     """Test gbasis.momentum.momentum_integral_spherical."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
 
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     momentum_integral_obj = MomentumIntegral(basis)
@@ -188,9 +184,7 @@ def test_momentum_integral_spherical():
 
 def test_momentum_integral_mix():
     """Test gbasis.momentum.momentum_integral_mix."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
 
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     momentum_integral_obj = MomentumIntegral(basis)
@@ -202,9 +196,7 @@ def test_momentum_integral_mix():
 
 def test_momentum_integral_lincomb():
     """Test gbasis.momentum.momentum_integral_lincomb."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     momentum_integral_obj = MomentumIntegral(basis)
     transform = np.random.rand(14, 18)

--- a/tests/test_nuclear_electron_attraction.py
+++ b/tests/test_nuclear_electron_attraction.py
@@ -12,9 +12,7 @@ def test_nuclear_electron_attraction_horton_anorcc_hhe():
     The test case is diatomic with H and He separated by 0.8 angstroms with basis set ANO-RCC.
 
     """
-    with open(find_datafile("data_anorcc.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_anorcc.nwchem"))
     # NOTE: used HORTON's conversion factor for angstroms to bohr
     coords = np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
     basis = make_contractions(basis_dict, ["H", "He"], coords)
@@ -35,9 +33,7 @@ def test_nuclear_electron_attraction_horton_anorcc_bec():
     The test case is diatomic with B and C separated by 1.0 angstroms with basis set ANO-RCC.
 
     """
-    with open(find_datafile("data_anorcc.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_anorcc.nwchem"))
     # NOTE: used HORTON's conversion factor for angstroms to bohr
     coords = np.array([[0, 0, 0], [1.0 * 1.0 / 0.5291772083, 0, 0]])
     basis = make_contractions(basis_dict, ["Be", "C"], coords)
@@ -54,9 +50,7 @@ def test_nuclear_electron_attraction_horton_anorcc_bec():
 
 def test_nuclear_electron_attraction_cartesian():
     """Test gbasis.nuclear_electron_attraction.nuclear_electron_attraction_cartesian."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
 
     nuclear_coords = np.random.rand(5, 3)
@@ -72,9 +66,7 @@ def test_nuclear_electron_attraction_cartesian():
 
 def test_nuclear_electron_attraction_spherical():
     """Test gbasis.nuclear_electron_attraction.nuclear_electron_attraction_spherical."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
 
     nuclear_coords = np.random.rand(5, 3)
@@ -90,9 +82,7 @@ def test_nuclear_electron_attraction_spherical():
 
 def test_nuclear_electron_attraction_mix():
     """Test gbasis.nuclear_electron_attraction.nuclear_electron_attraction_mix."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
 
     nuclear_coords = np.random.rand(5, 3)
@@ -110,9 +100,7 @@ def test_nuclear_electron_attraction_mix():
 
 def test_nuclear_electron_attraction_lincomb():
     """Test gbasis.nuclear_electron_attraction.nuclear_electron_attraction_lincomb."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
 
     nuclear_coords = np.random.rand(5, 3)

--- a/tests/test_overlap.py
+++ b/tests/test_overlap.py
@@ -73,9 +73,7 @@ def test_overlap_construct_array_contraction():
 
 def test_overlap_cartesian():
     """Test gbasis.eval.overlap_cartesian."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     overlap_obj = Overlap(basis)
     assert np.allclose(
@@ -85,9 +83,7 @@ def test_overlap_cartesian():
 
 def test_overlap_spherical():
     """Test gbasis.eval.overlap_spherical."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
 
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     overlap_obj = Overlap(basis)
@@ -98,9 +94,7 @@ def test_overlap_spherical():
 
 def test_overlap_mix():
     """Test gbasis.eval.overlap_mix."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
 
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     overlap_obj = Overlap(basis)
@@ -112,9 +106,7 @@ def test_overlap_mix():
 
 def test_overlap_lincomb():
     """Test gbasis.eval.overlap_lincomb."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     overlap_obj = Overlap(basis)
     transform = np.random.rand(14, 18)
@@ -130,9 +122,7 @@ def test_overlap_cartesian_norm_anorcc():
     The contraction coefficients in ANO-RCC is such that the cartesian contractions are normalized.
 
     """
-    with open(find_datafile("data_anorcc.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_anorcc.nwchem"))
 
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     overlap_obj = Overlap(basis)
@@ -146,9 +136,7 @@ def test_overlap_spherical_norm_sto6g():
     normalized to past 3rd decimal places.
 
     """
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
 
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     overlap_obj = Overlap(basis)
@@ -161,9 +149,7 @@ def test_overlap_spherical_norm_anorcc():
     The contraction coefficients in ANO-RCC is such that the Cartesian contractions are normalized.
 
     """
-    with open(find_datafile("data_anorcc.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_anorcc.nwchem"))
 
     basis = make_contractions(basis_dict, ["C"], np.array([[0, 0, 0]]))
     overlap_obj = Overlap(basis)
@@ -181,9 +167,7 @@ def test_overlap_cartesian_norm_sto6g():
     normalized to past 3rd decimal places.
 
     """
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
 
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     overlap_obj = Overlap(basis)
@@ -196,9 +180,7 @@ def test_overlap_horton_anorcc_hhe():
     The test case is diatomic with H and He separated by 0.8 angstroms with basis set ANO-RCC.
 
     """
-    with open(find_datafile("data_anorcc.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_anorcc.nwchem"))
     # NOTE: used HORTON's conversion factor for angstroms to bohr
     basis = make_contractions(
         basis_dict, ["H", "He"], np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
@@ -215,9 +197,7 @@ def test_overlap_horton_anorcc_bec():
     The test case is diatomic with Be and C separated by 1.0 angstroms with basis set ANO-RCC.
 
     """
-    with open(find_datafile("data_anorcc.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_anorcc.nwchem"))
     # NOTE: used HORTON's conversion factor for angstroms to bohr
     basis = make_contractions(
         basis_dict, ["Be", "C"], np.array([[0, 0, 0], [1.0 * 1.0 / 0.5291772083, 0, 0]])

--- a/tests/test_overlap_asymm.py
+++ b/tests/test_overlap_asymm.py
@@ -12,9 +12,7 @@ def test_overlap_integral_asymmetric_horton_anorcc_hhe():
     The test case is diatomic with H and He separated by 0.8 angstroms with basis set ANO-RCC.
 
     """
-    with open(find_datafile("data_anorcc.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_anorcc.nwchem"))
     # NOTE: used HORTON's conversion factor for angstroms to bohr
     basis = make_contractions(
         basis_dict, ["H", "He"], np.array([[0, 0, 0], [0.8 * 1.0 / 0.5291772083, 0, 0]])
@@ -36,9 +34,7 @@ def test_overlap_integral_asymmetric_horton_anorcc_bec():
     The test case is diatomic with Be and C separated by 1.0 angstroms with basis set ANO-RCC.
 
     """
-    with open(find_datafile("data_anorcc.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_anorcc.nwchem"))
     # NOTE: used HORTON's conversion factor for angstroms to bohr
     basis = make_contractions(
         basis_dict, ["Be", "C"], np.array([[0, 0, 0], [1.0 * 1.0 / 0.5291772083, 0, 0]])
@@ -56,9 +52,7 @@ def test_overlap_integral_asymmetric_horton_anorcc_bec():
 
 def test_overlap_integral_asymmetric_compare():
     """Test gbasis.eval.overlap against gbasis.overlap.overlap_integral."""
-    with open(find_datafile("data_anorcc.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_anorcc.nwchem"))
 
     basis = make_contractions(basis_dict, ["Kr", "Kr"], np.array([[0, 0, 0], [1.0, 0, 0]]))
     basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps) for i in basis]

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -7,9 +7,7 @@ from utils import find_datafile
 
 def test_parse_nwchem_sto6g():
     """Test gbasis.parsers.parse_nwchem for sto6g."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    test = parse_nwchem(test_basis)
+    test = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     # test specific cases
     assert len(test["H"]) == 1
     assert test["H"][0][0] == 0
@@ -199,9 +197,7 @@ def test_parse_nwchem_sto6g():
 
 def test_parse_nwchem_anorcc():
     """Test gbasis.parsers.parse_nwchem for anorcc."""
-    with open(find_datafile("data_anorcc.nwchem"), "r") as f:
-        test_basis = f.read()
-    test = parse_nwchem(test_basis)
+    test = parse_nwchem(find_datafile("data_anorcc.nwchem"))
     # test specific cases
     assert len(test["H"]) == 4
     assert test["H"][0][0] == 0
@@ -272,9 +268,7 @@ def test_parse_nwchem_anorcc():
 
 def test_parse_gbs_sto6g():
     """Test gbasis.parsers.parse_gbs for sto6g."""
-    with open(find_datafile("data_sto6g.gbs"), "r") as f:
-        test_basis = f.read()
-    test = parse_gbs(test_basis)
+    test = parse_gbs(find_datafile("data_sto6g.gbs"))
     # test specific cases
     assert len(test["H"]) == 1
     assert test["H"][0][0] == 0
@@ -464,9 +458,7 @@ def test_parse_gbs_sto6g():
 
 def test_parse_gbs_anorcc():
     """Test gbasis.parsers.parse_gbs for anorcc."""
-    with open(find_datafile("data_anorcc.gbs"), "r") as f:
-        test_basis = f.read()
-    test = parse_gbs(test_basis)
+    test = parse_gbs(find_datafile("data_anorcc.gbs"))
     # test specific cases
     assert len(test["H"]) == 4
     assert test["H"][0][0] == 0
@@ -537,9 +529,7 @@ def test_parse_gbs_anorcc():
 
 def test_make_contractions():
     """Test gbasis.contractions.make_contractions."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     with pytest.raises(TypeError):
         make_contractions(basis_dict, {"H", "H"}, np.array([[0, 0, 0], [1, 1, 1]]))
     with pytest.raises(TypeError):

--- a/tests/test_point_charge.py
+++ b/tests/test_point_charge.py
@@ -118,9 +118,7 @@ def test_construct_array_contraction():
 
 def test_point_charge_cartesian():
     """Test gbasis.point_charge.point_charge_cartesian."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     point_charge_obj = PointChargeIntegral(basis)
 
@@ -141,9 +139,7 @@ def test_point_charge_cartesian():
 
 def test_point_charge_spherical():
     """Test gbasis.point_charge.point_charge_spherical."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     point_charge_obj = PointChargeIntegral(basis)
 
@@ -164,9 +160,7 @@ def test_point_charge_spherical():
 
 def test_point_charge_mix():
     """Test gbasis.point_charge.point_charge_mix."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     point_charge_obj = PointChargeIntegral(basis)
 
@@ -182,9 +176,7 @@ def test_point_charge_mix():
 
 def test_point_charge_lincomb():
     """Test gbasis.point_charge.point_charge_lincomb."""
-    with open(find_datafile("data_sto6g.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]))
     point_charge_obj = PointChargeIntegral(basis)
 

--- a/tests/test_stress_tensor.py
+++ b/tests/test_stress_tensor.py
@@ -17,9 +17,7 @@ from utils import find_datafile, HortonContractions
 
 def test_evaluate_stress_tensor():
     """Test gbasis.stress_tensor.evaluate_stress_tensor."""
-    with open(find_datafile("data_anorcc.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_anorcc.nwchem"))
     coords = np.array([[0, 0, 0]])
     basis = make_contractions(basis_dict, ["H"], coords)
     points = np.random.rand(10, 3)
@@ -78,9 +76,7 @@ def test_evaluate_stress_tensor():
 
 def test_evaluate_ehrenfest_force():
     """Test gbasis.stress_tensor.evaluate_ehrenfest_force."""
-    with open(find_datafile("data_anorcc.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_anorcc.nwchem"))
     coords = np.array([[0, 0, 0]])
     basis = make_contractions(basis_dict, ["H"], coords)
     points = np.random.rand(10, 3)
@@ -141,9 +137,7 @@ def test_evaluate_ehrenfest_force():
 
 def test_evaluate_ehrenfest_hessian():
     """Test gbasis.stress_tensor.evaluate_ehrenfest_hessian."""
-    with open(find_datafile("data_anorcc.nwchem"), "r") as f:
-        test_basis = f.read()
-    basis_dict = parse_nwchem(test_basis)
+    basis_dict = parse_nwchem(find_datafile("data_anorcc.nwchem"))
     coords = np.array([[0, 0, 0]])
     basis = make_contractions(basis_dict, ["H"], coords)
     basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps) for i in basis]


### PR DESCRIPTION
Since almost all use cases of the parsers is with a gbs or nwchem file that is
stored outside of python, it made more sense to load the file inside the parsers
rather than outside.

1. Change argument of parse_nwchem forom nwchem_basis to nwchem_basis_file
2. Change argument of parse_gbs forom gbs_basis to gbs_basis_file
3. Make corresponding changes to tests and documentation

<!--

Thank you for submitting a PR!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing in this document:
https://github.com/theochem/gbasis/blob/master/CONTRIBUTING.md

-->

## Steps

- [x] Write a good description of what the PR does.
- [x] Add tests for each unit of code added (e.g. function, class)
- [x] Update documentation
- [x] Squash commits that can be grouped together
- [x] Rebase onto master

## Description


## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |
| ✓  | :scroll: Docs |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
