### PR TITLE
Add support for spherical s and p orbitals in iodata

### DIFF
--- a/gbasis/wrappers.py
+++ b/gbasis/wrappers.py
@@ -43,6 +43,13 @@ def from_iodata(mol):
 
     cart_conventions = {i[0]: j for i, j in molbasis.conventions.items() if i[1] == "c"}
     sph_conventions = {i[0]: j for i, j in molbasis.conventions.items() if i[1] == "p"}
+    if 0 not in sph_conventions:
+        sph_conventions[0] = ["sc0"]
+    if 1 not in sph_conventions:
+        # hard code conversion from cartesian form to spherical
+        p_orb_conversion = {"x": "pc1", "z": "pc0", "y": "ps1"}
+        # convert given cartesian ordering to spherical
+        sph_conventions[1] = [p_orb_conversion[i] for i in cart_conventions[1]]
 
     # NOTE: hard-coded angular momentum from iodata.basis.ANGMOM_CHARS
     iodata_angmom = "spdfghiklmnoqrtuvwxyzabce"

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -52,13 +52,27 @@ def test_from_iodata():
         basis[4].coeffs, np.array([0.1543289673, 0.5353281423, 0.4446345422]).reshape(-1, 1)
     )
 
-    with pytest.raises(ValueError):
-        basis[2].angmom_components_sph  # pylint: disable=W0104
     # artificially change angular momentum
+    basis[2].angmom = 0
+    assert basis[2].angmom_components_sph == (0,)
+    basis[2].angmom = 1
+    assert basis[2].angmom_components_sph == (1, -1, 0)
     basis[2].angmom = 2
     assert basis[2].angmom_components_sph == (0, 1, -1, 2, -2)
     basis[2].angmom = 3
     assert basis[2].angmom_components_sph == (0, 1, -1, 2, -2, 3, -3)
+
+    # NOTE: you shouldn't actually change the magnetic quantum number that is not compatible with
+    # the angular momentum, but we do so here to check that user input is accepted
+    mol.obasis.conventions[(0, "p")] = ["sc1"]
+    basis = from_iodata(mol)
+    basis[2].angmom = 0
+    assert basis[2].angmom_components_sph == (1,)
+
+    mol.obasis.conventions[(1, "p")] = ["pc1", "pc0", "ps1"]
+    basis = from_iodata(mol)
+    basis[2].angmom = 1
+    assert basis[2].angmom_components_sph == (1, 0, -1)
 
     with pytest.raises(ValueError):
         mol.obasis = mol.obasis._replace(primitive_normalization="L1")

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -75,6 +75,10 @@ def test_from_iodata():
     assert basis[2].angmom_components_sph == (1, 0, -1)
 
     with pytest.raises(ValueError):
+        basis[2].angmom = -1
+        basis[2].angmom_components_sph
+
+    with pytest.raises(ValueError):
         mol.obasis = mol.obasis._replace(primitive_normalization="L1")
         basis = from_iodata(mol)
 


### PR DESCRIPTION
## Steps

- [x] Write a good description of what the PR does.
- [x] Add tests for each unit of code added (e.g. function, class)
- [ ] Update documentation
- [x] Squash commits that can be grouped together
- [x] Rebase onto master

## Description
Iodata does not explicitly write out the spherical conventions for the s and p
orbitals, probably because they are easily converted into cartesian forms. I
understand that the s orbital is trivial to convert, but the the p orbitals
change ordering depending on the format. For example, if the ordering is by the
magnetic quantum number, then it would be x, z, y (or the reverse ordering).
However alphabetical ordering would result in x, y, z. I guessed that unless the
spherical ordering is given for the p orbitals, the cartesian ordering is used.

1. Add s orbital spherical orbital ordering convention in iodata wrapper
2. Add p orbital spherical orbital ordering convention in iodata wrapper
3. Add test

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Related Issue
https://github.com/theochem/iodata/issues/121

@tovrstra could I get you to confirm that in `iodata`, unless the
spherical ordering is given for the p orbitals, the cartesian ordering is used, i.e. x, y, z?