### PR TITLE
Fix ordering of the spherical contractions

### DIFF
--- a/gbasis/spherical.py
+++ b/gbasis/spherical.py
@@ -299,10 +299,10 @@ def generate_transformation(angmom, cartesian_order, spherical_order, apply_from
     }
     transform = np.zeros(((angmom + 1) * (angmom + 2) // 2, 2 * angmom + 1))
 
-    for mag in spherical_order:
+    for i, mag in enumerate(spherical_order):
         harmonic = real_solid_harmonic(angmom, mag)
         for components, coeff in harmonic.items():
-            transform[order[components], mag + angmom] = coeff
+            transform[order[components], i] = coeff
 
     # normalize
     transform *= np.sqrt(np.prod(factorial2(2 * cartesian_order - 1), axis=1))[:, np.newaxis]

--- a/tests/test_spherical.py
+++ b/tests/test_spherical.py
@@ -181,6 +181,15 @@ def test_generate_transformation_horton():
 
     Answer obtained from https://theochem.github.io/horton/2.0.1/tech_ref_gaussian_basis.html.
     """
+    answer = np.array([[1]])
+    assert np.allclose(generate_transformation(0, np.array([[0, 0, 0]]), (0,), "left"), answer)
+
+    answer = np.array([[0, 0, 1], [1, 0, 0], [0, 1, 0]])
+    assert np.allclose(
+        generate_transformation(1, np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]), (0, 1, -1), "left"),
+        answer,
+    )
+
     answer = np.array(
         [
             [-0.5, 0, 0, -0.5, 0, 1],
@@ -190,13 +199,11 @@ def test_generate_transformation_horton():
             [0, 1, 0, 0, 0, 0],
         ]
     )
-    # shuffle to have correct order
-    answer = answer[[4, 2, 0, 1, 3], :]
     assert np.allclose(
         generate_transformation(
             2,
             np.array([[2, 0, 0], [1, 1, 0], [1, 0, 1], [0, 2, 0], [0, 1, 1], [0, 0, 2]]),
-            (-2, -1, 0, 1, 2),
+            (0, 1, -1, 2, -2),
             "left",
         ),
         answer,
@@ -214,7 +221,6 @@ def test_generate_transformation_horton():
         ]
     )
     # shuffle to have correct order
-    answer = answer[[6, 4, 2, 0, 1, 3, 5], :]
     assert np.allclose(
         generate_transformation(
             3,
@@ -232,7 +238,7 @@ def test_generate_transformation_horton():
                     [0, 0, 3],
                 ]
             ),
-            (-3, -2, -1, 0, 1, 2, 3),
+            (0, 1, -1, 2, -2, 3, -3),
             "left",
         ),
         answer,


### PR DESCRIPTION
## Steps

- [x] Write a good description of what the PR does.
- [x] Add tests for each unit of code added (e.g. function, class)
- [x] Update documentation
- [x] Squash commits that can be grouped together
- [x] Rebase onto master

## Description

Even though the `spherical.generate_tranfsormation` is provided the `spherical_order` to specify the ordering of the spherical orbitals, they were not being ordered.

1. Fix ordering of spherical contractions
2. Modify test to test these cases
3. Add (commented) test for angular momentum 5 case

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
Though unrelated, a test was added for comparing transformation matrix against HORTON's (Issue #89 )