### PR TITLE
Add missing test when fixing ordering for pyscf spherical p orbitals

### DIFF
--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -75,7 +75,7 @@ def test_from_iodata():
     assert basis[2].angmom_components_sph == (1, 0, -1)
 
     with pytest.raises(ValueError):
-        basis[2].angmom = -1
+        basis[2].angmom = 10
         basis[2].angmom_components_sph
 
     with pytest.raises(ValueError):
@@ -109,3 +109,7 @@ def test_from_pyscf():
         assert np.allclose(i.exps, j.exps)
         assert np.allclose(i.coeffs, j.coeffs)
         assert np.allclose(i.norm_cont, j.norm_cont)
+
+    assert test[0].angmom_components_sph == (0,)
+    assert test[1].angmom_components_sph == (1, -1, 0)
+    assert test[2].angmom_components_sph == (-2, -1, 0, 1, 2)


### PR DESCRIPTION
Forgot to update the test.

## Steps

- [x] Write a good description of what the PR does.
- [x] Add tests for each unit of code added (e.g. function, class)
- [x] Update documentation
- [x] Squash commits that can be grouped together
- [x] Rebase onto master

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
PR #93
