### PR TITLE
Update iodata convention for pure functions

### DIFF
--- a/gbasis/wrappers.py
+++ b/gbasis/wrappers.py
@@ -44,15 +44,12 @@ def from_iodata(mol):
     cart_conventions = {i[0]: j for i, j in molbasis.conventions.items() if i[1] == "c"}
     sph_conventions = {i[0]: j for i, j in molbasis.conventions.items() if i[1] == "p"}
     if 0 not in sph_conventions:
-        sph_conventions[0] = ["sc0"]
+        sph_conventions[0] = ["c0"]
     if 1 not in sph_conventions:
         # hard code conversion from cartesian form to spherical
-        p_orb_conversion = {"x": "pc1", "z": "pc0", "y": "ps1"}
+        p_orb_conversion = {"x": "c1", "z": "c0", "y": "s1"}
         # convert given cartesian ordering to spherical
         sph_conventions[1] = [p_orb_conversion[i] for i in cart_conventions[1]]
-
-    # NOTE: hard-coded angular momentum from iodata.basis.ANGMOM_CHARS
-    iodata_angmom = "spdfghiklmnoqrtuvwxyzabce"
 
     class IODataShell(GeneralizedContractionShell):
         """Shell object that is compatible with `gbasis`' shell object.
@@ -117,15 +114,10 @@ def from_iodata(mol):
                         "Only the real solid harmonics as defined in Helgaker Section 6.4.2. is "
                         "supported."
                     )
-                if j[0] != iodata_angmom[self.angmom]:  # pragma: no cover
-                    raise NotImplementedError(
-                        "The angular momentum character, {0}, does not match up with the given "
-                        "angular momentum, {1}".format(j[0], self.angmom)
-                    )
 
-                if j[1] == "c":
+                if j[0] == "c":
                     factor = 1
-                elif j[1] == "s":
+                elif j[0] == "s":
                     factor = -1
                 else:  # pragma: no cover
                     raise ValueError(
@@ -133,7 +125,7 @@ def from_iodata(mol):
                         "or 's'."
                     )
 
-                output.append(factor * int(j[2:]))
+                output.append(factor * int(j[1:]))
 
             return tuple(output)
 

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -64,12 +64,12 @@ def test_from_iodata():
 
     # NOTE: you shouldn't actually change the magnetic quantum number that is not compatible with
     # the angular momentum, but we do so here to check that user input is accepted
-    mol.obasis.conventions[(0, "p")] = ["sc1"]
+    mol.obasis.conventions[(0, "p")] = ["c1"]
     basis = from_iodata(mol)
     basis[2].angmom = 0
     assert basis[2].angmom_components_sph == (1,)
 
-    mol.obasis.conventions[(1, "p")] = ["pc1", "pc0", "ps1"]
+    mol.obasis.conventions[(1, "p")] = ["c1", "c0", "s1"]
     basis = from_iodata(mol)
     basis[2].angmom = 1
     assert basis[2].angmom_components_sph == (1, 0, -1)


### PR DESCRIPTION

<!--

Thank you for submitting a PR!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing in this document:
https://github.com/theochem/gbasis/blob/master/CONTRIBUTING.md

-->

## Steps

- [x] Write a good description of what the PR does.
- [x] Add tests for each unit of code added (e.g. function, class)
- [x] Squash commits that can be grouped together
- [x] Rebase onto master

## Description

The angular momentum symbol was removed from the string that is used to describe
a pure function in iodata. This commit ensures that the gbasis module is
compatible with the commit https://github.com/theochem/iodata/commit/4ceb9adbf8dd3438e2e59afd1bed947c5c9abd16 of
iodata (master as of August 26, 2019).

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
Issue #78 