### PR TITLE
Do not compute transform when it is not used.

### DIFF
--- a/gbasis/base_one.py
+++ b/gbasis/base_one.py
@@ -220,19 +220,20 @@ class BaseOneIndex(BaseGaussianRelatedArray):
 
         matrices = []
         for cont, coord_type in zip(self.contractions, coord_types):
-            # get transformation from cartesian to spherical (applied to left)
-            transform = generate_transformation(
-                cont.angmom, cont.angmom_components_cart, cont.angmom_components_sph, "left"
-            )
             # evaluate the function at the given points
             matrix_contraction = self.construct_array_contraction(cont, **kwargs)
             # normalize contractions
             matrix_contraction *= cont.norm_cont.reshape(
                 *matrix_contraction.shape[:2], *[1 for _ in matrix_contraction.shape[2:]]
             )
-            # transform
-            # ASSUME array always has shape (M, L, ...)
             if coord_type == "spherical":
+                # get transformation from cartesian to spherical
+                # (applied to left), only when it is needed.
+                transform = generate_transformation(
+                    cont.angmom, cont.angmom_components_cart, cont.angmom_components_sph, "left"
+                )
+                # Apply the transform.
+                # ASSUME array always has shape (M, L, ...)
                 matrix_contraction = np.tensordot(transform, matrix_contraction, (1, 1))
                 matrix_contraction = np.swapaxes(matrix_contraction, 0, 1)
             matrix_contraction = np.concatenate(matrix_contraction, axis=0)

--- a/tests/test_base_one.py
+++ b/tests/test_base_one.py
@@ -235,10 +235,11 @@ def test_contruct_array_mix():
 
 
 def test_construct_array_mix_missing_conventions():
+    """Test BaseOneIndex.construct_array_mix with partially defined conventions."""
     class SpecialShell(GeneralizedContractionShell):
         @property
         def angmom_components_sph(self):
-            """These conventions are not necessarily defined."""
+            """Raise error in case undefined conventions are accessed."""
             raise NotImplementedError
 
     contractions = SpecialShell(1, np.array([1, 2, 3]), np.ones((1, 2)), np.ones(1))

--- a/tests/test_base_one.py
+++ b/tests/test_base_one.py
@@ -236,6 +236,7 @@ def test_contruct_array_mix():
 
 def test_construct_array_mix_missing_conventions():
     """Test BaseOneIndex.construct_array_mix with partially defined conventions."""
+
     class SpecialShell(GeneralizedContractionShell):
         @property
         def angmom_components_sph(self):

--- a/tests/test_base_one.py
+++ b/tests/test_base_one.py
@@ -234,6 +234,28 @@ def test_contruct_array_mix():
         test.construct_array_mix(["cartesian"] * 3, a=3),
 
 
+def test_construct_array_mix_missing_conventions():
+    class SpecialShell(GeneralizedContractionShell):
+        @property
+        def angmom_components_sph(self):
+            """These conventions are not necessarily defined."""
+            raise NotImplementedError
+
+    contractions = SpecialShell(1, np.array([1, 2, 3]), np.ones((1, 2)), np.ones(1))
+    Test = disable_abstract(  # noqa: N806
+        BaseOneIndex,
+        dict_overwrite={
+            "construct_array_contraction": (
+                lambda self, cont, a=2: np.arange(18, dtype=float).reshape(2, 3, 3) * a
+            )
+        },
+    )
+    test = Test([contractions, contractions])
+    assert np.allclose(
+        test.construct_array_cartesian(a=3), test.construct_array_mix(["cartesian"] * 2, a=3)
+    )
+
+
 def test_contruct_array_lincomb():
     """Test BaseOneIndex.construct_array_lincomb."""
     contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))


### PR DESCRIPTION
<!--

Thank you for submitting a PR!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing in this document:
https://github.com/theochem/gbasis/blob/master/CONTRIBUTING.md

-->

## Steps

- [x] Write a good description of what the PR does.
- [x] Add tests for each unit of code added (e.g. function, class)
- [x] Update documentation. -> **docs need no changes**
- [x] Squash commits that can be grouped together
- [x] Rebase onto master

## Description

In ``BaseOneIndex.construct_array_mix``, the transformation matrix from Cartesian to Spherical functions was also computed for Cartesian shells. This caused some unexpected issues when computing densities for wavefunction in Cartesian basis sets, for which no ordering of the spherical functions was defined. With this fix, also some unused calculations are avoided.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
| ✓  | :bug: Bug fix  |

## Related Issue

This fixes a part of #78. It does not fix it completely.
