### PR TITLE
Fix construct_array_mix

### DIFF
--- a/gbasis/base_four_symm.py
+++ b/gbasis/base_four_symm.py
@@ -435,6 +435,20 @@ class BaseFourIndexSymmetric(BaseGaussianRelatedArray):
             )
         )
         for pair_ind, ((i, cont_one, type_one), (j, cont_two, type_two)) in enumerate(pair_i_cont):
+            if type_one == "spherical":
+                transform_one = generate_transformation(
+                    cont_one.angmom,
+                    cont_one.angmom_components_cart,
+                    cont_one.angmom_components_sph,
+                    "left",
+                )
+            if type_two == "spherical":
+                transform_two = generate_transformation(
+                    cont_two.angmom,
+                    cont_two.angmom_components_cart,
+                    cont_two.angmom_components_sph,
+                    "left",
+                )
             for (k, cont_three, type_three), (l, cont_four, type_four) in pair_i_cont[pair_ind:]:
                 block = self.construct_array_contraction(
                     cont_one, cont_two, cont_three, cont_four, **kwargs
@@ -450,23 +464,12 @@ class BaseFourIndexSymmetric(BaseGaussianRelatedArray):
                 block *= cont_four.norm_cont.reshape(
                     1, 1, 1, 1, 1, 1, *block.shape[6:8], *[1 for _ in block.shape[8:]]
                 )
+
                 # transform
                 if type_one == "spherical":
-                    transform_one = generate_transformation(
-                        cont_one.angmom,
-                        cont_one.angmom_components_cart,
-                        cont_one.angmom_components_sph,
-                        "left",
-                    )
                     block = np.tensordot(transform_one, block, (1, 1))
                     block = np.swapaxes(block, 0, 1)
                 if type_two == "spherical":
-                    transform_two = generate_transformation(
-                        cont_two.angmom,
-                        cont_two.angmom_components_cart,
-                        cont_two.angmom_components_sph,
-                        "left",
-                    )
                     block = np.tensordot(transform_two, block, (1, 3))
                     block = np.swapaxes(np.swapaxes(np.swapaxes(block, 0, 1), 1, 2), 2, 3)
                 if type_three == "spherical":

--- a/gbasis/base_four_symm.py
+++ b/gbasis/base_four_symm.py
@@ -435,32 +435,7 @@ class BaseFourIndexSymmetric(BaseGaussianRelatedArray):
             )
         )
         for pair_ind, ((i, cont_one, type_one), (j, cont_two, type_two)) in enumerate(pair_i_cont):
-            transform_one = generate_transformation(
-                cont_one.angmom,
-                cont_one.angmom_components_cart,
-                cont_one.angmom_components_sph,
-                "left",
-            )
-            transform_two = generate_transformation(
-                cont_two.angmom,
-                cont_two.angmom_components_cart,
-                cont_two.angmom_components_sph,
-                "left",
-            )
             for (k, cont_three, type_three), (l, cont_four, type_four) in pair_i_cont[pair_ind:]:
-                transform_three = generate_transformation(
-                    cont_three.angmom,
-                    cont_three.angmom_components_cart,
-                    cont_three.angmom_components_sph,
-                    "left",
-                )
-                transform_four = generate_transformation(
-                    cont_four.angmom,
-                    cont_four.angmom_components_cart,
-                    cont_four.angmom_components_sph,
-                    "left",
-                )
-
                 block = self.construct_array_contraction(
                     cont_one, cont_two, cont_three, cont_four, **kwargs
                 )
@@ -475,15 +450,32 @@ class BaseFourIndexSymmetric(BaseGaussianRelatedArray):
                 block *= cont_four.norm_cont.reshape(
                     1, 1, 1, 1, 1, 1, *block.shape[6:8], *[1 for _ in block.shape[8:]]
                 )
-
                 # transform
                 if type_one == "spherical":
+                    transform_one = generate_transformation(
+                        cont_one.angmom,
+                        cont_one.angmom_components_cart,
+                        cont_one.angmom_components_sph,
+                        "left",
+                    )
                     block = np.tensordot(transform_one, block, (1, 1))
                     block = np.swapaxes(block, 0, 1)
                 if type_two == "spherical":
+                    transform_two = generate_transformation(
+                        cont_two.angmom,
+                        cont_two.angmom_components_cart,
+                        cont_two.angmom_components_sph,
+                        "left",
+                    )
                     block = np.tensordot(transform_two, block, (1, 3))
                     block = np.swapaxes(np.swapaxes(np.swapaxes(block, 0, 1), 1, 2), 2, 3)
                 if type_three == "spherical":
+                    transform_three = generate_transformation(
+                        cont_three.angmom,
+                        cont_three.angmom_components_cart,
+                        cont_three.angmom_components_sph,
+                        "left",
+                    )
                     block = np.tensordot(transform_three, block, (1, 5))
                     block = np.swapaxes(
                         np.swapaxes(
@@ -493,6 +485,12 @@ class BaseFourIndexSymmetric(BaseGaussianRelatedArray):
                         5,
                     )
                 if type_four == "spherical":
+                    transform_four = generate_transformation(
+                        cont_four.angmom,
+                        cont_four.angmom_components_cart,
+                        cont_four.angmom_components_sph,
+                        "left",
+                    )
                     block = np.tensordot(transform_four, block, (1, 7))
                     block = np.swapaxes(
                         np.swapaxes(

--- a/gbasis/base_two_asymm.py
+++ b/gbasis/base_two_asymm.py
@@ -318,6 +318,15 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
 
         matrices_spherical = []
         for cont_one, type_one in zip(self.contractions_one, coord_types_one):
+            if type_one == "spherical":
+                # get transformation from cartesian to spherical for the first index (applied to
+                # left)
+                transform_one = generate_transformation(
+                    cont_one.angmom,
+                    cont_one.angmom_components_cart,
+                    cont_one.angmom_components_sph,
+                    "left",
+                )
             matrices_spherical_cols = []
             for cont_two, type_two in zip(self.contractions_two, coord_types_two):
                 # evaluate
@@ -330,14 +339,6 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
                 # transform
                 # assume array always has shape (M_1, L_1, M_2, L_2, ...)
                 if type_one == "spherical":
-                    # get transformation from cartesian to spherical for the first index (applied to
-                    # left)
-                    transform_one = generate_transformation(
-                        cont_one.angmom,
-                        cont_one.angmom_components_cart,
-                        cont_one.angmom_components_sph,
-                        "left",
-                    )
                     block = np.tensordot(transform_one, block, (1, 1))
                     block = np.swapaxes(block, 0, 1)
                 block = np.concatenate(block, axis=0)

--- a/gbasis/base_two_asymm.py
+++ b/gbasis/base_two_asymm.py
@@ -318,23 +318,8 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
 
         matrices_spherical = []
         for cont_one, type_one in zip(self.contractions_one, coord_types_one):
-            # get transformation from cartesian to spherical for the first index (applied to left)
-            transform_one = generate_transformation(
-                cont_one.angmom,
-                cont_one.angmom_components_cart,
-                cont_one.angmom_components_sph,
-                "left",
-            )
             matrices_spherical_cols = []
             for cont_two, type_two in zip(self.contractions_two, coord_types_two):
-                # get transformation from cartesian to spherical for the first index (applied to
-                # left)
-                transform_two = generate_transformation(
-                    cont_two.angmom,
-                    cont_two.angmom_components_cart,
-                    cont_two.angmom_components_sph,
-                    "left",
-                )
                 # evaluate
                 block = self.construct_array_contraction(cont_one, cont_two, **kwargs)
                 # normalize contractions
@@ -345,11 +330,27 @@ class BaseTwoIndexAsymmetric(BaseGaussianRelatedArray):
                 # transform
                 # assume array always has shape (M_1, L_1, M_2, L_2, ...)
                 if type_one == "spherical":
+                    # get transformation from cartesian to spherical for the first index (applied to
+                    # left)
+                    transform_one = generate_transformation(
+                        cont_one.angmom,
+                        cont_one.angmom_components_cart,
+                        cont_one.angmom_components_sph,
+                        "left",
+                    )
                     block = np.tensordot(transform_one, block, (1, 1))
                     block = np.swapaxes(block, 0, 1)
                 block = np.concatenate(block, axis=0)
                 # array now has shape (M_1 L_1, M_2, L_2, ...)
                 if type_two == "spherical":
+                    # get transformation from cartesian to spherical for the first index (applied to
+                    # left)
+                    transform_two = generate_transformation(
+                        cont_two.angmom,
+                        cont_two.angmom_components_cart,
+                        cont_two.angmom_components_sph,
+                        "left",
+                    )
                     block = np.tensordot(transform_two, block, (1, 2))
                     block = np.swapaxes(np.swapaxes(block, 0, 1), 0, 2)
                 else:

--- a/gbasis/base_two_symm.py
+++ b/gbasis/base_two_symm.py
@@ -297,6 +297,14 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
 
         triu_blocks = []
         for i, (cont_one, type_one) in enumerate(zip(self.contractions, coord_types)):
+            if type_one == "spherical":
+                # get transformation from cartesian to spherical (applied to left)
+                transform_one = generate_transformation(
+                    cont_one.angmom,
+                    cont_one.angmom_components_cart,
+                    cont_one.angmom_components_sph,
+                    "left",
+                )
             for cont_two, type_two in zip(self.contractions[i:], coord_types[i:]):
                 # evaluate
                 block = self.construct_array_contraction(cont_one, cont_two, **kwargs)
@@ -307,13 +315,6 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
                 )
                 # assume array has shape (M_1, L_1, M_2, L_2, ...)
                 if type_one == "spherical":
-                    # get transformation from cartesian to spherical (applied to left)
-                    transform_one = generate_transformation(
-                        cont_one.angmom,
-                        cont_one.angmom_components_cart,
-                        cont_one.angmom_components_sph,
-                        "left",
-                    )
                     # transform
                     block = np.tensordot(transform_one, block, (1, 1))
                     block = np.swapaxes(block, 0, 1)

--- a/gbasis/base_two_symm.py
+++ b/gbasis/base_two_symm.py
@@ -297,20 +297,7 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
 
         triu_blocks = []
         for i, (cont_one, type_one) in enumerate(zip(self.contractions, coord_types)):
-            # get transformation from cartesian to spherical (applied to left)
-            transform_one = generate_transformation(
-                cont_one.angmom,
-                cont_one.angmom_components_cart,
-                cont_one.angmom_components_sph,
-                "left",
-            )
             for cont_two, type_two in zip(self.contractions[i:], coord_types[i:]):
-                transform_two = generate_transformation(
-                    cont_two.angmom,
-                    cont_two.angmom_components_cart,
-                    cont_two.angmom_components_sph,
-                    "left",
-                )
                 # evaluate
                 block = self.construct_array_contraction(cont_one, cont_two, **kwargs)
                 # normalize contractions
@@ -320,12 +307,26 @@ class BaseTwoIndexSymmetric(BaseGaussianRelatedArray):
                 )
                 # assume array has shape (M_1, L_1, M_2, L_2, ...)
                 if type_one == "spherical":
+                    # get transformation from cartesian to spherical (applied to left)
+                    transform_one = generate_transformation(
+                        cont_one.angmom,
+                        cont_one.angmom_components_cart,
+                        cont_one.angmom_components_sph,
+                        "left",
+                    )
                     # transform
                     block = np.tensordot(transform_one, block, (1, 1))
                     block = np.swapaxes(block, 0, 1)
                 block = np.concatenate(block, axis=0)
                 # array now has shape (M_1 L_1, M_2, L_2, ...)
                 if type_two == "spherical":
+                    # get transformation from cartesian to spherical (applied to left)
+                    transform_two = generate_transformation(
+                        cont_two.angmom,
+                        cont_two.angmom_components_cart,
+                        cont_two.angmom_components_sph,
+                        "left",
+                    )
                     block = np.tensordot(transform_two, block, (1, 2))
                     block = np.swapaxes(np.swapaxes(block, 0, 1), 0, 2)
                 else:

--- a/tests/test_base_four_symm.py
+++ b/tests/test_base_four_symm.py
@@ -511,32 +511,55 @@ def test_construct_array_mix():
 
 def test_construct_array_mix_with_both_cartesian_and_spherical():
     r"""Test construct_array_mix with both a P-Type Cartesian and D-Type Spherical contractions."""
-    NUM_PTS, NUM_SEG_SHELL = 1, 1
+    num_pts, num_seg_shell = 1, 1
     # Define the coefficients used to seperate which contraction block it is,
     #       Put it in a dictionary to avoid doing so many nested if-statements.
-    COEFF_P_P_P_P_TYPE = 2
-    COEFF_P_P_P_D_TYPE = 4
-    COEFF_P_P_D_D_TYPE = 5
-    COEFF_P_D_P_P_TYPE = 6
-    COEFF_P_D_P_D_TYPE = 8
-    COEFF_P_D_D_D_TYPE = 10
-    COEFF_D_D_P_P_TYPE = 12
-    COEFF_D_D_P_D_TYPE = 14
-    COEFF_D_D_D_D_TYPE = 16
-    coeff_dict = {"1111" : COEFF_P_P_P_P_TYPE, "1112" : COEFF_P_P_P_D_TYPE,
-                  "1122" : COEFF_P_P_D_D_TYPE, "1211" : COEFF_P_D_P_P_TYPE,
-                  "1212" : COEFF_P_D_P_D_TYPE, "1222" : COEFF_P_D_D_D_TYPE,
-                  "2211" : COEFF_D_D_P_P_TYPE, "2212" : COEFF_D_D_P_D_TYPE,
-                  "2222" : COEFF_D_D_D_D_TYPE}
+    coeff_p_p_p_p_type = 2
+    coeff_p_p_p_d_type = 4
+    coeff_p_p_d_d_type = 5
+    coeff_p_d_p_p_type = 6
+    coeff_p_d_p_d_type = 8
+    coeff_p_d_d_d_type = 10
+    coeff_d_d_p_p_type = 12
+    coeff_d_d_p_d_type = 14
+    coeff_d_d_d_d_type = 16
+    coeff_dict = {
+        "1111": coeff_p_p_p_p_type,
+        "1112": coeff_p_p_p_d_type,
+        "1122": coeff_p_p_d_d_type,
+        "1211": coeff_p_d_p_p_type,
+        "1212": coeff_p_d_p_d_type,
+        "1222": coeff_p_d_d_d_type,
+        "2211": coeff_d_d_p_p_type,
+        "2212": coeff_d_d_p_d_type,
+        "2222": coeff_d_d_d_d_type,
+    }
 
     def construct_array_cont(self, cont_one, cont_two, cont_three, cont_four):
-        output = np.ones(cont_one.num_cart * cont_two.num_cart * cont_three.num_cart *
-                         cont_four.num_cart * NUM_PTS, dtype=float).reshape(
-            NUM_SEG_SHELL, cont_one.num_cart, NUM_SEG_SHELL, cont_two.num_cart,
-            NUM_SEG_SHELL, cont_three.num_cart, NUM_SEG_SHELL, cont_four.num_cart, NUM_PTS
+        output = np.ones(
+            cont_one.num_cart
+            * cont_two.num_cart
+            * cont_three.num_cart
+            * cont_four.num_cart
+            * num_pts,
+            dtype=float,
+        ).reshape(
+            num_seg_shell,
+            cont_one.num_cart,
+            num_seg_shell,
+            cont_two.num_cart,
+            num_seg_shell,
+            cont_three.num_cart,
+            num_seg_shell,
+            cont_four.num_cart,
+            num_pts,
         )
-        identifier = str(cont_one.angmom) + str(cont_two.angmom) + str(cont_three.angmom) + \
-            str(cont_four.angmom)
+        identifier = (
+            str(cont_one.angmom)
+            + str(cont_two.angmom)
+            + str(cont_three.angmom)
+            + str(cont_four.angmom)
+        )
         return output * coeff_dict[identifier]
 
     Test = disable_abstract(  # noqa: N806
@@ -556,62 +579,78 @@ def test_construct_array_mix_with_both_cartesian_and_spherical():
     actual = test.construct_array_mix(["cartesian", "spherical"])[:, :, :, :, 0]
 
     # Test P-type to P-type to P-Type To P-type i.e. (P, P, P, P)
-    assert np.allclose(actual[:3, :3, :3, :3], np.ones((3, 3)) * COEFF_P_P_P_P_TYPE)
+    assert np.allclose(actual[:3, :3, :3, :3], np.ones((3, 3)) * coeff_p_p_p_p_type)
     # Test (P, P, P, D)
     # Transformation matrix from  normalized Cartesian to normalized Spherical,
     #       Transfers [xx, xy, xz, yy, yz, zz] to [S_{22}, S_{21}, C_{20}, C_{21}, C_{22}]
     #       Obtained form iodata website or can find it in Helgeker's book.
-    generate_transformation_array = np.array([[0, 1, 0, 0, 0, 0],
-                                              [0, 0, 0, 0, 1, 0],
-                                              [-0.5, 0, 0, -0.5, 0, 1],
-                                              [0, 0, 1, 0, 0, 0],
-                                              [np.sqrt(3.)/2.0, 0, 0, -np.sqrt(3.)/2.0, 0, 0],
-                                              ])
+    generate_transformation_array = np.array(
+        [
+            [0, 1, 0, 0, 0, 0],
+            [0, 0, 0, 0, 1, 0],
+            [-0.5, 0, 0, -0.5, 0, 1],
+            [0, 0, 1, 0, 0, 0],
+            [np.sqrt(3.0) / 2.0, 0, 0, -np.sqrt(3.0) / 2.0, 0, 0],
+        ]
+    )
     assert np.allclose(
         actual[:3, :3, :3, 3:],
-        np.ones((3, 3, 3, 6)).dot(generate_transformation_array.T) * COEFF_P_P_P_D_TYPE
+        np.ones((3, 3, 3, 6)).dot(generate_transformation_array.T) * coeff_p_p_p_d_type,
     )
 
     assert np.allclose(
         actual[:3, :3, 3:, :3],
-        np.einsum("ij,mnjl->mnil", generate_transformation_array,
-                  np.ones((3, 3, 6, 3))) * COEFF_P_P_P_D_TYPE
+        np.einsum("ij,mnjl->mnil", generate_transformation_array, np.ones((3, 3, 6, 3)))
+        * coeff_p_p_p_d_type,
     )
     # Test (P, P, D, D), (D, D, P, P)
     assert np.allclose(
         actual[:3, :3, 3:, 3:],
-        np.einsum("ij,mnjl,pl->mnip", generate_transformation_array,
-                  np.ones((3, 3, 6, 6)), generate_transformation_array) * COEFF_P_P_D_D_TYPE
+        np.einsum(
+            "ij,mnjl,pl->mnip",
+            generate_transformation_array,
+            np.ones((3, 3, 6, 6)),
+            generate_transformation_array,
+        )
+        * coeff_p_p_d_d_type,
     )
-    assert np.allclose(
-        actual[3:, 3:, :3, :3], actual[:3, :3, 3:, 3:].T
-    )  # Symmetry
+    assert np.allclose(actual[3:, 3:, :3, :3], actual[:3, :3, 3:, 3:].T)  # Symmetry
     # Test (P, D, P, D)
     assert np.allclose(
         actual[:3, 3:, :3, 3:],
-        np.einsum("ij,mjnl,pl->minp", generate_transformation_array,
-                  np.ones((3, 6, 3, 6)), generate_transformation_array) * COEFF_P_D_P_D_TYPE
+        np.einsum(
+            "ij,mjnl,pl->minp",
+            generate_transformation_array,
+            np.ones((3, 6, 3, 6)),
+            generate_transformation_array,
+        )
+        * coeff_p_d_p_d_type,
     )
     # Test (P, D, D, D), & (D, D, P, D)
     assert np.allclose(
         actual[:3, 3:, 3:, 3:],
-        np.einsum("in,mnjl,pl,oj->miop", generate_transformation_array,
-                  np.ones((3, 6, 6, 6)), generate_transformation_array, generate_transformation_array)
-        * COEFF_P_D_D_D_TYPE
+        np.einsum(
+            "in,mnjl,pl,oj->miop",
+            generate_transformation_array,
+            np.ones((3, 6, 6, 6)),
+            generate_transformation_array,
+            generate_transformation_array,
+        )
+        * coeff_p_d_d_d_type,
     )
-    assert np.allclose(
-        actual[3:, 3:, :3, 3:],
-        np.einsum("ijkl->klij", actual[:3, 3:, 3:, 3:])
-    )
+    assert np.allclose(actual[3:, 3:, :3, 3:], np.einsum("ijkl->klij", actual[:3, 3:, 3:, 3:]))
     # Test (D, D, D, D)
     assert np.allclose(
         actual[3:, 3:, 3:, 3:],
-        np.einsum("dm,in,mnjl,pl,oj->diop",
-                  generate_transformation_array,
-                  generate_transformation_array,
-                  np.ones((6, 6, 6, 6)), generate_transformation_array,
-                  generate_transformation_array)
-        * COEFF_D_D_D_D_TYPE
+        np.einsum(
+            "dm,in,mnjl,pl,oj->diop",
+            generate_transformation_array,
+            generate_transformation_array,
+            np.ones((6, 6, 6, 6)),
+            generate_transformation_array,
+            generate_transformation_array,
+        )
+        * coeff_d_d_d_d_type,
     )
 
 
@@ -1204,6 +1243,7 @@ def test_construct_array_lincomb():
 
 def test_construct_array_mix_missing_conventions():
     """Test BaseFourIndexSymmetric.construct_array_mix with partially defined conventions."""
+
     class SpecialShell(GeneralizedContractionShell):
         @property
         def angmom_components_sph(self):
@@ -1215,8 +1255,10 @@ def test_construct_array_mix_missing_conventions():
         BaseFourIndexSymmetric,
         dict_overwrite={
             "construct_array_contraction": (
-                lambda self, cont1, cont2, cont3, cont4, a=2:
-                    np.arange((2 * 3)**4, dtype=float).reshape(2, 3, 2, 3, 2, 3, 2, 3) * a
+                lambda self, cont1, cont2, cont3, cont4, a=2: np.arange(
+                    (2 * 3) ** 4, dtype=float
+                ).reshape(2, 3, 2, 3, 2, 3, 2, 3)
+                * a
             )
         },
     )

--- a/tests/test_base_four_symm.py
+++ b/tests/test_base_four_symm.py
@@ -1094,3 +1094,27 @@ def test_construct_array_lincomb():
             orb_transform,
         ),
     )
+
+
+def test_construct_array_mix_missing_conventions():
+    """Test BaseTwoIndexSymmetric.construct_array_mix with partially defined conventions."""
+    class SpecialShell(GeneralizedContractionShell):
+        @property
+        def angmom_components_sph(self):
+            """Raise error in case undefined conventions are accessed."""
+            raise NotImplementedError
+
+    contractions = SpecialShell(1, np.array([1, 2, 3]), np.ones((1, 2)), np.ones(1))
+    Test = disable_abstract(  # noqa: N806
+        BaseFourIndexSymmetric,
+        dict_overwrite={
+            "construct_array_contraction": (
+                lambda self, cont1, cont2, cont3, cont4, a=2:
+                    np.arange((2 * 3)**4, dtype=float).reshape(2, 3, 2, 3, 2, 3, 2, 3) * a
+            )
+        },
+    )
+    test = Test([contractions, contractions])
+    assert np.allclose(
+        test.construct_array_cartesian(a=3), test.construct_array_mix(["cartesian"] * 2, a=3)
+    )

--- a/tests/test_base_two_asymm.py
+++ b/tests/test_base_two_asymm.py
@@ -299,36 +299,48 @@ def test_contruct_array_mix():
 
 def test_construct_array_mix_with_both_cartesian_and_spherical():
     r"""Test construct_array_mix with both a P-Type Cartesian and D-Type Spherical contractions."""
-    NUM_PTS = 1
+    num_pts = 1
     # Define the coefficients used to seperate which contraction block it is
-    COEFF_P_P_TYPE = 2
-    COEFF_P_D_TYPE = 4
-    COEFF_D_P_TYPE = 5
-    COEFF_D_D_TYPE = 6
+    coeff_p_p_type = 2
+    coeff_p_d_type = 4
+    coeff_d_p_type = 5
+    coeff_d_d_type = 6
 
     def construct_array_cont(self, cont_one, cont_two):
         if cont_one.angmom == 1:
             if cont_two.angmom == 1:
                 # Return array with all values of "COEFF_P_PTYPE" with right size
-                output= np.ones(cont_one.num_cart * cont_two.num_cart * NUM_PTS, dtype=float).reshape(
-                    1, cont_one.num_cart, 1, cont_two.num_cart, NUM_PTS
-                ) * COEFF_P_P_TYPE
+                output = (
+                    np.ones(cont_one.num_cart * cont_two.num_cart * num_pts, dtype=float).reshape(
+                        1, cont_one.num_cart, 1, cont_two.num_cart, num_pts
+                    )
+                    * coeff_p_p_type
+                )
             elif cont_two.angmom == 2:
                 # Return array with all values of "COEFF_P_D_TYPE" with right size
-                output = np.ones(cont_one.num_cart * cont_two.num_cart * NUM_PTS, dtype=float).reshape(
-                    1, cont_one.num_cart, 1, cont_two.num_cart, NUM_PTS
-                ) * COEFF_P_D_TYPE
+                output = (
+                    np.ones(cont_one.num_cart * cont_two.num_cart * num_pts, dtype=float).reshape(
+                        1, cont_one.num_cart, 1, cont_two.num_cart, num_pts
+                    )
+                    * coeff_p_d_type
+                )
         if cont_one.angmom == 2:
             if cont_two.angmom == 1:
                 # Return array with all values of "COEFF_P_PTYPE" with right size
-                output= np.ones(cont_one.num_cart * cont_two.num_cart * NUM_PTS, dtype=float).reshape(
-                    1, cont_one.num_cart, 1, cont_two.num_cart, NUM_PTS
-                ) * COEFF_D_P_TYPE
+                output = (
+                    np.ones(cont_one.num_cart * cont_two.num_cart * num_pts, dtype=float).reshape(
+                        1, cont_one.num_cart, 1, cont_two.num_cart, num_pts
+                    )
+                    * coeff_d_p_type
+                )
             elif cont_two.angmom == 2:
                 # Return array with all values of "COEFF_D_D_TYPE" with right size
-                output = np.ones(cont_one.num_cart * cont_two.num_cart * NUM_PTS, dtype=float).reshape(
-                    1, cont_one.num_cart, 1, cont_two.num_cart, NUM_PTS
-                ) * COEFF_D_D_TYPE
+                output = (
+                    np.ones(cont_one.num_cart * cont_two.num_cart * num_pts, dtype=float).reshape(
+                        1, cont_one.num_cart, 1, cont_two.num_cart, num_pts
+                    )
+                    * coeff_d_d_type
+                )
         return output
 
     Test = disable_abstract(  # noqa: N806
@@ -345,33 +357,37 @@ def test_construct_array_mix_with_both_cartesian_and_spherical():
 
     # Should have shape (3 + 5, 3 + 5, NUM_PTS), due to the following:
     #           3-> Number of P-type, 5->Number of Spherical D-type.
-    actual = test.construct_array_mix(["cartesian", "spherical"],
-                                      ["cartesian", "spherical"])[:, :, 0]
+    actual = test.construct_array_mix(["cartesian", "spherical"], ["cartesian", "spherical"])[
+        :, :, 0
+    ]
 
     # Test P-type to P-type
-    assert np.allclose(actual[:3, :3], np.ones((3, 3)) * COEFF_P_P_TYPE)
+    assert np.allclose(actual[:3, :3], np.ones((3, 3)) * coeff_p_p_type)
     # Test P-type to D-type
     # Transformation matrix from  normalized Cartesian to normalized Spherical,
     #       Transfers [xx, xy, xz, yy, yz, zz] to [S_{22}, S_{21}, C_{20}, C_{21}, C_{22}]
     #       Obtained form iodata website or can find it in Helgeker's book.
-    generate_transformation_array = np.array([[0, 1, 0, 0, 0, 0],
-                                              [0, 0, 0, 0, 1, 0],
-                                              [-0.5, 0, 0, -0.5, 0, 1],
-                                              [0, 0, 1, 0, 0, 0],
-                                              [np.sqrt(3.)/2.0, 0, 0, -np.sqrt(3.)/2.0, 0, 0],
-                                              ])
-    assert np.allclose(
-        actual[:3, 3:], np.ones((3, 6)).dot(generate_transformation_array.T) * COEFF_P_D_TYPE
+    generate_transformation_array = np.array(
+        [
+            [0, 1, 0, 0, 0, 0],
+            [0, 0, 0, 0, 1, 0],
+            [-0.5, 0, 0, -0.5, 0, 1],
+            [0, 0, 1, 0, 0, 0],
+            [np.sqrt(3.0) / 2.0, 0, 0, -np.sqrt(3.0) / 2.0, 0, 0],
+        ]
     )
     assert np.allclose(
-        actual[3:, :3], generate_transformation_array.dot(np.ones((6, 3))) * COEFF_D_P_TYPE
+        actual[:3, 3:], np.ones((3, 6)).dot(generate_transformation_array.T) * coeff_p_d_type
+    )
+    assert np.allclose(
+        actual[3:, :3], generate_transformation_array.dot(np.ones((6, 3))) * coeff_d_p_type
     )
     # Test D-type to D-type.
     assert np.allclose(
         actual[3:, 3:],
         generate_transformation_array.dot(np.ones(6 * 6, dtype=float).reshape(6, 6) * 6).dot(
-                generate_transformation_array.T
-        )
+            generate_transformation_array.T
+        ),
     )
 
 
@@ -533,6 +549,7 @@ def test_contruct_array_lincomb():
 
 def test_construct_array_mix_missing_conventions():
     """Test BaseTwoIndexAsymmetric.construct_array_mix with partially defined conventions."""
+
     class SpecialShell(GeneralizedContractionShell):
         @property
         def angmom_components_sph(self):
@@ -544,13 +561,15 @@ def test_construct_array_mix_missing_conventions():
         BaseTwoIndexAsymmetric,
         dict_overwrite={
             "construct_array_contraction": (
-                lambda self, cont1, cont2, a=2:
-                    np.arange((2 * 3)**2, dtype=float).reshape(2, 3, 2, 3) * a
+                lambda self, cont1, cont2, a=2: np.arange((2 * 3) ** 2, dtype=float).reshape(
+                    2, 3, 2, 3
+                )
+                * a
             )
         },
     )
     test = Test([contractions, contractions], [contractions, contractions])
     assert np.allclose(
         test.construct_array_cartesian(a=3),
-        test.construct_array_mix(["cartesian"] * 2, ["cartesian"] * 2, a=3)
+        test.construct_array_mix(["cartesian"] * 2, ["cartesian"] * 2, a=3),
     )

--- a/tests/test_base_two_asymm.py
+++ b/tests/test_base_two_asymm.py
@@ -297,6 +297,84 @@ def test_contruct_array_mix():
         test.construct_array_mix(["cartesian"] * 2, ["cartesian"] * 2, a=3),
 
 
+def test_construct_array_mix_with_both_cartesian_and_spherical():
+    r"""Test construct_array_mix with both a P-Type Cartesian and D-Type Spherical contractions."""
+    NUM_PTS = 1
+    # Define the coefficients used to seperate which contraction block it is
+    COEFF_P_P_TYPE = 2
+    COEFF_P_D_TYPE = 4
+    COEFF_D_P_TYPE = 5
+    COEFF_D_D_TYPE = 6
+
+    def construct_array_cont(self, cont_one, cont_two):
+        if cont_one.angmom == 1:
+            if cont_two.angmom == 1:
+                # Return array with all values of "COEFF_P_PTYPE" with right size
+                output= np.ones(cont_one.num_cart * cont_two.num_cart * NUM_PTS, dtype=float).reshape(
+                    1, cont_one.num_cart, 1, cont_two.num_cart, NUM_PTS
+                ) * COEFF_P_P_TYPE
+            elif cont_two.angmom == 2:
+                # Return array with all values of "COEFF_P_D_TYPE" with right size
+                output = np.ones(cont_one.num_cart * cont_two.num_cart * NUM_PTS, dtype=float).reshape(
+                    1, cont_one.num_cart, 1, cont_two.num_cart, NUM_PTS
+                ) * COEFF_P_D_TYPE
+        if cont_one.angmom == 2:
+            if cont_two.angmom == 1:
+                # Return array with all values of "COEFF_P_PTYPE" with right size
+                output= np.ones(cont_one.num_cart * cont_two.num_cart * NUM_PTS, dtype=float).reshape(
+                    1, cont_one.num_cart, 1, cont_two.num_cart, NUM_PTS
+                ) * COEFF_D_P_TYPE
+            elif cont_two.angmom == 2:
+                # Return array with all values of "COEFF_D_D_TYPE" with right size
+                output = np.ones(cont_one.num_cart * cont_two.num_cart * NUM_PTS, dtype=float).reshape(
+                    1, cont_one.num_cart, 1, cont_two.num_cart, NUM_PTS
+                ) * COEFF_D_D_TYPE
+        return output
+
+    Test = disable_abstract(  # noqa: N806
+        BaseTwoIndexAsymmetric,
+        dict_overwrite={"construct_array_contraction": construct_array_cont},
+    )
+    cont_one = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
+    cont_two = GeneralizedContractionShell(2, np.array([1, 2, 3]), np.ones(1), np.ones(1))
+
+    # Remove the dependence on norm constants.
+    cont_one.norm_cont = np.ones((1, cont_one.num_cart))
+    cont_two.norm_cont = np.ones((1, cont_two.num_cart))
+    test = Test([cont_one, cont_two], [cont_one, cont_two])
+
+    # Should have shape (3 + 5, 3 + 5, NUM_PTS), due to the following:
+    #           3-> Number of P-type, 5->Number of Spherical D-type.
+    actual = test.construct_array_mix(["cartesian", "spherical"],
+                                      ["cartesian", "spherical"])[:, :, 0]
+
+    # Test P-type to P-type
+    assert np.allclose(actual[:3, :3], np.ones((3, 3)) * COEFF_P_P_TYPE)
+    # Test P-type to D-type
+    # Transformation matrix from  normalized Cartesian to normalized Spherical,
+    #       Transfers [xx, xy, xz, yy, yz, zz] to [S_{22}, S_{21}, C_{20}, C_{21}, C_{22}]
+    #       Obtained form iodata website or can find it in Helgeker's book.
+    generate_transformation_array = np.array([[0, 1, 0, 0, 0, 0],
+                                              [0, 0, 0, 0, 1, 0],
+                                              [-0.5, 0, 0, -0.5, 0, 1],
+                                              [0, 0, 1, 0, 0, 0],
+                                              [np.sqrt(3.)/2.0, 0, 0, -np.sqrt(3.)/2.0, 0, 0],
+                                              ])
+    assert np.allclose(
+        actual[:3, 3:], np.ones((3, 6)).dot(generate_transformation_array.T) * COEFF_P_D_TYPE
+    )
+    assert np.allclose(
+        actual[3:, :3], generate_transformation_array.dot(np.ones((6, 3))) * COEFF_D_P_TYPE
+    )
+    # Test D-type to D-type.
+    assert np.allclose(
+        actual[3:, 3:],
+        generate_transformation_array.dot(np.ones(6 * 6, dtype=float).reshape(6, 6) * 6).dot(
+                generate_transformation_array.T
+        )
+    )
+
+
 def test_contruct_array_lincomb():
     """Test BaseTwoIndexAsymmetric.construct_array_lincomb."""
     contractions = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
@@ -454,7 +532,7 @@ def test_contruct_array_lincomb():
 
 
 def test_construct_array_mix_missing_conventions():
-    """Test BaseTwoIndexSymmetric.construct_array_mix with partially defined conventions."""
+    """Test BaseTwoIndexAsymmetric.construct_array_mix with partially defined conventions."""
     class SpecialShell(GeneralizedContractionShell):
         @property
         def angmom_components_sph(self):

--- a/tests/test_base_two_symm.py
+++ b/tests/test_base_two_symm.py
@@ -694,30 +694,39 @@ def test_contruct_array_lincomb():
 
 def test_construct_array_mix():
     r"""Test construct_array_mix with both a P-Type Cartesian and D-Type Spherical contractions."""
-    NUM_PTS = 1
+    num_pts = 1
     # Define the coefficients used to seperate which contraction block it is
-    COEFF_P_P_TYPE = 2
-    COEFF_P_D_TYPE = 4
-    COEFF_D_D_TYPE = 6
+    coeff_p_p_type = 2
+    coeff_p_d_type = 4
+    coeff_d_d_type = 6
 
     def construct_array_cont(self, cont_one, cont_two):
         if cont_one.angmom == 1:
             if cont_two.angmom == 1:
                 # Return array with all values of "COEFF_P_PTYPE" with right size
-                output= np.ones(cont_one.num_cart * cont_two.num_cart * NUM_PTS, dtype=float).reshape(
-                    1, cont_one.num_cart, 1, cont_two.num_cart, NUM_PTS
-                ) * COEFF_P_P_TYPE
+                output = (
+                    np.ones(cont_one.num_cart * cont_two.num_cart * num_pts, dtype=float).reshape(
+                        1, cont_one.num_cart, 1, cont_two.num_cart, num_pts
+                    )
+                    * coeff_p_p_type
+                )
             elif cont_two.angmom == 2:
                 # Return array with all values of "COEFF_P_D_TYPE" with right size
-                output = np.ones(cont_one.num_cart * cont_two.num_cart * NUM_PTS, dtype=float).reshape(
-                    1, cont_one.num_cart, 1, cont_two.num_cart, NUM_PTS
-                ) * COEFF_P_D_TYPE
+                output = (
+                    np.ones(cont_one.num_cart * cont_two.num_cart * num_pts, dtype=float).reshape(
+                        1, cont_one.num_cart, 1, cont_two.num_cart, num_pts
+                    )
+                    * coeff_p_d_type
+                )
         if cont_one.angmom == 2:
             if cont_two.angmom == 2:
                 # Return array with all values of "COEFF_D_D_TYPE" with right size
-                output = np.ones(cont_one.num_cart * cont_two.num_cart * NUM_PTS, dtype=float).reshape(
-                    1, cont_one.num_cart, 1, cont_two.num_cart, NUM_PTS
-                ) * COEFF_D_D_TYPE
+                output = (
+                    np.ones(cont_one.num_cart * cont_two.num_cart * num_pts, dtype=float).reshape(
+                        1, cont_one.num_cart, 1, cont_two.num_cart, num_pts
+                    )
+                    * coeff_d_d_type
+                )
         return output
 
     Test = disable_abstract(  # noqa: N806
@@ -737,29 +746,32 @@ def test_construct_array_mix():
     actual = test.construct_array_mix(["cartesian", "spherical"])[:, :, 0]
 
     # Test P-type to P-type
-    assert np.allclose(actual[:3, :3], np.ones((3, 3)) * COEFF_P_P_TYPE)
+    assert np.allclose(actual[:3, :3], np.ones((3, 3)) * coeff_p_p_type)
     # Test P-type to D-type
     # Transformation matrix from  normalized Cartesian to normalized Spherical,
     #       Transfers [xx, xy, xz, yy, yz, zz] to [S_{22}, S_{21}, C_{20}, C_{21}, C_{22}]
     #       Obtained form iodata website or can find it in Helgeker's book.
-    generate_transformation_array = np.array([[0, 1, 0, 0, 0, 0],
-                                              [0, 0, 0, 0, 1, 0],
-                                              [-0.5, 0, 0, -0.5, 0, 1],
-                                              [0, 0, 1, 0, 0, 0],
-                                              [np.sqrt(3.)/2.0, 0, 0, -np.sqrt(3.)/2.0, 0, 0],
-                                              ])
-    assert np.allclose(
-        actual[:3, 3:], np.ones((3, 6)).dot(generate_transformation_array.T) * COEFF_P_D_TYPE
+    generate_transformation_array = np.array(
+        [
+            [0, 1, 0, 0, 0, 0],
+            [0, 0, 0, 0, 1, 0],
+            [-0.5, 0, 0, -0.5, 0, 1],
+            [0, 0, 1, 0, 0, 0],
+            [np.sqrt(3.0) / 2.0, 0, 0, -np.sqrt(3.0) / 2.0, 0, 0],
+        ]
     )
     assert np.allclose(
-        actual[3:, :3], generate_transformation_array.dot(np.ones((6, 3))) * COEFF_P_D_TYPE
+        actual[:3, 3:], np.ones((3, 6)).dot(generate_transformation_array.T) * coeff_p_d_type
+    )
+    assert np.allclose(
+        actual[3:, :3], generate_transformation_array.dot(np.ones((6, 3))) * coeff_p_d_type
     )
     # Test D-type to D-type.
     assert np.allclose(
         actual[3:, 3:],
         generate_transformation_array.dot(np.ones(6 * 6, dtype=float).reshape(6, 6) * 6).dot(
-                generate_transformation_array.T
-        )
+            generate_transformation_array.T
+        ),
     )
 
 
@@ -833,6 +845,7 @@ def test_compare_two_asymm():
 
 def test_construct_array_mix_missing_conventions():
     """Test BaseTwoIndexSymmetric.construct_array_mix with partially defined conventions."""
+
     class SpecialShell(GeneralizedContractionShell):
         @property
         def angmom_components_sph(self):

--- a/tests/test_base_two_symm.py
+++ b/tests/test_base_two_symm.py
@@ -758,3 +758,26 @@ def test_compare_two_asymm():
             cart_orb_transform, cart_orb_transform, "cartesian", "cartesian"
         ),
     )
+
+
+def test_construct_array_mix_missing_conventions():
+    """Test BaseTwoIndexSymmetric.construct_array_mix with partially defined conventions."""
+    class SpecialShell(GeneralizedContractionShell):
+        @property
+        def angmom_components_sph(self):
+            """Raise error in case undefined conventions are accessed."""
+            raise NotImplementedError
+
+    contractions = SpecialShell(1, np.array([1, 2, 3]), np.ones((1, 2)), np.ones(1))
+    Test = disable_abstract(  # noqa: N806
+        BaseTwoIndexSymmetric,
+        dict_overwrite={
+            "construct_array_contraction": (
+                lambda self, cont1, cont2, a=2: np.arange(36, dtype=float).reshape(2, 3, 2, 3) * a
+            )
+        },
+    )
+    test = Test([contractions, contractions])
+    assert np.allclose(
+        test.construct_array_cartesian(a=3), test.construct_array_mix(["cartesian"] * 2, a=3)
+    )

--- a/tests/test_base_two_symm.py
+++ b/tests/test_base_two_symm.py
@@ -692,6 +692,77 @@ def test_contruct_array_lincomb():
     )
 
 
+def test_construct_array_mix():
+    r"""Test construct_array_mix with both a P-Type Cartesian and D-Type Spherical contractions."""
+    NUM_PTS = 1
+    # Define the coefficients used to seperate which contraction block it is
+    COEFF_P_P_TYPE = 2
+    COEFF_P_D_TYPE = 4
+    COEFF_D_D_TYPE = 6
+
+    def construct_array_cont(self, cont_one, cont_two):
+        if cont_one.angmom == 1:
+            if cont_two.angmom == 1:
+                # Return array with all values of "COEFF_P_PTYPE" with right size
+                output= np.ones(cont_one.num_cart * cont_two.num_cart * NUM_PTS, dtype=float).reshape(
+                    1, cont_one.num_cart, 1, cont_two.num_cart, NUM_PTS
+                ) * COEFF_P_P_TYPE
+            elif cont_two.angmom == 2:
+                # Return array with all values of "COEFF_P_D_TYPE" with right size
+                output = np.ones(cont_one.num_cart * cont_two.num_cart * NUM_PTS, dtype=float).reshape(
+                    1, cont_one.num_cart, 1, cont_two.num_cart, NUM_PTS
+                ) * COEFF_P_D_TYPE
+        if cont_one.angmom == 2:
+            if cont_two.angmom == 2:
+                # Return array with all values of "COEFF_D_D_TYPE" with right size
+                output = np.ones(cont_one.num_cart * cont_two.num_cart * NUM_PTS, dtype=float).reshape(
+                    1, cont_one.num_cart, 1, cont_two.num_cart, NUM_PTS
+                ) * COEFF_D_D_TYPE
+        return output
+
+    Test = disable_abstract(  # noqa: N806
+        BaseTwoIndexSymmetric,
+        dict_overwrite={"construct_array_contraction": construct_array_cont},
+    )
+    cont_one = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))
+    cont_two = GeneralizedContractionShell(2, np.array([1, 2, 3]), np.ones(1), np.ones(1))
+
+    # Remove the dependence on norm constants.
+    cont_one.norm_cont = np.ones((1, cont_one.num_cart))
+    cont_two.norm_cont = np.ones((1, cont_two.num_cart))
+    test = Test([cont_one, cont_two])
+
+    # Should have shape (3 + 5, 3 + 5, NUM_PTS), due to the following:
+    #           3-> Number of P-type, 5->Number of Spherical D-type.
+    actual = test.construct_array_mix(["cartesian", "spherical"])[:, :, 0]
+
+    # Test P-type to P-type
+    assert np.allclose(actual[:3, :3], np.ones((3, 3)) * COEFF_P_P_TYPE)
+    # Test P-type to D-type
+    # Transformation matrix from  normalized Cartesian to normalized Spherical,
+    #       Transfers [xx, xy, xz, yy, yz, zz] to [S_{22}, S_{21}, C_{20}, C_{21}, C_{22}]
+    #       Obtained form iodata website or can find it in Helgeker's book.
+    generate_transformation_array = np.array([[0, 1, 0, 0, 0, 0],
+                                              [0, 0, 0, 0, 1, 0],
+                                              [-0.5, 0, 0, -0.5, 0, 1],
+                                              [0, 0, 1, 0, 0, 0],
+                                              [np.sqrt(3.)/2.0, 0, 0, -np.sqrt(3.)/2.0, 0, 0],
+                                              ])
+    assert np.allclose(
+        actual[:3, 3:], np.ones((3, 6)).dot(generate_transformation_array.T) * COEFF_P_D_TYPE
+    )
+    assert np.allclose(
+        actual[3:, :3], generate_transformation_array.dot(np.ones((6, 3))) * COEFF_P_D_TYPE
+    )
+    # Test D-type to D-type.
+    assert np.allclose(
+        actual[3:, 3:],
+        generate_transformation_array.dot(np.ones(6 * 6, dtype=float).reshape(6, 6) * 6).dot(
+                generate_transformation_array.T
+        )
+    )
+
+
 def test_compare_two_asymm():
     """Test BaseTwoIndexSymmetric by comparing it against BaseTwoIndexAsymmetric."""
     cont_one = GeneralizedContractionShell(1, np.array([1, 2, 3]), np.ones(1), np.ones(1))


### PR DESCRIPTION
<!--

Thank you for submitting a PR!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing in this document:
https://github.com/theochem/gbasis/blob/master/CONTRIBUTING.md

-->
## Steps

- [✓] Write a good description of what the PR does.
- [✓] Add tests for each unit of code added (e.g. function, class)
- [ ] Update documentation
- [ ] Squash commits that can be grouped together
- [ ] Rebase onto master

## Description
This pull request is regarding the function construct_array_mix within the class BaseTwoIndexSymmetric, BaseTwoIndexAsymmetric, and BaseFourIndexSymmetric. They are further explained in the issue #119 and #114.
In short, the function construct_array_mix transforms from Cartesian to Spherical when it is not necessary, e.g. when one only needs Cartesian form or angular momentum is zero.  This is fixed by adding a if-statement to only apply these transformation when the contraction shell is of type "spherical".

I have added tests suggested in the issue #114 and added my own test with one Cartesian P-type shell and one Spherical D-type shell.  Within the test, the function "construct_array_contraction" is replaced with a simple function that allows one to differentiate between integrating P-P, P-D, D-D type shells, the number of points evaluated is one and the normalization constant are set to one.

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
Issue #119 and Issue #114

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
