### PR TITLE
Clip Negative Electron Density Values from `evaluate_density`

### DIFF
--- a/gbasis/evals/density.py
+++ b/gbasis/evals/density.py
@@ -99,7 +99,7 @@ def evaluate_density(one_density_matrix, basis, points, transform=None, coord_ty
 
     """
     orb_eval = evaluate_basis(basis, points, transform=transform, coord_type=coord_type)
-    # use numpy.ndarray.clip method in return to remove small negative values
+    # Fix: # 117; to avoid small negative density values, the array is clipped
     return evaluate_density_using_evaluated_orbs(one_density_matrix, orb_eval).clip(min=0.0)
 
 

--- a/gbasis/evals/density.py
+++ b/gbasis/evals/density.py
@@ -99,7 +99,8 @@ def evaluate_density(one_density_matrix, basis, points, transform=None, coord_ty
 
     """
     orb_eval = evaluate_basis(basis, points, transform=transform, coord_type=coord_type)
-    return evaluate_density_using_evaluated_orbs(one_density_matrix, orb_eval)
+    # use numpy.ndarray.clip method in return to remove small negative values
+    return evaluate_density_using_evaluated_orbs(one_density_matrix, orb_eval).clip(min=0.0)
 
 
 def evaluate_deriv_reduced_density_matrix(

--- a/gbasis/evals/density.py
+++ b/gbasis/evals/density.py
@@ -511,7 +511,8 @@ def evaluate_posdef_kinetic_energy_density(
             transform=transform,
             coord_type=coord_type,
         )
-    return 0.5 * output
+    # Fix: #117; to avoid small negative values, the array is clipped
+    return (0.5 * output).clip(min=0.0)
 
 
 # TODO: test against a reference

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -25,12 +25,15 @@ def test_evaluate_density_using_evaluated_orbs():
         evaluate_density_using_evaluated_orbs(density_mat, orb_eval),
         np.einsum("ij,ik,jk->k", density_mat, orb_eval, orb_eval),
     )
+    assert(evaluate_density_using_evaluated_orbs(density_mat, orb_eval) >= 0)
+
     density_mat = np.array([[1.0, 2.0], [2.0, 3.0]])
     orb_eval = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
     assert np.allclose(
         evaluate_density_using_evaluated_orbs(density_mat, orb_eval),
         np.einsum("ij,ik,jk->k", density_mat, orb_eval, orb_eval),
     )
+    assert(evaluate_density_using_evaluated_orbs(density_mat, orb_eval).all() >= 0)
 
     with pytest.raises(TypeError):
         orb_eval = [[1.0, 2.0], [1.0, 2.0]]
@@ -74,6 +77,7 @@ def test_evaluate_density():
         evaluate_density(density, basis, points, transform),
         np.einsum("ij,ik,jk->k", density, evaluate_orbs, evaluate_orbs),
     )
+    assert(evaluate_density(density, basis, points, transform).all() >= 0)
 
 
 def test_evaluate_deriv_density():
@@ -295,6 +299,7 @@ def test_evaluate_density_horton():
     assert np.allclose(
         evaluate_density(np.identity(88), basis, grid_3d, np.identity(88)), horton_density
     )
+    assert(evaluate_density(np.identity(88), basis, grid_3d, np.identity(88)).all() >= 0)
 
 
 def test_evaluate_density_gradient_horton():
@@ -399,7 +404,7 @@ def test_evaluate_posdef_kinetic_energy_density():
         evaluate_posdef_kinetic_energy_density(np.identity(88), basis, grid_3d, np.identity(88)),
         horton_density_kinetic_density,
     )
-
+    assert(evaluate_posdef_kinetic_energy_density(np.identity(88), basis, grid_3d, np.identity(88)).all() >= 0)
 
 def test_evaluate_general_kinetic_energy_density_horton():
     """Test evaluate_general_kinetic_energy_density against results from HORTON.

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -21,19 +21,15 @@ def test_evaluate_density_using_evaluated_orbs():
     """Test gbasis.evals.density.evaluate_density_using_evaluated_orbs."""
     density_mat = np.array([[1.0, 2.0], [2.0, 3.0]])
     orb_eval = np.array([[1.0], [2.0]])
-    assert np.allclose(
-        evaluate_density_using_evaluated_orbs(density_mat, orb_eval),
-        np.einsum("ij,ik,jk->k", density_mat, orb_eval, orb_eval),
-    )
-    assert(evaluate_density_using_evaluated_orbs(density_mat, orb_eval) >= 0)
+    dens = evaluate_density_using_evaluated_orbs(density_mat, orb_eval)
+    assert np.all(dens >= 0.0)
+    assert np.allclose(dens, np.einsum("ij,ik,jk->k", density_mat, orb_eval, orb_eval))
 
     density_mat = np.array([[1.0, 2.0], [2.0, 3.0]])
     orb_eval = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
-    assert np.allclose(
-        evaluate_density_using_evaluated_orbs(density_mat, orb_eval),
-        np.einsum("ij,ik,jk->k", density_mat, orb_eval, orb_eval),
-    )
-    assert(evaluate_density_using_evaluated_orbs(density_mat, orb_eval).all() >= 0)
+    dens = evaluate_density_using_evaluated_orbs(density_mat, orb_eval)
+    assert np.all(dens >= 0)
+    assert np.allclose(dens, np.einsum("ij,ik,jk->k", density_mat, orb_eval, orb_eval))
 
     with pytest.raises(TypeError):
         orb_eval = [[1.0, 2.0], [1.0, 2.0]]
@@ -73,11 +69,9 @@ def test_evaluate_density():
     points = np.random.rand(10, 3)
 
     evaluate_orbs = evaluate_basis(basis, points, transform)
-    assert np.allclose(
-        evaluate_density(density, basis, points, transform),
-        np.einsum("ij,ik,jk->k", density, evaluate_orbs, evaluate_orbs),
-    )
-    assert(evaluate_density(density, basis, points, transform).all() >= 0)
+    dens = evaluate_density(density, basis, points, transform)
+    assert np.all(dens >= 0.0)
+    assert np.allclose(dens, np.einsum("ij,ik,jk->k", density, evaluate_orbs, evaluate_orbs))
 
 
 def test_evaluate_deriv_density():
@@ -296,10 +290,9 @@ def test_evaluate_density_horton():
     grid_x, grid_y, grid_z = np.meshgrid(grid_1d, grid_1d, grid_1d)
     grid_3d = np.vstack([grid_x.ravel(), grid_y.ravel(), grid_z.ravel()]).T
 
-    assert np.allclose(
-        evaluate_density(np.identity(88), basis, grid_3d, np.identity(88)), horton_density
-    )
-    assert(evaluate_density(np.identity(88), basis, grid_3d, np.identity(88)).all() >= 0)
+    dens = evaluate_density(np.identity(88), basis, grid_3d, np.identity(88))
+    assert np.all(dens >= 0.0)
+    assert np.allclose(dens, horton_density)
 
 
 def test_evaluate_density_gradient_horton():
@@ -338,7 +331,7 @@ def test_evaluate_hessian_deriv_horton():
     basis = make_contractions(basis_dict, ["H", "He"], points)
     basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps) for i in basis]
 
-    horton_density_hessian = np.zeros((10 ** 3, 3, 3))
+    horton_density_hessian = np.zeros((10**3, 3, 3))
     horton_density_hessian[:, [0, 0, 0, 1, 1, 2], [0, 1, 2, 1, 2, 2]] = np.load(
         find_datafile("data_horton_hhe_sph_density_hessian.npy")
     )
@@ -400,11 +393,10 @@ def test_evaluate_posdef_kinetic_energy_density():
     grid_x, grid_y, grid_z = np.meshgrid(grid_1d, grid_1d, grid_1d)
     grid_3d = np.vstack([grid_x.ravel(), grid_y.ravel(), grid_z.ravel()]).T
 
-    assert np.allclose(
-        evaluate_posdef_kinetic_energy_density(np.identity(88), basis, grid_3d, np.identity(88)),
-        horton_density_kinetic_density,
-    )
-    assert(evaluate_posdef_kinetic_energy_density(np.identity(88), basis, grid_3d, np.identity(88)).all() >= 0)
+    dens = evaluate_posdef_kinetic_energy_density(np.identity(88), basis, grid_3d, np.identity(88))
+    assert np.all(dens >= 0.0)
+    assert np.allclose(dens, horton_density_kinetic_density)
+
 
 def test_evaluate_general_kinetic_energy_density_horton():
     """Test evaluate_general_kinetic_energy_density against results from HORTON.


### PR DESCRIPTION
<!--

Thank you for submitting a PR!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing in this document:
https://github.com/theochem/gbasis/blob/master/CONTRIBUTING.md

-->

## Steps

- [X] Write a good description of what the PR does.
- [ ] ~Add tests for each unit of code added (e.g. function, class)~ (this didn't require new tests)
- [X] Update documentation
- [X] Squash commits that can be grouped together
- [ ] Rebase onto master

## Description

In accordance with @FarnazH's request in Issue #117, I have used [Numpy's clip method](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.clip.html) in the statement that returns the density array in  `evaluate_density`. By specifying `.clip(min=0.0)`, negative values in the array will be reassigned to a value of 0.0 (this is done in-place).

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
| ✓  | :hammer: Refactoring  |
| ✓  | :scroll: Docs |

## Related Issue

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
