### PR TITLE
Fix factorial2

### DIFF
--- a/gbasis/contractions.py
+++ b/gbasis/contractions.py
@@ -1,6 +1,6 @@
 """Data class for contractions of Gaussian-type primitives."""
+from gbasis.utils import factorial2
 import numpy as np
-from scipy.special import factorial2
 
 
 class GeneralizedContractionShell:

--- a/gbasis/integrals/_one_elec_int.py
+++ b/gbasis/integrals/_one_elec_int.py
@@ -1,6 +1,6 @@
 """One-electron integrals involving Contracted Cartesian Gaussians."""
 import numpy as np
-from scipy.special import factorial2
+from gbasis.utils import factorial2
 
 
 # pylint: disable=C0103,R0914,R0915

--- a/gbasis/integrals/_two_elec_int.py
+++ b/gbasis/integrals/_two_elec_int.py
@@ -1,6 +1,6 @@
 """Two-electron integrals involving Contracted Cartesian Gaussians."""
 import numpy as np
-from scipy.special import factorial2
+from gbasis.utils import factorial2
 
 # pylint: disable=C0103,R0914,R0915
 

--- a/gbasis/spherical.py
+++ b/gbasis/spherical.py
@@ -3,7 +3,8 @@
 from collections import defaultdict
 
 import numpy as np
-from scipy.special import comb, factorial, factorial2
+from scipy.special import comb, factorial
+from gbasis.utils import factorial2
 
 
 def shift_factor(mag):

--- a/gbasis/utils.py
+++ b/gbasis/utils.py
@@ -1,0 +1,22 @@
+"""Utility functions for gbasis."""
+
+import numpy as np
+import scipy.special
+
+
+def factorial2(n):
+    """Wrap scipy.special.factorial2 to return 1.0 when the input is not positive.
+
+    This is a temporary workaround to address issue #129, while we wait for Scipy's update.
+    To learn more, see https://github.com/scipy/scipy/issues/18409.
+
+    Parameters
+    ----------
+    n : int or np.ndarray
+        Values to calculate n!! for. If n <= 0, the return value is 1.
+    """
+    # Scipy  1.11.x returns an integer when n is an integer, but 1.10.x returns an array,
+    # so np.array(n) is passed to make sure the output is always an array.
+    out = scipy.special.factorial2(np.array(n))
+    out[out <= 0] = 1.0
+    return out

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     keywords="gaussian primitive contraction orbital integral differentiation evaluation density ",
     packages=find_packages(exclude=["docs", "tests"]),
     python_requires=">=3.5",
-    install_requires=["numpy>=1.10", "scipy>=1.0,<=1.10.1"],
+    install_requires=["numpy>=1.10", "scipy>=1.0"],
     extras_require={
         "dev": ["tox"],
         "test": ["tox", "pytest", "pytest-cov"],

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -3,9 +3,9 @@ from gbasis.contractions import GeneralizedContractionShell
 from gbasis.evals._deriv import _eval_deriv_contractions
 from gbasis.evals.eval import Eval, evaluate_basis
 from gbasis.parsers import make_contractions, parse_nwchem
+from gbasis.utils import factorial2
 import numpy as np
 import pytest
-from scipy.special import factorial2
 from utils import find_datafile, HortonContractions
 
 

--- a/tests/test_eval_deriv.py
+++ b/tests/test_eval_deriv.py
@@ -5,9 +5,9 @@ from gbasis.contractions import GeneralizedContractionShell
 from gbasis.evals._deriv import _eval_deriv_contractions
 from gbasis.evals.eval_deriv import EvalDeriv, evaluate_deriv_basis
 from gbasis.parsers import make_contractions, parse_nwchem
+from gbasis.utils import factorial2
 import numpy as np
 import pytest
-from scipy.special import factorial2
 from utils import find_datafile
 
 

--- a/tests/test_kinetic_energy.py
+++ b/tests/test_kinetic_energy.py
@@ -3,9 +3,9 @@ from gbasis.contractions import GeneralizedContractionShell
 from gbasis.integrals._diff_operator_int import _compute_differential_operator_integrals
 from gbasis.integrals.kinetic_energy import kinetic_energy_integral, KineticEnergyIntegral
 from gbasis.parsers import make_contractions, parse_nwchem
+from gbasis.utils import factorial2
 import numpy as np
 import pytest
-from scipy.special import factorial2
 from utils import find_datafile, HortonContractions
 
 

--- a/tests/test_moment.py
+++ b/tests/test_moment.py
@@ -3,9 +3,9 @@ from gbasis.contractions import GeneralizedContractionShell
 from gbasis.integrals._moment_int import _compute_multipole_moment_integrals
 from gbasis.integrals.moment import Moment, moment_integral
 from gbasis.parsers import make_contractions, parse_nwchem
+from gbasis.utils import factorial2
 import numpy as np
 import pytest
-from scipy.special import factorial2
 from utils import find_datafile
 
 

--- a/tests/test_moment_int.py
+++ b/tests/test_moment_int.py
@@ -2,8 +2,8 @@
 import itertools as it
 
 from gbasis.integrals._moment_int import _compute_multipole_moment_integrals
+from gbasis.utils import factorial2
 import numpy as np
-from scipy.special import factorial2
 
 
 def answer_prim(coord_type, i, j, k):

--- a/tests/test_momentum.py
+++ b/tests/test_momentum.py
@@ -3,9 +3,9 @@ from gbasis.contractions import GeneralizedContractionShell
 from gbasis.integrals._diff_operator_int import _compute_differential_operator_integrals
 from gbasis.integrals.momentum import momentum_integral, MomentumIntegral
 from gbasis.parsers import make_contractions, parse_nwchem
+from gbasis.utils import factorial2
 import numpy as np
 import pytest
-from scipy.special import factorial2
 from utils import find_datafile
 
 

--- a/tests/test_overlap.py
+++ b/tests/test_overlap.py
@@ -3,9 +3,10 @@ from gbasis.contractions import GeneralizedContractionShell
 from gbasis.integrals._moment_int import _compute_multipole_moment_integrals
 from gbasis.integrals.overlap import Overlap, overlap_integral
 from gbasis.parsers import make_contractions, parse_nwchem
+from gbasis.utils import factorial2
 import numpy as np
 import pytest
-from scipy.special import factorial2
+
 from utils import find_datafile, HortonContractions
 
 

--- a/tests/test_two_elec_int.py
+++ b/tests/test_two_elec_int.py
@@ -3,9 +3,10 @@ from gbasis.integrals._two_elec_int import (
     _compute_two_elec_integrals,
     _compute_two_elec_integrals_angmom_zero,
 )
+from gbasis.utils import factorial2
 import numpy as np
 import pytest
-from scipy.special import factorial2, hyp1f1  # pylint: disable=E0611
+from scipy.special import hyp1f1  # pylint: disable=E0611
 
 
 def boys_func(order, weighted_dist):


### PR DESCRIPTION
## Steps

- [x] Write a good description of what the PR does.
- [x] Add tests for each unit of code added (e.g. function, class)
- [x] Update documentation
- [x] Squash commits that can be grouped together
- [x] Rebase onto master

## Description
This PR addresses issue #129 by adding a `factorial2` function that wraps `scipy.special.factorial2` to return 1.0 when the input is not positive. This is temporary additional, while we wait for Scipy's update. To learn more, see https://github.com/scipy/scipy/issues/18409. This function is added in `gbasis.utils` (I tried adding it to `gbasis.wrappers` first but that would cause circular imports).

Just patching scipy version (as was done in f74123ebf4b640333bf1a3aec4460b1766a7d046) was not enough, because unless you install the `gbasis` package, the correct version of `scipy` is not used causing headache. Also, one might need to use scipy `1.11.x` in their environment for other purposes. In the meanwhile, correcting the `factorial2` output seems to me a more practical solution than patching the scipy version.

## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue
Closes #129

