### PR TITLE
Fix Failed IOData Test

### DIFF
--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -107,9 +107,8 @@ def test_from_iodata():
         basis[2].angmom_components_sph
 
     with pytest.raises(ValueError):
-        mol.obasis = mol.obasis._replace(primitive_normalization="L1")
+        mol.obasis.primitive_normalization = "L1"
         basis, coord_types = from_iodata(mol)
-
 
 def test_from_pyscf():
     """Test gbasis.wrapper.from_pyscf."""


### PR DESCRIPTION
## Steps

- [x] Write a good description of what the PR does.
- [ ] Add tests for each unit of code added (e.g. function, class)
- [ ] Update documentation
- [x] Squash commits that can be grouped together
- [x] Rebase onto master

## Description
This PR is made so the latest IOData from `master` branch (not the released) version can be used.
IOData no longer uses NamedTuples for `MolecularOrbital` class, so the `_replace()` methods cannot be used (which returns a new NamedTuples). The attribute `primitive_normalization` is set to a new value to made the test work but no second copy of class is created.

@Ali-Tehrani  and @leila-pujal when working on the CI part, make sure to install `iodata` from `master` branch (not conda or pip).

## Type of Changes
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
