### PR TITLE
Update code of conduct and links

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,65 +1,64 @@
-## Code of Conduct
+# Synopsis:
+- Treat everyone with respect, kindness, and empathy. Assume they're doing the same.
+- Communication is a two-party activity. If you’re not sure what someone means, then ask them; don’t assume.
+- If someone asks you to stop, then stop.
+- When critiquing the work of others, focus on ways to improve that work and keep in mind that your perspective is unique: what is obvious to you may not be obvious to others.
+- If a dispute can’t be resolved directly, contact the qc.devs administrators (qc.devs@gmail.com). If you do not feel comfortable contacting the qc.devs administrators directly, you can contact any of the individual administrators (ayers@mcmaster.ca, farnaz.heidarzadeh@queensu.ca, toon.verstraelen@ugent.be, or evohringer@udec.cl). 
 
-### Our Pledge
+# Statement of Principles:
+The QCDevs team embraces the diversity of its past, current, and future members, recognizing that the diversity of our backgrounds, preferences, personalities, ambitions, priorities, knowledge, and skills provide unique and useful perspectives that enrich our collaboration and enhance the quality of the software we build together and helps us grow, together and separately, as developers and as people. This certainly includes diversity of ethnicity, race, body shape, personal appearance, age, gender identity and expression, sexual identity and orientation, culture, religion, political affiliation, socioeconomic status, physical and mental capabilities, and national origin, but also diversity of perspectives, skills, knowledge, educational background, and priorities. It is expected that members of QCDevs are not only open-minded towards diverse backgrounds and perspectives, but actively encourage the participation of others. We, both individually and collectively, have zero tolerance for disrespectful or inconsiderate behavior of any kind.
 
-In the interest of fostering an open and welcoming environment, we as contributors and maintainers
-pledge to making participation in our project and our community a harassment-free experience for
-everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level
-of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+The following code borrows heavily from the previous codes of conduct in QCDevs projects and the freeBSD, Python, and Open-Source Contributor codes of conduct. The QCDevs team revisits this code whenever a major release is made.
 
-### Our Standards
+## Detailed Code of Conduct:
+The QCDevs team strives to be welcoming and respectful, and we want to ensure that our inclusive environment is not only maintained, but improved, as the team grows and evolves. To this end, we ask that people endeavor to always:
+- be friendly and patient,
+- be welcoming,
+- be positive,
+- be considerate,
+- be respectful,
+- be empathetic,
+- be careful in the words that you choose and be kind to others,
+- be supportive,
+- be open to new ideas and approaches,
+- accept responsibility for their actions and the effects they have on others, sincerely, apologize without hesitation, and learn from their mistakes to become better,
+- communicate clearly, constructively, and politely during disagreements and, after any tense discussions are resolved, revisit them for lessons on how future interactions can be improved, 
+- give others’ intentions the benefit of the doubt. Assume that others are trying to be constructive and helpful, because they probably are.
+- think about the long term. Just as you are building on others’ contributions, they will build on your contributions. Try to make it easier for them; think about the implications of your actions and decisions.
+- steadfastly strive to become a better colleague and developer,
+ 
+Similarly, the following activities are always unacceptable:
+- sexualized language or imagery, and sexual attention or advances of any kind
+- trolling, insulting or derogatory comments, and personal or political attacks
+- public or private harassment
+- publishing others' private information, such as a their physical or email address, without their explicit permission (doxing)
+- any conduct which could reasonably be considered inappropriate in a professional setting
+- any conduct that weakens the group, is destructive, or which contravenes the precepts of collegiality presented in the previous list.
 
-Examples of behavior that contributes to creating a positive environment include:
+This isn't an exhaustive list of things that you can and cannot do. Rather, take it in the spirit in which it's intended - a guide to make it easier to communicate and participate in QCDevs. As a single overarching rule: do not focus on what is best for you, but focus on what is best for the QCDevs team as a whole. This does not mean that your personal success does not matter! It means that everyone’s success matters equally, because our team is strong only when all of us are thriving personally and professionally.
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+## Enforcement: 
+If you believe someone is violating the code of conduct we ask that you report it to the QCDevs administrative team at qc.devs@gmail.com. However, if you believe anyone is in physical danger, please notify appropriate law enforcement first. If you do not feel comfortable contacting the QCDevs administrators collectively, you can contact any of the individual administrators (ayers@mcmaster.ca, farnaz.heidarzadeh@queensu.ca, toon.verstraelen@ugent.be, or evohringer@udec.cl). 
 
-Examples of unacceptable behavior by participants include:
+All reports will be kept confidential whenever possible. The QCDevs Administrators will strive to protect the identity and safety of reporters. In some cases we may need to make a public statement of some form, in which case we will use the minimum details and identifying information necessary to protect our community. In rare cases, we may need to identify some of the people involved to comply with the law or protect other potential victims. In these cases, we will consult with the reporter to find out what their wishes are and take them into account. In all cases, we aim not to directly or indirectly identify reporters without their consent.
 
-* The use of sexualized language or imagery and unwelcome sexual attention or advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic address, without explicit
-  permission
-* Other conduct which could reasonably be considered inappropriate in a professional setting
+In your report please include 
+- your name and contact information, 
+- names (real, nicknames, and/or pseudonyms) of any individuals involved. If there were other witnesses besides you, please try to include them as well.
+- when and where the incident occurred. Please be as specific as possible.
+- your account of what occurred. If there is a publicly available record please include a link and/or screen shots.
+- any extra context you believe relevant for the incident.
+- if you believe this incident is ongoing.
+- any other information you believe we should have.
 
-### Our Responsibilities
+As quickly as possible, the QCDevs administrators will review the incident and determine whether an investigation is needed, including interviewing additional parties or witnesses. After we have determined what has happened, we’ll determine whether the behaviour contravenes the code of conduct. Actions taken may include one or more of the following:
+- nothing (for example, if we determine that no violation occurred).
+- a private reprimand to the individual(s) involved, explaining why the conduct was inappropriate. This is appropriate when the behavior is minor, potentially accidental, and there is no damage to the QCDevs team as a whole, nor to its principles.
+- a public reprimand. This is appropriate when the action compromises the cohesiveness and integrity of the QCDevs team as a whole. 
+- a request for a private or public apology.
+- a request to compose an accountability plan or to engage in mediation.
+- a temporary or permanent suspension from QCDevs.
 
-Project maintainers are responsible for clarifying the standards of acceptable behavior and are
-expected to take appropriate and fair corrective action in response to any instances of unacceptable
-behavior.
+Once the QCDevs administrators have determined our final action, we will contact the original reporter to let them know what action (if any) we will be taking. We welcome feedback from the reporter on the appropriateness of our response, and we may (or may not) modulate our response based on that feedback.
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits,
-code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or
-to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
-
-### Scope
-
-This Code of Conduct applies both within project spaces and in public spaces when an individual is
-representing the project or its community. Examples of representing a project or community include
-using an official project e-mail address, posting via an official social media account, or acting as
-an appointed representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
-
-### Enforcement
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting
-the project team at theochem@github.com. All complaints will be reviewed and investigated and will
-result in a response that is deemed necessary and appropriate to the circumstances. The project team
-is obligated to maintain confidentiality with regard to the reporter of an incident. Further details
-of specific enforcement policies may be posted separately.
-
-Project maintainers who do not follow or enforce the Code of Conduct in good faith may face
-temporary or permanent repercussions as determined by other members of the project's leadership.
-
-### Attribution
-
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at
-[http://contributor-covenant.org/version/1/4][version]
-
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+**Credits:** This document was written by Wil Adams, Paul Ayers, Fanwang Meng, Lian Pharoah, and Michael Richer based on previous codes of conduct in QCDevs projects (primarily from Farnaz Heidar-Zadeh and Toon Verstraelen) and the freeBSD code of conduct, the Python code of conduct, the Open-Source Contributor Code of Conduct, and resources provided by the Office of Equity and Inclusion at McMaster University. The current version of the code of conduct was edited, then approved, by the QCDevs administrators. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to gbasis
 Hello! Thank you for taking your time to contribute!
 
-Please note we have a [Code of Conduct](CODE_OF_CONDUCT.md) , please follow it in all your interactions with the project. Please report unacceptable behavior to [theochem@github.com](mailto:theochem@github.com).
+Please note we have a [Code of Conduct](https://qcdevs.org/guidelines/QCDevsCodeOfConduct/) , please follow it in all your interactions with the project. Please report unacceptable behavior to [theochem@github.com](mailto:theochem@github.com).
 
 ## Do you have a question?
 


### PR DESCRIPTION
## Description
Old code of conduct was out of date. Contributing Guidelines need to be updated but that's a QC-Devs issue that we are aware of, not a specific gbasis issue.

Closes #14

