### PR TITLE
Add setup.py to fix install problem

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,8 @@
+from setuptools import setup
+
+setup(
+    name='your_package',
+    version='0.0',
+    packages=['gbasis'],
+    # other setup parameters...
+)


### PR DESCRIPTION
Gbasis has three folders in its main level and pypi gets lost during the the discovery of top-level packages during the installation. With this the package directory is set.

<!--

Thank you for submitting a PR!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing in this document:
https://github.com/theochem/gbasis/blob/master/CONTRIBUTING.md

-->

<!-- Description of the PR: what it does, what issues it addresses, etc -->

## Checklist

- [x] Write a good description of what the PR does.
- [ ] Add tests for each unit of code added (e.g. function, class)
- [ ] Update documentation
- [x] Squash commits that can be grouped together
- [x] Rebase onto master

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
