### PR TITLE
Add nuclear gradient functions

### DIFF
--- a/gbasis/integrals/libcint.py
+++ b/gbasis/integrals/libcint.py
@@ -1139,7 +1139,7 @@ class CBasis:
         # Compute nuclear gradient
         d_s = self._d_ovlp()
         for iatm, icoords in enumerate(self.atcoords):
-            start, end = self._atm_offs[iatm:iatm + 2]
+            start, end = self._atm_offs[iatm : iatm + 2]
             d_ovlp[start:end, :, iatm, :] -= d_s[start:end, :, :]
             d_ovlp[:, :, iatm, :] += d_ovlp[:, :, iatm, :].transpose(1, 0, 2)
         # Return output array
@@ -1161,7 +1161,7 @@ class CBasis:
         d_h = self._d_kin()
         d_h += self._d_nuc()
         for iatm, (iz, icoords) in enumerate(zip(self.atnums, self.atcoords)):
-            start, end = self._atm_offs[iatm:iatm + 2]
+            start, end = self._atm_offs[iatm : iatm + 2]
             d_rinv = -iz * self._d_rinv(inv_origin=icoords)
             d_rinv[start:end, :, :] -= d_h[start:end, :, :]
             d_rinv += d_rinv.transpose(1, 0, 2)
@@ -1184,7 +1184,7 @@ class CBasis:
         # Compute nuclear gradient
         d_i = self._d_eri()
         for iatm, icoords in enumerate(self.atcoords):
-            start, end = self._atm_offs[iatm:iatm + 2]
+            start, end = self._atm_offs[iatm : iatm + 2]
             d_eri[start:end, :, :, :, iatm, :] -= d_i[start:end, :, :, :, :]
             d_eri[:, :, :, :, iatm, :] += d_eri[:, :, :, :, iatm, :].transpose(2, 3, 0, 1, 4)
             d_eri[:, :, :, :, iatm, :] += d_eri[:, :, :, :, iatm, :].transpose(1, 0, 2, 3, 4)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ doc = [
     "nbsphinx-link"
 ]
 "dev" = ["tox"]
-"test" = ["tox", "pytest", "pytest-cov"]
+"test" = ["tox", "pytest", "pytest-cov", "derivcheck"]
 "iodata" = ["iodata>0.1.7"]
 "pyscf" = ["pyscf>=1.6.1"]
 

--- a/tests/test_libcint.py
+++ b/tests/test_libcint.py
@@ -196,10 +196,10 @@ def test_nuclear_gradient(basis, atsyms, atcoords, coord_type, gradient):
         py_basis = make_contractions(basis_dict, atsyms, atcoords, coord_types=coord_type)
         lc_basis = CBasis(py_basis, atsyms, atcoords, coord_type=coord_type)
         if gradient == "overlap":
-            return lc_basis.grad_overlap().reshape(lc_basis.nbfn ** 2, -1)
+            return lc_basis.grad_overlap().reshape(lc_basis.nbfn**2, -1)
         elif gradient == "core_hamiltonian":
-            return lc_basis.grad_core_hamiltonian().reshape(lc_basis.nbfn ** 2, -1)
+            return lc_basis.grad_core_hamiltonian().reshape(lc_basis.nbfn**2, -1)
         elif gradient == "electron_repulsion":
-            return lc_basis.grad_electron_repulsion().reshape(lc_basis.nbfn ** 4, -1)
+            return lc_basis.grad_electron_repulsion().reshape(lc_basis.nbfn**4, -1)
 
     assert_deriv(f, g, atcoords.reshape(-1))


### PR DESCRIPTION
<!--

Thank you for submitting a PR!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing in this document:
https://github.com/theochem/gbasis/blob/master/CONTRIBUTING.md

-->

This PR adds nuclear gradients for the overlap integrals, the core Hamiltonian ($\hat{T} + \hat{V}_{ne}$) integrals, and the electron repulsion integrals, in the AO basis.

I based this on pyscf `pyscf/grad/rhf.py`, although that code is for an optimized Hartree-Fock wave function (in the MO basis). Once I am able to test these, the code will be ready to merge. 

<!-- Description of the PR: what it does, what issues it addresses, etc -->

## Checklist

- [x] Write a good description of what the PR does.
- [ ] Add tests for each unit of code added (e.g. function, class)
- [ ] Update documentation
- [ ] Squash commits that can be grouped together
- [ ] Rebase onto master

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |