### PR TITLE
Fix memory doubling for density evaluation

### DIFF
--- a/gbasis/evals/density.py
+++ b/gbasis/evals/density.py
@@ -60,6 +60,7 @@ def evaluate_density_using_evaluated_orbs(one_density_matrix, orb_eval):
     density = np.sum(orb_eval * (one_density_matrix.dot(orb_eval)), axis=0)
     return density
 
+
 def evaluate_density(one_density_matrix, basis, points, transform=None, threshold=1.0e-8):
     r"""Return the density of the given basis set at the given points.
 

--- a/gbasis/evals/density.py
+++ b/gbasis/evals/density.py
@@ -57,10 +57,8 @@ def evaluate_density_using_evaluated_orbs(one_density_matrix, orb_eval):
             " of the orbital evaluations."
         )
 
-    density = one_density_matrix.dot(orb_eval)
-    density *= orb_eval
-    return np.sum(density, axis=0)
-
+    density = np.sum(orb_eval * (one_density_matrix.dot(orb_eval)), axis=0)
+    return density
 
 def evaluate_density(one_density_matrix, basis, points, transform=None, threshold=1.0e-8):
     r"""Return the density of the given basis set at the given points.


### PR DESCRIPTION
<!--

Thank you for submitting a PR!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing in this document:
https://github.com/theochem/gbasis/blob/master/CONTRIBUTING.md

-->

<!-- Description of the PR: what it does, what issues it addresses, etc -->

This PR fixes bug reported in #121 about memory doubling when calling the function `evaluate_density_using_evaluated_orbs`. Problematic code was condensed to avoid creating a new array which was causing the doubling in memory. 

Test: Pass existing test 

## Checklist

- [x] Write a good description of what the PR does.
- [ ] Add tests for each unit of code added (e.g. function, class)
- [ ] Update documentation
- [ ] Squash commits that can be grouped together
- [ ] Rebase onto master

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #121
-->
