### PR TITLE
Extend screening overlap to IOData wrapper

### DIFF
--- a/gbasis/contractions.py
+++ b/gbasis/contractions.py
@@ -141,7 +141,7 @@ class GeneralizedContractionShell:
             "spherical" or "p".
         icenter : np.int64 or None (optional)
             Index for the atomic center for the contraction
-        ovr_tol : float
+        tol : float
             Tolerance used in overlap screening.
         ovr_screen : boolean
             Flag used for activating overlap screening.

--- a/gbasis/parsers.py
+++ b/gbasis/parsers.py
@@ -214,7 +214,7 @@ def make_contractions(basis_dict, atoms, coords, coord_types, tol=1e-20, overlap
     if not isinstance(tol, float):
         raise TypeError("Tolerance must be provided as a float.")
     if not isinstance(overlap, bool):
-        raise TypeError("Tolerance must be provided as True or False.")
+        raise TypeError("Overlap must be provided as True or False.")
     if len(atoms) != coords.shape[0]:
         raise ValueError("Number of atoms must be equal to the number of rows in the coordinates.")
 

--- a/gbasis/wrappers.py
+++ b/gbasis/wrappers.py
@@ -142,7 +142,7 @@ def from_iodata(mol, tol=1e-20, overlap=False):
                 shell.kinds[0],
                 icenter=shell.icenter,
                 tol=tol,
-                ovr_screen=overlap
+                ovr_screen=overlap,
             )
         )
 

--- a/gbasis/wrappers.py
+++ b/gbasis/wrappers.py
@@ -3,13 +3,17 @@ from gbasis.contractions import GeneralizedContractionShell
 import numpy as np
 
 
-def from_iodata(mol):
+def from_iodata(mol, tol=1e-20, overlap=False):
     """Return basis set stored within the `IOData` instance in `iodata`.
 
     Parameters
     ----------
     mol : iodata.iodata.IOData
         `IOData` instance from `iodata` module.
+    tol : float
+        Tolerance used in overlap screening.
+    ovrlap : bool
+        Flag for performing overlap screening between contractions.
 
     Returns
     -------
@@ -114,6 +118,10 @@ def from_iodata(mol):
             "Only L2 normalization scheme is supported in `gbasis`. Given `IOData` instance uses "
             "primitive normalization scheme, {}".format(molbasis.primitive_normalization)
         )
+    if not isinstance(tol, float):
+        raise TypeError("Tolerance must be provided as a float.")
+    if not isinstance(overlap, bool):
+        raise TypeError("Overlap must be provided as True or False.")
 
     basis = []
     for shell in molbasis.shells:
@@ -133,6 +141,8 @@ def from_iodata(mol):
                 shell.exponents,
                 shell.kinds[0],
                 icenter=shell.icenter,
+                tol=tol,
+                ovr_screen=overlap
             )
         )
 

--- a/gbasis/wrappers.py
+++ b/gbasis/wrappers.py
@@ -12,7 +12,7 @@ def from_iodata(mol, tol=1e-20, overlap=False):
         `IOData` instance from `iodata` module.
     tol : float
         Tolerance used in overlap screening.
-    ovrlap : bool
+    overlap : bool
         Flag for performing overlap screening between contractions.
 
     Returns

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -123,8 +123,9 @@ def test_from_iodata():
         mol.obasis.primitive_normalization = "L1"
         basis, coord_types = from_iodata(mol)
 
+
 def test_from_iodata_ovlp():
-    """Test gbasis.wrapper.from_iodata only for the ovr_screen and tol attributes """
+    """Test gbasis.wrapper.from_iodata only for the ovr_screen and tol attributes"""
     pytest.importorskip("iodata")
     from iodata import load_one
 

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -18,6 +18,8 @@ def test_from_iodata():
     coord_types = [type for type in [shell.coord_type for shell in basis]]
 
     assert coord_types == ["cartesian"] * 5
+    assert basis[0].ovr_screen == False
+    assert basis[0].ovr_tol == 1e-20
     assert all(isinstance(i, GeneralizedContractionShell) for i in basis)
     assert basis[0].angmom == 0
     assert np.allclose(basis[0].coord, mol.atcoords[0])
@@ -28,6 +30,8 @@ def test_from_iodata():
     assert np.allclose(basis[0].norm_cont, 1.0)
 
     assert basis[1].angmom == 0
+    assert basis[1].ovr_screen == False
+    assert basis[1].ovr_tol == 1e-20
     assert np.allclose(basis[1].coord, mol.atcoords[0])
     assert np.allclose(basis[1].exps, np.array([5.033151319, 1.169596125, 0.3803889600]))
     assert np.allclose(
@@ -36,6 +40,8 @@ def test_from_iodata():
     assert np.allclose(basis[1].norm_cont, 1.0)
 
     assert basis[2].angmom == 1
+    assert basis[2].ovr_screen == False
+    assert basis[2].ovr_tol == 1e-20
     assert np.allclose(basis[2].coord, mol.atcoords[0])
     assert np.allclose(basis[2].exps, np.array([5.033151319, 1.169596125, 0.3803889600]))
     assert np.allclose(
@@ -44,6 +50,8 @@ def test_from_iodata():
     assert np.allclose(basis[2].norm_cont, 1.0)
 
     assert basis[3].angmom == 0
+    assert basis[3].ovr_screen == False
+    assert basis[3].ovr_tol == 1e-20
     assert np.allclose(basis[3].coord, mol.atcoords[1])
     assert np.allclose(basis[3].exps, np.array([3.425250914, 0.6239137298, 0.1688554040]))
     assert np.allclose(
@@ -52,6 +60,8 @@ def test_from_iodata():
     assert np.allclose(basis[3].norm_cont, 1.0)
 
     assert basis[4].angmom == 0
+    assert basis[4].ovr_screen == False
+    assert basis[4].ovr_tol == 1e-20
     assert np.allclose(basis[4].coord, mol.atcoords[2])
     assert np.allclose(basis[4].exps, np.array([3.425250914, 0.6239137298, 0.1688554040]))
     assert np.allclose(
@@ -112,6 +122,26 @@ def test_from_iodata():
     with pytest.raises(ValueError):
         mol.obasis.primitive_normalization = "L1"
         basis, coord_types = from_iodata(mol)
+
+def test_from_iodata_ovlp():
+    """Test gbasis.wrapper.from_iodata only for the ovr_screen and tol attributes """
+    pytest.importorskip("iodata")
+    from iodata import load_one
+
+    mol = load_one(find_datafile("data_iodata_water_sto3g_hf_g03.fchk"))
+
+    basis = from_iodata(mol, tol=0.001, overlap=True)
+
+    assert basis[0].ovr_screen == True
+    assert basis[0].ovr_tol == 0.001
+    assert basis[1].ovr_screen == True
+    assert basis[1].ovr_tol == 0.001
+    assert basis[2].ovr_screen == True
+    assert basis[2].ovr_tol == 0.001
+    assert basis[3].ovr_screen == True
+    assert basis[3].ovr_tol == 0.001
+    assert basis[4].ovr_screen == True
+    assert basis[4].ovr_tol == 0.001
 
 
 def test_from_pyscf():


### PR DESCRIPTION
<!--

Thank you for submitting a PR!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing in this document:
https://github.com/theochem/gbasis/blob/master/CONTRIBUTING.md

-->

<!-- Description of the PR: what it does, what issues it addresses, etc -->
This PR builds on top of PR #111 to extend the screening overlap functionality to data load from and `IOData` object. PR #111 implemented the screening of overlap type integrals. This feature is set up at the user level when the function `make_contractions` is employed in combination with a parsed basis from a Gaussian or NWChem basis set. The same API is added to the function `from_iodata` to be able to access the overlap screening feature. `test_wrappers.py` has been updated and also a new test has been added to check the new API correctly stores the overlap screening information passed when instantiating each `GeneralizedContractionShell`



## Checklist

- [x] Write a good description of what the PR does.
- [x] Add tests for each unit of code added (e.g. function, class)
- [x] Update documentation
- [x] Squash commits that can be grouped together
- [x] Rebase onto master

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |

## Related

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
