### PR TITLE
Add transform= keyword to cbasis integrals (#178)

### DIFF
--- a/gbasis/integrals/libcint.py
+++ b/gbasis/integrals/libcint.py
@@ -1160,7 +1160,9 @@ class CBasis:
         raise NotImplementedError("Angular momentum integral doesn't work; see Issue #149")
         # return self._amom(origin=origin, notation=notation, transform=transform)
 
-    def point_charge_integral(self, point_coords, point_charges, notation="physicist", transform=None):
+    def point_charge_integral(
+        self, point_coords, point_charges, notation="physicist", transform=None
+    ):
         r"""
         Compute the point charge integrals.
 
@@ -1234,7 +1236,9 @@ class CBasis:
                 if sum(order) == 0:
                     out[:, :, i] = self._ovlp(notation=notation, transform=transform)
                 else:
-                    out[:, :, i] = self._moments[tuple(order)](origin=origin, notation=notation, transform=transform)
+                    out[:, :, i] = self._moments[tuple(order)](
+                        origin=origin, notation=notation, transform=transform
+                    )
         except KeyError:
             raise ValueError(
                 "Invalid order; can use up to order 4 for any XYZ component,"

--- a/gbasis/integrals/libcint.py
+++ b/gbasis/integrals/libcint.py
@@ -670,7 +670,7 @@ class CBasis:
         )
 
         # Make instance-bound integral method
-        def int1e(notation="physicist", origin=None, inv_origin=None):
+        def int1e(notation="physicist", transform=None, origin=None, inv_origin=None):
             # Handle ``notation`` argument
             if notation not in ("physicist", "chemist"):
                 raise ValueError("``notation`` must be one of 'physicist' or 'chemist'")
@@ -755,11 +755,17 @@ class CBasis:
             # Apply permutation
             out = out[self._permutations, :][:, self._permutations]
 
-            # Return normalized integrals
+            # Normalize integrals
             if self.coord_type == "cartesian":
-                return np.einsum(norm_einsum, self._ovlp_minhalf, self._ovlp_minhalf, out)
-            else:
-                return out
+                out = np.einsum(norm_einsum, self._ovlp_minhalf, self._ovlp_minhalf, out)
+
+            # Apply transformation
+            if transform is not None:
+                out = np.tensordot(transform, out, (1, 0))
+                out = np.tensordot(transform, out, (1, 1))
+                out = np.swapaxes(out, 0, 1)
+
+            return out
 
         # Return instance-bound integral method
         return int1e
@@ -823,7 +829,7 @@ class CBasis:
         )
 
         # Make instance-bound integral method
-        def int2e(notation="physicist", origin=None, inv_origin=None):
+        def int2e(notation="physicist", transform=None, origin=None, inv_origin=None):
             # Handle ``notation`` argument
             if notation == "physicist":
                 physicist = True
@@ -962,9 +968,9 @@ class CBasis:
             out = out[:, :, self._permutations]
             out = out[:, :, :, self._permutations]
 
-            # Return normalized integrals
+            # Normalize integrals
             if self.coord_type == "cartesian":
-                return np.einsum(
+                out = np.einsum(
                     norm_einsum,
                     self._ovlp_minhalf,
                     self._ovlp_minhalf,
@@ -972,8 +978,16 @@ class CBasis:
                     self._ovlp_minhalf,
                     out,
                 )
-            else:
-                return out
+
+            # Apply transformation
+            if transform is not None:
+                out = np.tensordot(transform, out, (1, 0))
+                out = np.tensordot(transform, out, (1, 1))
+                out = np.tensordot(transform, out, (1, 2))
+                out = np.tensordot(transform, out, (1, 3))
+                out = np.swapaxes(np.swapaxes(out, 0, 3), 1, 2)
+
+            return out
 
         # Return instance-bound integral method
         return int2e

--- a/gbasis/integrals/libcint.py
+++ b/gbasis/integrals/libcint.py
@@ -958,10 +958,6 @@ class CBasis:
             if constant is not None:
                 out *= constant
 
-            # Transpose integrals in `out` array to proper notation
-            if physicist:
-                out = out.transpose(0, 2, 1, 3)
-
             # Apply permutation
             out = out[self._permutations]
             out = out[:, self._permutations]
@@ -979,6 +975,10 @@ class CBasis:
                     out,
                 )
 
+            # Transpose integrals in `out` array to proper notation
+            if physicist:
+                out = out.transpose(0, 2, 1, 3)
+
             # Apply transformation
             if transform is not None:
                 out = np.tensordot(transform, out, (1, 0))
@@ -992,7 +992,7 @@ class CBasis:
         # Return instance-bound integral method
         return int2e
 
-    def overlap_integral(self, notation="physicist"):
+    def overlap_integral(self, notation="physicist", transform=None):
         r"""
         Compute the overlap integrals.
 
@@ -1000,6 +1000,12 @@ class CBasis:
         ----------
         notation : ("physicist" | "chemist"), default="physicist"
             Axis order convention.
+        transform : np.ndarray(K, K_cont)
+            Transformation matrix from the basis set in the given coordinate system (e.g. AO) to linear
+            combinations of contractions (e.g. MO).
+            Transformation is applied to the left, i.e. the sum is over the index 1 of `transform`
+            and index 0 of the array for contractions.
+            Default is no transformation.
 
         Returns
         -------
@@ -1007,9 +1013,9 @@ class CBasis:
             Integral array.
 
         """
-        return self._ovlp(notation=notation)
+        return self._ovlp(notation=notation, transform=transform)
 
-    def kinetic_energy_integral(self, notation="physicist"):
+    def kinetic_energy_integral(self, notation="physicist", transform=None):
         r"""
         Compute the kinetic energy integrals.
 
@@ -1017,6 +1023,12 @@ class CBasis:
         ----------
         notation : ("physicist" | "chemist"), default="physicist"
             Axis order convention.
+        transform : np.ndarray(K, K_cont)
+            Transformation matrix from the basis set in the given coordinate system (e.g. AO) to linear
+            combinations of contractions (e.g. MO).
+            Transformation is applied to the left, i.e. the sum is over the index 1 of `transform`
+            and index 0 of the array for contractions.
+            Default is no transformation.
 
         Returns
         -------
@@ -1024,9 +1036,9 @@ class CBasis:
             Integral array.
 
         """
-        return self._kin(notation=notation)
+        return self._kin(notation=notation, transform=transform)
 
-    def nuclear_attraction_integral(self, notation="physicist"):
+    def nuclear_attraction_integral(self, notation="physicist", transform=None):
         r"""
         Compute the nuclear attraction integrals.
 
@@ -1034,6 +1046,12 @@ class CBasis:
         ----------
         notation : ("physicist" | "chemist"), default="physicist"
             Axis order convention.
+        transform : np.ndarray(K, K_cont)
+            Transformation matrix from the basis set in the given coordinate system (e.g. AO) to linear
+            combinations of contractions (e.g. MO).
+            Transformation is applied to the left, i.e. the sum is over the index 1 of `transform`
+            and index 0 of the array for contractions.
+            Default is no transformation.
 
         Returns
         -------
@@ -1041,9 +1059,9 @@ class CBasis:
             Integral array.
 
         """
-        return self._nuc(notation=notation)
+        return self._nuc(notation=notation, transform=transform)
 
-    def electron_repulsion_integral(self, notation="physicist"):
+    def electron_repulsion_integral(self, notation="physicist", transform=None):
         r"""
         Compute the electron repulsion integrals.
 
@@ -1051,6 +1069,12 @@ class CBasis:
         ----------
         notation : ("physicist" | "chemist"), default="physicist"
             Axis order convention.
+        transform : np.ndarray(K, K_cont)
+            Transformation matrix from the basis set in the given coordinate system (e.g. AO) to linear
+            combinations of contractions (e.g. MO).
+            Transformation is applied to the left, i.e. the sum is over the index 1 of `transform`
+            and index 0 of the array for contractions.
+            Default is no transformation.
 
         Returns
         -------
@@ -1058,9 +1082,9 @@ class CBasis:
             Integral array.
 
         """
-        return self._eri(notation=notation)
+        return self._eri(notation=notation, transform=transform)
 
-    def r_inv_integral(self, origin=None, notation="physicist"):
+    def r_inv_integral(self, origin=None, notation="physicist", transform=None):
         r"""
         Compute the :math:`1/\left|\mathbf{r} - \mathbf{R}_\text{inv}\right|` integrals.
 
@@ -1070,6 +1094,12 @@ class CBasis:
             Origin about which to evaluate integrals.
         notation : ("physicist" | "chemist"), default="physicist"
             Axis order convention.
+        transform : np.ndarray(K, K_cont)
+            Transformation matrix from the basis set in the given coordinate system (e.g. AO) to linear
+            combinations of contractions (e.g. MO).
+            Transformation is applied to the left, i.e. the sum is over the index 1 of `transform`
+            and index 0 of the array for contractions.
+            Default is no transformation.
 
         Returns
         -------
@@ -1077,9 +1107,9 @@ class CBasis:
             Integral array.
 
         """
-        return self._rinv(inv_origin=origin, notation=notation)
+        return self._rinv(inv_origin=origin, notation=notation, transform=transform)
 
-    def momentum_integral(self, origin=None, notation="physicist"):
+    def momentum_integral(self, origin=None, notation="physicist", transform=None):
         r"""
         Compute the momentum integrals.
 
@@ -1089,6 +1119,12 @@ class CBasis:
             Origin about which to evaluate integrals.
         notation : ("physicist" | "chemist"), default="physicist"
             Axis order convention.
+        transform : np.ndarray(K, K_cont)
+            Transformation matrix from the basis set in the given coordinate system (e.g. AO) to linear
+            combinations of contractions (e.g. MO).
+            Transformation is applied to the left, i.e. the sum is over the index 1 of `transform`
+            and index 0 of the array for contractions.
+            Default is no transformation.
 
         Returns
         -------
@@ -1096,9 +1132,9 @@ class CBasis:
             Integral array.
 
         """
-        return self._mom(origin=origin, notation=notation)
+        return self._mom(origin=origin, notation=notation, transform=transform)
 
-    def angular_momentum_integral(self, origin=None, notation="physicist"):
+    def angular_momentum_integral(self, origin=None, notation="physicist", transform=None):
         r"""
         Compute the angular momentum integrals.
 
@@ -1108,6 +1144,12 @@ class CBasis:
             Origin about which to evaluate integrals.
         notation : ("physicist" | "chemist"), default="physicist"
             Axis order convention.
+        transform : np.ndarray(K, K_cont)
+            Transformation matrix from the basis set in the given coordinate system (e.g. AO) to linear
+            combinations of contractions (e.g. MO).
+            Transformation is applied to the left, i.e. the sum is over the index 1 of `transform`
+            and index 0 of the array for contractions.
+            Default is no transformation.
 
         Returns
         -------
@@ -1116,9 +1158,9 @@ class CBasis:
 
         """
         raise NotImplementedError("Angular momentum integral doesn't work; see Issue #149")
-        # return self._amom(origin=origin, notation=notation)
+        # return self._amom(origin=origin, notation=notation, transform=transform)
 
-    def point_charge_integral(self, point_coords, point_charges, notation="physicist"):
+    def point_charge_integral(self, point_coords, point_charges, notation="physicist", transform=None):
         r"""
         Compute the point charge integrals.
 
@@ -1130,6 +1172,12 @@ class CBasis:
             Charges of point charges.
         notation : ("physicist" | "chemist"), default="physicist"
             Axis order convention.
+        transform : np.ndarray(K, K_cont)
+            Transformation matrix from the basis set in the given coordinate system (e.g. AO) to linear
+            combinations of contractions (e.g. MO).
+            Transformation is applied to the left, i.e. the sum is over the index 1 of `transform`
+            and index 0 of the array for contractions.
+            Default is no transformation.
 
         Returns
         -------
@@ -1141,13 +1189,13 @@ class CBasis:
         out = np.zeros((self.nbfn, self.nbfn, len(point_charges)), dtype=c_double, order="F")
         # Compute 1/|r - r_{inv}| for each charge
         for icharge, (coord, charge) in enumerate(zip(point_coords, point_charges)):
-            val = self._rinv(inv_origin=coord, notation=notation)
+            val = self._rinv(inv_origin=coord, notation=notation, transform=transform)
             val *= -charge
             out[:, :, icharge] = val
         # Return integrals in `out` array
         return out
 
-    def moment_integral(self, orders, origin=None, notation="physicist"):
+    def moment_integral(self, orders, origin=None, notation="physicist", transform=None):
         r"""
         Compute the moment integrals.
 
@@ -1159,6 +1207,12 @@ class CBasis:
             Origin about which to evaluate integrals.
         notation : ("physicist" | "chemist"), default="physicist"
             Axis order convention.
+        transform : np.ndarray(K, K_cont)
+            Transformation matrix from the basis set in the given coordinate system (e.g. AO) to linear
+            combinations of contractions (e.g. MO).
+            Transformation is applied to the left, i.e. the sum is over the index 1 of `transform`
+            and index 0 of the array for contractions.
+            Default is no transformation.
 
         Returns
         -------
@@ -1178,9 +1232,9 @@ class CBasis:
         try:
             for i, order in enumerate(orders):
                 if sum(order) == 0:
-                    out[:, :, i] = self._ovlp(notation=notation)
+                    out[:, :, i] = self._ovlp(notation=notation, transform=transform)
                 else:
-                    out[:, :, i] = self._moments[tuple(order)](origin=origin, notation=notation)
+                    out[:, :, i] = self._moments[tuple(order)](origin=origin, notation=notation, transform=transform)
         except KeyError:
             raise ValueError(
                 "Invalid order; can use up to order 4 for any XYZ component,"


### PR DESCRIPTION
<!--

Thank you for submitting a PR!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing in this document:
https://github.com/theochem/gbasis/blob/master/CONTRIBUTING.md

-->

Fixes #178: Add transform argument to all integral methods; make sure to keep arguments in the same order as original code.

I don't see where `transform=` keyword is tested in the main Gbasis Python code... @leila-pujal are there tests for this? 

Once I add tests, it can be merged.  I made sure it still runs and passes, at least. I just want to make sure I can replicate any existing tests.

## Checklist

- [x] Write a good description of what the PR does.
- [x] Add tests for each unit of code added (e.g. function, class)
- [x] Update documentation
- [ ] Squash commits that can be grouped together
- [ ] Rebase onto master

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
| ✓  | :hammer: Refactoring  |
| ✓  | :scroll: Docs |

## Related

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
