### PR TITLE
Add '_integral' to make cbasis fn names consistent with gbasis (#177)

### DIFF
--- a/gbasis/integrals/libcint.py
+++ b/gbasis/integrals/libcint.py
@@ -978,45 +978,65 @@ class CBasis:
         # Return instance-bound integral method
         return int2e
 
-    def overlap_integral(self):
+    def overlap_integral(self, notation="physicist"):
         r"""
         Compute the overlap integrals.
 
+        Parameters
+        ----------
+        notation : ("physicist" | "chemist"), default="physicist"
+            Axis order convention.
+
         Returns
         -------
         out : np.ndarray(Nbasis, Nbasis, dtype=float)
             Integral array.
 
         """
-        return self._ovlp()
+        return self._ovlp(notation=notation)
 
-    def kinetic_energy_integral(self):
+    def kinetic_energy_integral(self, notation="physicist"):
         r"""
         Compute the kinetic energy integrals.
 
+        Parameters
+        ----------
+        notation : ("physicist" | "chemist"), default="physicist"
+            Axis order convention.
+
         Returns
         -------
         out : np.ndarray(Nbasis, Nbasis, dtype=float)
             Integral array.
 
         """
-        return self._kin()
+        return self._kin(notation=notation)
 
-    def nuclear_attraction_integral(self):
+    def nuclear_attraction_integral(self, notation="physicist"):
         r"""
         Compute the nuclear attraction integrals.
 
+        Parameters
+        ----------
+        notation : ("physicist" | "chemist"), default="physicist"
+            Axis order convention.
+
         Returns
         -------
         out : np.ndarray(Nbasis, Nbasis, dtype=float)
             Integral array.
 
         """
-        return self._nuc()
+        return self._nuc(notation=notation)
 
-    def electron_repulsion_integral(self):
+    def electron_repulsion_integral(self, notation="physicist"):
         r"""
         Compute the electron repulsion integrals.
+
+        Parameters
+        ----------
+        notation : ("physicist" | "chemist"), default="physicist"
+            Axis order convention.
 
         Returns
         -------
@@ -1024,9 +1044,9 @@ class CBasis:
             Integral array.
 
         """
-        return self._eri()
+        return self._eri(notation=notation)
 
-    def r_inv_integral(self, origin=None):
+    def r_inv_integral(self, origin=None, notation="physicist"):
         r"""
         Compute the :math:`1/\left|\mathbf{r} - \mathbf{R}_\text{inv}\right|` integrals.
 
@@ -1034,6 +1054,8 @@ class CBasis:
         ----------
         origin : np.ndarray(3, dtype=float), default=[0, 0, 0]
             Origin about which to evaluate integrals.
+        notation : ("physicist" | "chemist"), default="physicist"
+            Axis order convention.
 
         Returns
         -------
@@ -1041,9 +1063,9 @@ class CBasis:
             Integral array.
 
         """
-        return self._rinv(inv_origin=origin)
+        return self._rinv(inv_origin=origin, notation=notation)
 
-    def momentum_integral(self, origin=None):
+    def momentum_integral(self, origin=None, notation="physicist"):
         r"""
         Compute the momentum integrals.
 
@@ -1051,6 +1073,8 @@ class CBasis:
         ----------
         origin : np.ndarray(3, dtype=float), default=[0, 0, 0]
             Origin about which to evaluate integrals.
+        notation : ("physicist" | "chemist"), default="physicist"
+            Axis order convention.
 
         Returns
         -------
@@ -1058,9 +1082,9 @@ class CBasis:
             Integral array.
 
         """
-        return self._mom(origin=origin)
+        return self._mom(origin=origin, notation=notation)
 
-    def angular_momentum_integral(self, origin=None):
+    def angular_momentum_integral(self, origin=None, notation="physicist"):
         r"""
         Compute the angular momentum integrals.
 
@@ -1068,6 +1092,8 @@ class CBasis:
         ----------
         origin : np.ndarray(3, dtype=float), default=[0, 0, 0]
             Origin about which to evaluate integrals.
+        notation : ("physicist" | "chemist"), default="physicist"
+            Axis order convention.
 
         Returns
         -------
@@ -1076,9 +1102,9 @@ class CBasis:
 
         """
         raise NotImplementedError("Angular momentum integral doesn't work; see Issue #149")
-        # return self._amom(origin=origin)
+        # return self._amom(origin=origin, notation=notation)
 
-    def point_charge_integral(self, point_coords, point_charges):
+    def point_charge_integral(self, point_coords, point_charges, notation="physicist"):
         r"""
         Compute the point charge integrals.
 
@@ -1088,6 +1114,8 @@ class CBasis:
             Coordinates of point charges.
         point_charges : np.ndarray(N, dtype=float)
             Charges of point charges.
+        notation : ("physicist" | "chemist"), default="physicist"
+            Axis order convention.
 
         Returns
         -------
@@ -1099,13 +1127,13 @@ class CBasis:
         out = np.zeros((self.nbfn, self.nbfn, len(point_charges)), dtype=c_double, order="F")
         # Compute 1/|r - r_{inv}| for each charge
         for icharge, (coord, charge) in enumerate(zip(point_coords, point_charges)):
-            val = self._rinv(inv_origin=coord)
+            val = self._rinv(inv_origin=coord, notation=notation)
             val *= -charge
             out[:, :, icharge] = val
         # Return integrals in `out` array
         return out
 
-    def moment_integral(self, orders, origin=None):
+    def moment_integral(self, orders, origin=None, notation="physicist"):
         r"""
         Compute the moment integrals.
 
@@ -1115,6 +1143,8 @@ class CBasis:
             Moment orders :math:`\left[x, y, z\right\]` to evaluate.
         origin : np.ndarray(3, dtype=float), default=[0, 0, 0]
             Origin about which to evaluate integrals.
+        notation : ("physicist" | "chemist"), default="physicist"
+            Axis order convention.
 
         Returns
         -------
@@ -1134,9 +1164,9 @@ class CBasis:
         try:
             for i, order in enumerate(orders):
                 if sum(order) == 0:
-                    out[:, :, i] = self._ovlp()
+                    out[:, :, i] = self._ovlp(notation=notation)
                 else:
-                    out[:, :, i] = self._moments[tuple(order)](origin=origin)
+                    out[:, :, i] = self._moments[tuple(order)](origin=origin, notation=notation)
         except KeyError:
             raise ValueError(
                 "Invalid order; can use up to order 4 for any XYZ component,"

--- a/gbasis/integrals/libcint.py
+++ b/gbasis/integrals/libcint.py
@@ -978,7 +978,7 @@ class CBasis:
         # Return instance-bound integral method
         return int2e
 
-    def overlap(self):
+    def overlap_integral(self):
         r"""
         Compute the overlap integrals.
 
@@ -990,7 +990,7 @@ class CBasis:
         """
         return self._ovlp()
 
-    def kinetic_energy(self):
+    def kinetic_energy_integral(self):
         r"""
         Compute the kinetic energy integrals.
 
@@ -1002,7 +1002,7 @@ class CBasis:
         """
         return self._kin()
 
-    def nuclear_attraction(self):
+    def nuclear_attraction_integral(self):
         r"""
         Compute the nuclear attraction integrals.
 
@@ -1014,7 +1014,7 @@ class CBasis:
         """
         return self._nuc()
 
-    def electron_repulsion(self):
+    def electron_repulsion_integral(self):
         r"""
         Compute the electron repulsion integrals.
 
@@ -1026,7 +1026,7 @@ class CBasis:
         """
         return self._eri()
 
-    def r_inv(self, origin=None):
+    def r_inv_integral(self, origin=None):
         r"""
         Compute the :math:`1/\left|\mathbf{r} - \mathbf{R}_\text{inv}\right|` integrals.
 
@@ -1043,7 +1043,7 @@ class CBasis:
         """
         return self._rinv(inv_origin=origin)
 
-    def momentum(self, origin=None):
+    def momentum_integral(self, origin=None):
         r"""
         Compute the momentum integrals.
 
@@ -1060,7 +1060,7 @@ class CBasis:
         """
         return self._mom(origin=origin)
 
-    def angular_momentum(self, origin=None):
+    def angular_momentum_integral(self, origin=None):
         r"""
         Compute the angular momentum integrals.
 
@@ -1078,7 +1078,7 @@ class CBasis:
         raise NotImplementedError("Angular momentum integral doesn't work; see Issue #149")
         # return self._amom(origin=origin)
 
-    def point_charge(self, point_coords, point_charges):
+    def point_charge_integral(self, point_coords, point_charges):
         r"""
         Compute the point charge integrals.
 
@@ -1105,7 +1105,7 @@ class CBasis:
         # Return integrals in `out` array
         return out
 
-    def moment(self, orders, origin=None):
+    def moment_integral(self, orders, origin=None):
         r"""
         Compute the moment integrals.
 

--- a/tests/test_libcint.py
+++ b/tests/test_libcint.py
@@ -88,33 +88,33 @@ def test_integral(basis, atsyms, atcoords, coord_type, integral):
     if integral == "overlap":
         py_int = overlap_integral(py_basis)
         npt.assert_array_equal(py_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
-        lc_int = lc_basis.overlap()
+        lc_int = lc_basis.overlap_integral()
         npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
 
     elif integral == "kinetic_energy":
         py_int = kinetic_energy_integral(py_basis)
         npt.assert_array_equal(py_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
-        lc_int = lc_basis.kinetic_energy()
+        lc_int = lc_basis.kinetic_energy_integral()
         npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
 
     elif integral == "nuclear_attraction":
         py_int = nuclear_electron_attraction_integral(py_basis, atcoords, atnums)
         npt.assert_array_equal(py_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
-        lc_int = lc_basis.nuclear_attraction()
+        lc_int = lc_basis.nuclear_attraction_integral()
         npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
 
     elif integral == "angular_momentum":
         # py_int = angular_momentum_integral(py_basis)
         # npt.assert_array_equal(py_int.shape, (lc_basis.nbfn, lc_basis.nbfn, 3))
         with pytest.raises(NotImplementedError):
-            lc_int = lc_basis.angular_momentum(origin=np.zeros(3))
+            lc_int = lc_basis.angular_momentum_integral(origin=np.zeros(3))
         # npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn, 3))
         return
 
     elif integral == "momentum":
         py_int = momentum_integral(py_basis)
         npt.assert_array_equal(py_int.shape, (lc_basis.nbfn, lc_basis.nbfn, 3))
-        lc_int = lc_basis.momentum(origin=np.zeros(3))
+        lc_int = lc_basis.momentum_integral(origin=np.zeros(3))
         npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn, 3))
 
     elif integral == "electron_repulsion":
@@ -122,7 +122,7 @@ def test_integral(basis, atsyms, atcoords, coord_type, integral):
         npt.assert_array_equal(
             py_int.shape, (lc_basis.nbfn, lc_basis.nbfn, lc_basis.nbfn, lc_basis.nbfn)
         )
-        lc_int = lc_basis.electron_repulsion()
+        lc_int = lc_basis.electron_repulsion_integral()
         npt.assert_array_equal(
             lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn, lc_basis.nbfn, lc_basis.nbfn)
         )
@@ -133,7 +133,7 @@ def test_integral(basis, atsyms, atcoords, coord_type, integral):
         for i in range(1, len(charges) + 1):
             py_int = point_charge_integral(py_basis, charge_coords[:i], charges[:i])
             npt.assert_array_equal(py_int.shape, (lc_basis.nbfn, lc_basis.nbfn, i))
-            lc_int = lc_basis.point_charge(charge_coords[:i], charges[:i])
+            lc_int = lc_basis.point_charge_integral(charge_coords[:i], charges[:i])
             npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn, i))
 
     elif integral == "moment":
@@ -154,7 +154,7 @@ def test_integral(basis, atsyms, atcoords, coord_type, integral):
         )
         py_int = moment_integral(py_basis, origin, orders)
         npt.assert_array_equal(py_int.shape, (lc_basis.nbfn, lc_basis.nbfn, len(orders)))
-        lc_int = lc_basis.moment(orders, origin=origin)
+        lc_int = lc_basis.moment_integral(orders, origin=origin)
         npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn, len(orders)))
 
     else:
@@ -199,33 +199,33 @@ def test_integral_iodata(fname, elements, coord_type, integral):
     if integral == "overlap":
         py_int = overlap_integral(py_basis)
         npt.assert_array_equal(py_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
-        lc_int = lc_basis.overlap()
+        lc_int = lc_basis.overlap_integral()
         npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
 
     elif integral == "kinetic_energy":
         py_int = kinetic_energy_integral(py_basis)
         npt.assert_array_equal(py_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
-        lc_int = lc_basis.kinetic_energy()
+        lc_int = lc_basis.kinetic_energy_integral()
         npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
 
     elif integral == "nuclear_attraction":
         py_int = nuclear_electron_attraction_integral(py_basis, mol.atcoords, mol.atnums)
         npt.assert_array_equal(py_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
-        lc_int = lc_basis.nuclear_attraction()
+        lc_int = lc_basis.nuclear_attraction_integral()
         npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
 
     elif integral == "angular_momentum":
         # py_int = angular_momentum_integral(py_basis)
         # npt.assert_array_equal(py_int.shape, (lc_basis.nbfn, lc_basis.nbfn, 3))
         with pytest.raises(NotImplementedError):
-            lc_int = lc_basis.angular_momentum(origin=np.zeros(3))
+            lc_int = lc_basis.angular_momentum_integral(origin=np.zeros(3))
         # npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn, 3))
         return
 
     elif integral == "momentum":
         py_int = momentum_integral(py_basis)
         npt.assert_array_equal(py_int.shape, (lc_basis.nbfn, lc_basis.nbfn, 3))
-        lc_int = lc_basis.momentum(origin=np.zeros(3))
+        lc_int = lc_basis.momentum_integral(origin=np.zeros(3))
         npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn, 3))
 
     elif integral == "electron_repulsion":
@@ -233,7 +233,7 @@ def test_integral_iodata(fname, elements, coord_type, integral):
         npt.assert_array_equal(
             py_int.shape, (lc_basis.nbfn, lc_basis.nbfn, lc_basis.nbfn, lc_basis.nbfn)
         )
-        lc_int = lc_basis.electron_repulsion()
+        lc_int = lc_basis.electron_repulsion_integral()
         npt.assert_array_equal(
             lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn, lc_basis.nbfn, lc_basis.nbfn)
         )
@@ -244,7 +244,7 @@ def test_integral_iodata(fname, elements, coord_type, integral):
         for i in range(1, len(charges) + 1):
             py_int = point_charge_integral(py_basis, charge_coords[:i], charges[:i])
             npt.assert_array_equal(py_int.shape, (lc_basis.nbfn, lc_basis.nbfn, i))
-            lc_int = lc_basis.point_charge(charge_coords[:i], charges[:i])
+            lc_int = lc_basis.point_charge_integral(charge_coords[:i], charges[:i])
             npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn, i))
 
     elif integral == "moment":
@@ -265,7 +265,7 @@ def test_integral_iodata(fname, elements, coord_type, integral):
         )
         py_int = moment_integral(py_basis, origin, orders)
         npt.assert_array_equal(py_int.shape, (lc_basis.nbfn, lc_basis.nbfn, len(orders)))
-        lc_int = lc_basis.moment(orders, origin=origin)
+        lc_int = lc_basis.moment_integral(orders, origin=origin)
         npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn, len(orders)))
 
     else:


### PR DESCRIPTION
<!--

Thank you for submitting a PR!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing in this document:
https://github.com/theochem/gbasis/blob/master/CONTRIBUTING.md

-->

Make the functions/methods consistent between the original gbasis implementation and the libcint interface by adding `_integral` to all libcint integral methods.

Fixes #177.

## Checklist

- [x] Write a good description of what the PR does.
- [x] Add tests for each unit of code added (e.g. function, class)
- [x] Update documentation
- [x] Squash commits that can be grouped together
- [ ] Rebase onto master

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
| ✓  | :hammer: Refactoring  |
| ✓  | :scroll: Docs |

## Related

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
