### PR TITLE
Fix inclusion of libcint .so files in package_data via pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,4 +92,4 @@ addopts = "-v"
 #local_scheme = "no-local-version"
 
 [tool.setuptools.package-data]
-"gbasis.integrals.lib" = ["libcint.so*"]
+gbasis = ["integrals/include/cint*.h", "integrals/lib/libcint.so*"]


### PR DESCRIPTION
<!--

Thank you for submitting a PR!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing in this document:
https://github.com/theochem/gbasis/blob/master/CONTRIBUTING.md

-->

Previously, when running pip install on gbasis, the libcint files were not included with the distribution or in the installation. This fixed pyproject.toml so that libcint files are included with the installation now.

## Checklist

- [x] Write a good description of what the PR does.
- [x] Add tests for each unit of code added (e.g. function, class)
- [x] Update documentation
- [x] Squash commits that can be grouped together
- [ ] Rebase onto master

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
| ✓  | :hammer: Refactoring  |
| ✓  | :scroll: Docs |

## Related

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
