### PR TITLE
Fix incorrect condition for skipping Libcint tests

### DIFF
--- a/tests/test_libcint.py
+++ b/tests/test_libcint.py
@@ -1,11 +1,16 @@
 """Test gbasis.integrals.libcint."""
 
 import pytest
-import os as os
-import sys as sys
+import os
+import sys
+
+from os.path import dirname, join
+from glob import glob
 
 import numpy as np
 import numpy.testing as npt
+
+import gbasis
 
 from gbasis.integrals.angular_momentum import angular_momentum_integral
 from gbasis.integrals.electron_repulsion import electron_repulsion_integral
@@ -59,8 +64,10 @@ TEST_INTEGRALS = [
 ]
 
 @pytest.mark.skipif(sys.platform == "win32", reason="This test does not work on Windows")
-@pytest.mark.skipif(os.path.exists(f"{os.path.dirname(os.path.abspath(__file__).split('tests')[0])}/build") == False,
-                    reason="Libcint build not found")
+@pytest.mark.skipif(
+    len(glob("libcint.so*", root_dir=join(dirname(gbasis.__file__), "integrals", "lib"))) == 0,
+    reason="The libcint shared library object was not found",
+)
 @pytest.mark.parametrize("integral", TEST_INTEGRALS)
 @pytest.mark.parametrize("coord_type", TEST_COORD_TYPES)
 @pytest.mark.parametrize("atsyms, atcoords", TEST_SYSTEMS)
@@ -180,8 +187,10 @@ TEST_INTEGRALS_IODATA = [
     pytest.param("moment", id="Moment"),
 ]
 @pytest.mark.skipif(sys.platform == "win32", reason="This test does not work on Windows")
-@pytest.mark.skipif(os.path.exists(f"{os.path.dirname(os.path.abspath(__file__).split('tests')[0])}/build") == False,
-                    reason="Libcint build not found")
+@pytest.mark.skipif(
+    len(glob("libcint.so*", root_dir=join(dirname(gbasis.__file__), "integrals", "lib"))) == 0,
+    reason="The libcint shared library object was not found",
+)
 @pytest.mark.parametrize("fname, elements, coord_type", TEST_SYSTEMS_IODATA)
 @pytest.mark.parametrize("integral", TEST_INTEGRALS_IODATA)
 def test_integral_iodata(fname, elements, coord_type, integral):

--- a/tests/test_libcint.py
+++ b/tests/test_libcint.py
@@ -65,7 +65,7 @@ TEST_INTEGRALS = [
 
 @pytest.mark.skipif(sys.platform == "win32", reason="This test does not work on Windows")
 @pytest.mark.skipif(
-    len(glob("libcint.so*", root_dir=join(dirname(gbasis.__file__), "integrals", "lib"))) == 0,
+    len(glob(join(dirname(gbasis.__file__), "integrals", "lib", "libcint.so*"))) == 0,
     reason="The libcint shared library object was not found",
 )
 @pytest.mark.parametrize("integral", TEST_INTEGRALS)
@@ -188,7 +188,7 @@ TEST_INTEGRALS_IODATA = [
 ]
 @pytest.mark.skipif(sys.platform == "win32", reason="This test does not work on Windows")
 @pytest.mark.skipif(
-    len(glob("libcint.so*", root_dir=join(dirname(gbasis.__file__), "integrals", "lib"))) == 0,
+    len(glob(join(dirname(gbasis.__file__), "integrals", "lib", "libcint.so*"))) == 0,
     reason="The libcint shared library object was not found",
 )
 @pytest.mark.parametrize("fname, elements, coord_type", TEST_SYSTEMS_IODATA)


### PR DESCRIPTION
<!--

Thank you for submitting a PR!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing in this document:
https://github.com/theochem/gbasis/blob/master/CONTRIBUTING.md

-->

The current test won't work because it only checks if the build files exist: https://github.com/theochem/gbasis/blob/3a88b8400d17070e2e41e43ab281dea5a109279a/tests/test_libcint.py#L62-L63

It should actually check if a file matching `gbasis/integrals/lib/libcint.so*` exists, as this is the actual file that will be loaded, and included with gbasis when it is packaged.

This commit fixes the check, so that the libcint tests will only be skipped if Libcint is missing from the actual package.

@leila-pujal 

## Checklist

- [x] Write a good description of what the PR does.
- [x] Add tests for each unit of code added (e.g. function, class)
- [x] Update documentation
- [ ] Squash commits that can be grouped together
- [ ] Rebase onto master

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
| ✓  | :hammer: Refactoring  |
| ✓  | :scroll: Docs |

## Related

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
