### PR TITLE
libcint fix: change np.complex_ to np.complex128 for numpy 2.0

### DIFF
--- a/gbasis/integrals/libcint.py
+++ b/gbasis/integrals/libcint.py
@@ -742,7 +742,7 @@ class CBasis:
 
             # Cast `out` to complex if `is_complex` is set
             if is_complex:
-                out = out.reshape(*out.shape[:-2], -1).view(np.complex_)
+                out = out.reshape(*out.shape[:-2], -1).view(np.complex128)
 
             # Remove useless axis in `out` if no `components` was given
             if no_comp:
@@ -948,7 +948,7 @@ class CBasis:
 
             # Cast `out` to complex if `is_complex` is set
             if is_complex:
-                out = out.reshape(*out.shape[:-2], out.shape[-2] * 2).view(np.complex_)
+                out = out.reshape(*out.shape[:-2], out.shape[-2] * 2).view(np.complex128)
 
             # Remove useless axis in `out` if no `components` was given
             if no_comp:


### PR DESCRIPTION
<!--

Thank you for submitting a PR!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing in this document:
https://github.com/theochem/gbasis/blob/master/CONTRIBUTING.md

-->

Change `np.complex_` to `np.complex128` because it is removed in NumPy 2.0.

## Checklist

- [x] Write a good description of what the PR does.
- [x] Add tests for each unit of code added (e.g. function, class)
- [x] Update documentation
- [x] Squash commits that can be grouped together
- [x] Rebase onto master

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
| ✓  | :hammer: Refactoring  |
| ✓  | :scroll: Docs |

## Related

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
