### PR TITLE
Fix compatibility with changes in IOData (prepare_segmented)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ celerybeat-schedule
 *.sage.py
 
 # Environments
+.envrc
 .env
 .venv
 env/

--- a/gbasis/wrappers.py
+++ b/gbasis/wrappers.py
@@ -1,8 +1,8 @@
 """Module for interfacing to other quantum chemistry packages."""
 
-from gbasis.contractions import GeneralizedContractionShell
 import numpy as np
 
+from gbasis.contractions import GeneralizedContractionShell
 
 CONVENTIONS_LIBCINT = {
     (5, "p"): ["s5", "s4", "s3", "s2", "s1", "c0", "c1", "c2", "c3", "c4", "c5"],
@@ -123,7 +123,9 @@ def from_iodata(mol):
         raise ValueError("`mol` must be an IOData instance.")
 
     # GBasis can only work with segmented basis sets.
-    molbasis = mol.obasis.get_segmented()
+    from iodata.convert import convert_to_segmented
+
+    molbasis = convert_to_segmented(mol.obasis)
 
     cart_conventions = {i[0]: j for i, j in molbasis.conventions.items() if i[1] == "c"}
     sph_conventions = {i[0]: j for i, j in molbasis.conventions.items() if i[1] == "p"}
@@ -187,7 +189,7 @@ def from_iodata(mol):
             if self.angmom not in sph_conventions:
                 raise ValueError(
                     "Given convention does not support spherical contractions for the angular "
-                    "momentum {0}".format(self.angmom)
+                    f"momentum {self.angmom}"
                 )
 
             return tuple(sph_conventions[self.angmom])
@@ -228,7 +230,7 @@ def from_iodata(mol):
     if molbasis.primitive_normalization != "L2":  # pragma: no cover
         raise ValueError(
             "Only L2 normalization scheme is supported in `gbasis`. Given `IOData` instance uses "
-            "primitive normalization scheme, {}".format(molbasis.primitive_normalization)
+            f"primitive normalization scheme, {molbasis.primitive_normalization}"
         )
 
     basis = []


### PR DESCRIPTION
The required function is imported locally from the iodata library because the wrapper module also contains a wrapper for pyscf. When the import is made at the top and IOData is not installed, it would also become impossible to use the pyscf wrapper. (You may want to split the wrapper module into one per package to avoid local imports, but this is not critical.)

This commit includes a few side effects:

- Ruff fixes were required in wrappers.py to make the commit.
- .envrc is added to .gitignore. I used direnv for managing environments

<!--

Thank you for submitting a PR!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing in this document:
https://github.com/theochem/gbasis/blob/master/CONTRIBUTING.md

-->

<!-- Description of the PR: what it does, what issues it addresses, etc -->

## Checklist

- [x] Write a good description of what the PR does.
- [x] Tests pass locally
- [x] Pre-commit passes
- [ ] ~~Add tests for each unit of code added (e.g. function, class)~~
- [ ] ~~Update documentation~~
- [x] Squash commits that can be grouped together
- [x] Rebase onto master

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related

Fixes #195