### PR TITLE
Two-index screening

### DIFF
--- a/gbasis/integrals/angular_momentum.py
+++ b/gbasis/integrals/angular_momentum.py
@@ -115,7 +115,7 @@ class AngularMomentumIntegral(BaseTwoIndexSymmetric):
                     len(contractions_two.norm_prim_cart),
                     3,
                 ),
-                dtype=complex,
+                dtype=np.complex128,
             )
 
         diff_integrals = _compute_differential_operator_integrals_intermediate(

--- a/gbasis/integrals/angular_momentum.py
+++ b/gbasis/integrals/angular_momentum.py
@@ -123,7 +123,7 @@ class AngularMomentumIntegral(BaseTwoIndexSymmetric):
                     len(contractions_two.norm_prim_cart),
                     3,
                 ),
-                dtype=np.complex128,
+                dtype=np.float64,
             )
 
         diff_integrals = _compute_differential_operator_integrals_intermediate(

--- a/gbasis/integrals/kinetic_energy.py
+++ b/gbasis/integrals/kinetic_energy.py
@@ -107,7 +107,8 @@ class KineticEnergyIntegral(BaseTwoIndexSymmetric):
                     len(contractions_one.norm_prim_cart),
                     contractions_two.num_seg_cont,
                     len(contractions_two.norm_prim_cart),
-                )
+                ),
+                dtype=np.float64,
             )
 
         coord_a = contractions_one.coord

--- a/gbasis/integrals/kinetic_energy.py
+++ b/gbasis/integrals/kinetic_energy.py
@@ -5,7 +5,7 @@ import numpy as np
 from gbasis.base_two_symm import BaseTwoIndexSymmetric
 from gbasis.contractions import GeneralizedContractionShell
 from gbasis.integrals._diff_operator_int import _compute_differential_operator_integrals
-from gbasis.screening import is_two_index_integral_screened
+from gbasis.screening import is_two_index_overlap_screened
 
 
 class KineticEnergyIntegral(BaseTwoIndexSymmetric):
@@ -106,7 +106,7 @@ class KineticEnergyIntegral(BaseTwoIndexSymmetric):
             raise TypeError("`contractions_two` must be a `GeneralizedContractionShell` instance.")
 
         # return zero if screening is enabled, and the integral is screened
-        if screen_basis and is_two_index_integral_screened(
+        if screen_basis and is_two_index_overlap_screened(
             contractions_one, contractions_two, tol_screen
         ):
             return np.zeros(
@@ -118,32 +118,32 @@ class KineticEnergyIntegral(BaseTwoIndexSymmetric):
                 ),
                 dtype=np.float64,
             )
-        # calculate the integral otherwise
-        else:
-            coord_a = contractions_one.coord
-            angmoms_a = contractions_one.angmom_components_cart
-            alphas_a = contractions_one.exps
-            coeffs_a = contractions_one.coeffs
-            norm_a_prim = contractions_one.norm_prim_cart
-            coord_b = contractions_two.coord
-            angmoms_b = contractions_two.angmom_components_cart
-            alphas_b = contractions_two.exps
-            coeffs_b = contractions_two.coeffs
-            norm_b_prim = contractions_two.norm_prim_cart
-            output = _compute_differential_operator_integrals(
-                np.array([[2, 0, 0], [0, 2, 0], [0, 0, 2]]),
-                coord_a,
-                angmoms_a,
-                alphas_a,
-                coeffs_a,
-                norm_a_prim,
-                coord_b,
-                angmoms_b,
-                alphas_b,
-                coeffs_b,
-                norm_b_prim,
-            )
-            return -0.5 * np.sum(output, axis=0)
+
+        # compute not-screened integrals
+        coord_a = contractions_one.coord
+        angmoms_a = contractions_one.angmom_components_cart
+        alphas_a = contractions_one.exps
+        coeffs_a = contractions_one.coeffs
+        norm_a_prim = contractions_one.norm_prim_cart
+        coord_b = contractions_two.coord
+        angmoms_b = contractions_two.angmom_components_cart
+        alphas_b = contractions_two.exps
+        coeffs_b = contractions_two.coeffs
+        norm_b_prim = contractions_two.norm_prim_cart
+        output = _compute_differential_operator_integrals(
+            np.array([[2, 0, 0], [0, 2, 0], [0, 0, 2]]),
+            coord_a,
+            angmoms_a,
+            alphas_a,
+            coeffs_a,
+            norm_a_prim,
+            coord_b,
+            angmoms_b,
+            alphas_b,
+            coeffs_b,
+            norm_b_prim,
+        )
+        return -0.5 * np.sum(output, axis=0)
 
 
 def kinetic_energy_integral(basis, transform=None, screen_basis=True, tol_screen=1e-8):

--- a/gbasis/integrals/moment.py
+++ b/gbasis/integrals/moment.py
@@ -145,7 +145,8 @@ class Moment(BaseTwoIndexSymmetric):
                     contractions_two.num_seg_cont,
                     len(contractions_two.norm_prim_cart),
                     3,
-                )
+                ),
+                dtype=np.float64,
             )
 
         coord_a = contractions_one.coord

--- a/gbasis/integrals/moment.py
+++ b/gbasis/integrals/moment.py
@@ -5,7 +5,7 @@ import numpy as np
 from gbasis.base_two_symm import BaseTwoIndexSymmetric
 from gbasis.contractions import GeneralizedContractionShell
 from gbasis.integrals._moment_int import _compute_multipole_moment_integrals
-from gbasis.screening import is_two_index_integral_screened
+from gbasis.screening import is_two_index_overlap_screened
 
 
 class Moment(BaseTwoIndexSymmetric):
@@ -146,7 +146,7 @@ class Moment(BaseTwoIndexSymmetric):
             )
 
         # return zero if screening is enabled, and the integral is screened
-        if screen_basis and is_two_index_integral_screened(
+        if screen_basis and is_two_index_overlap_screened(
             contractions_one, contractions_two, tol_screen
         ):
             return np.zeros(
@@ -159,33 +159,32 @@ class Moment(BaseTwoIndexSymmetric):
                 ),
                 dtype=np.float64,
             )
-        # calculate the integral otherwise
-        else:
-            coord_a = contractions_one.coord
-            angmoms_a = contractions_one.angmom_components_cart
-            exps_a = contractions_one.exps
-            coeffs_a = contractions_one.coeffs
-            norm_a_prim = contractions_one.norm_prim_cart
-            coord_b = contractions_two.coord
-            angmoms_b = contractions_two.angmom_components_cart
-            exps_b = contractions_two.exps
-            coeffs_b = contractions_two.coeffs
-            norm_b_prim = contractions_two.norm_prim_cart
-            output = _compute_multipole_moment_integrals(
-                moment_coord,
-                moment_orders,
-                coord_a,
-                angmoms_a,
-                exps_a,
-                coeffs_a,
-                norm_a_prim,
-                coord_b,
-                angmoms_b,
-                exps_b,
-                coeffs_b,
-                norm_b_prim,
-            )
-            return np.transpose(output, (1, 2, 3, 4, 0))
+        # compute not-screened integrals
+        coord_a = contractions_one.coord
+        angmoms_a = contractions_one.angmom_components_cart
+        exps_a = contractions_one.exps
+        coeffs_a = contractions_one.coeffs
+        norm_a_prim = contractions_one.norm_prim_cart
+        coord_b = contractions_two.coord
+        angmoms_b = contractions_two.angmom_components_cart
+        exps_b = contractions_two.exps
+        coeffs_b = contractions_two.coeffs
+        norm_b_prim = contractions_two.norm_prim_cart
+        output = _compute_multipole_moment_integrals(
+            moment_coord,
+            moment_orders,
+            coord_a,
+            angmoms_a,
+            exps_a,
+            coeffs_a,
+            norm_a_prim,
+            coord_b,
+            angmoms_b,
+            exps_b,
+            coeffs_b,
+            norm_b_prim,
+        )
+        return np.transpose(output, (1, 2, 3, 4, 0))
 
 
 def moment_integral(

--- a/gbasis/integrals/momentum.py
+++ b/gbasis/integrals/momentum.py
@@ -1,8 +1,10 @@
 """Module for evaluating the integral over the momentum operator."""
+import numpy as np
+
 from gbasis.base_two_symm import BaseTwoIndexSymmetric
 from gbasis.contractions import GeneralizedContractionShell
 from gbasis.integrals._diff_operator_int import _compute_differential_operator_integrals
-import numpy as np
+from gbasis.screening import two_index_screening
 
 
 # TODO: need to test against reference
@@ -53,17 +55,22 @@ class MomentumIntegral(BaseTwoIndexSymmetric):
     """
 
     @staticmethod
-    def construct_array_contraction(contractions_one, contractions_two):
+    def construct_array_contraction(contractions_one, contractions_two, tol_screen=None):
         """Return the integrals over the momentum operator of the given contractions.
 
         Parameters
         ----------
         contractions_one : GeneralizedContractionShell
             Contracted Cartesian Gaussians (of the same shell) associated with the first index of
-            the kinetic energy integral.
+            the momentum energy integral.
         contractions_two : GeneralizedContractionShell
             Contracted Cartesian Gaussians (of the same shell) associated with the second index of
-            the kinetic energy integral.
+            the momentum energy integral.
+        tol_screen : None or float, optional
+            The tolerance used for screening momentum integrals. The `tol_screen` is combined with the
+            minimum contraction exponents to compute a cutoff which is compared to the distance between
+            the contraction centers to decide whether the momentum integral should be set to zero (i.e.,
+            screened). If `None`, no screening is performed.
 
         Returns
         -------
@@ -96,6 +103,18 @@ class MomentumIntegral(BaseTwoIndexSymmetric):
         if not isinstance(contractions_two, GeneralizedContractionShell):
             raise TypeError("`contractions_two` must be a `GeneralizedContractionShell` instance.")
 
+        if two_index_screening(contractions_one, contractions_two, tol_screen):
+            return np.zeros(
+                (
+                    contractions_one.num_seg_cont,
+                    len(contractions_one.norm_prim_cart),
+                    contractions_two.num_seg_cont,
+                    len(contractions_two.norm_prim_cart),
+                    3,
+                ),
+                dtype=complex,
+            )
+
         output = _compute_differential_operator_integrals(
             np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
             contractions_one.coord,
@@ -112,7 +131,7 @@ class MomentumIntegral(BaseTwoIndexSymmetric):
         return -1j * np.transpose(output, (1, 2, 3, 4, 0))
 
 
-def momentum_integral(basis, transform=None):
+def momentum_integral(basis, transform=None, tol_screen=None):
     r"""Return integral over momentum operator of the given basis set.
 
     .. math::
@@ -136,6 +155,12 @@ def momentum_integral(basis, transform=None):
         Transformation is applied to the left, i.e. the sum is over the index 1 of `transform`
         and index 0 of the array for contractions.
         Default is no transformation.
+        Default is no transformation.
+    tol_screen : None or float, optional
+        The tolerance used for screening momentum integrals. The `tol_screen` is combined with the
+        minimum contraction exponents to compute a cutoff which is compared to the distance between
+        the contraction centers to decide whether the momentum integral should be set to zero (i.e.,
+        screened). If `None`, no screening is performed.
 
     Returns
     -------
@@ -146,11 +171,12 @@ def momentum_integral(basis, transform=None):
 
     """
     coord_type = [ct for ct in [shell.coord_type for shell in basis]]
+    kwargs = {"tol_screen": tol_screen}
 
     if transform is not None:
-        return MomentumIntegral(basis).construct_array_lincomb(transform, coord_type)
+        return MomentumIntegral(basis).construct_array_lincomb(transform, coord_type, **kwargs)
     if all(ct == "cartesian" for ct in coord_type):
-        return MomentumIntegral(basis).construct_array_cartesian()
+        return MomentumIntegral(basis).construct_array_cartesian(**kwargs)
     if all(ct == "spherical" for ct in coord_type):
-        return MomentumIntegral(basis).construct_array_spherical()
-    return MomentumIntegral(basis).construct_array_mix(coord_type)
+        return MomentumIntegral(basis).construct_array_spherical(**kwargs)
+    return MomentumIntegral(basis).construct_array_mix(coord_type, **kwargs)

--- a/gbasis/integrals/momentum.py
+++ b/gbasis/integrals/momentum.py
@@ -112,7 +112,7 @@ class MomentumIntegral(BaseTwoIndexSymmetric):
                     len(contractions_two.norm_prim_cart),
                     3,
                 ),
-                dtype=complex,
+                dtype=np.complex128,
             )
 
         output = _compute_differential_operator_integrals(

--- a/gbasis/integrals/momentum.py
+++ b/gbasis/integrals/momentum.py
@@ -1,10 +1,11 @@
 """Module for evaluating the integral over the momentum operator."""
+
 import numpy as np
 
 from gbasis.base_two_symm import BaseTwoIndexSymmetric
 from gbasis.contractions import GeneralizedContractionShell
 from gbasis.integrals._diff_operator_int import _compute_differential_operator_integrals
-from gbasis.screening import two_index_screening
+from gbasis.screening import is_two_index_integral_screened
 
 
 # TODO: need to test against reference
@@ -55,7 +56,9 @@ class MomentumIntegral(BaseTwoIndexSymmetric):
     """
 
     @staticmethod
-    def construct_array_contraction(contractions_one, contractions_two, tol_screen=None):
+    def construct_array_contraction(
+        contractions_one, contractions_two, screen_basis=True, tol_screen=1e-8
+    ):
         """Return the integrals over the momentum operator of the given contractions.
 
         Parameters
@@ -66,11 +69,13 @@ class MomentumIntegral(BaseTwoIndexSymmetric):
         contractions_two : GeneralizedContractionShell
             Contracted Cartesian Gaussians (of the same shell) associated with the second index of
             the momentum energy integral.
-        tol_screen : None or float, optional
-            The tolerance used for screening momentum integrals. The `tol_screen` is combined with the
-            minimum contraction exponents to compute a cutoff which is compared to the distance between
-            the contraction centers to decide whether the momentum integral should be set to zero (i.e.,
-            screened). If `None`, no screening is performed.
+        screen_basis : bool, optional
+            A toggle to enable or disable screening. Default value is True to enable screening.
+        tol_screen : float, optional
+            The tolerance used for screening overlap integrals. `tol_screen` is combined with the
+            minimum contraction exponents to compute a cutoff which is compared to the distance
+            between the contraction centers to decide whether the overlap integral should be
+            set to zero. The default value for `tol_screen` is 1e-8.
 
         Returns
         -------
@@ -103,7 +108,10 @@ class MomentumIntegral(BaseTwoIndexSymmetric):
         if not isinstance(contractions_two, GeneralizedContractionShell):
             raise TypeError("`contractions_two` must be a `GeneralizedContractionShell` instance.")
 
-        if two_index_screening(contractions_one, contractions_two, tol_screen):
+        # return zero if screening is enabled, and the integral is screened
+        if screen_basis and is_two_index_integral_screened(
+            contractions_one, contractions_two, tol_screen
+        ):
             return np.zeros(
                 (
                     contractions_one.num_seg_cont,
@@ -114,24 +122,25 @@ class MomentumIntegral(BaseTwoIndexSymmetric):
                 ),
                 dtype=np.complex128,
             )
+        # calculate the integral otherwise
+        else:
+            output = _compute_differential_operator_integrals(
+                np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+                contractions_one.coord,
+                contractions_one.angmom_components_cart,
+                contractions_one.exps,
+                contractions_one.coeffs,
+                contractions_one.norm_prim_cart,
+                contractions_two.coord,
+                contractions_two.angmom_components_cart,
+                contractions_two.exps,
+                contractions_two.coeffs,
+                contractions_two.norm_prim_cart,
+            )
+            return -1j * np.transpose(output, (1, 2, 3, 4, 0))
 
-        output = _compute_differential_operator_integrals(
-            np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
-            contractions_one.coord,
-            contractions_one.angmom_components_cart,
-            contractions_one.exps,
-            contractions_one.coeffs,
-            contractions_one.norm_prim_cart,
-            contractions_two.coord,
-            contractions_two.angmom_components_cart,
-            contractions_two.exps,
-            contractions_two.coeffs,
-            contractions_two.norm_prim_cart,
-        )
-        return -1j * np.transpose(output, (1, 2, 3, 4, 0))
 
-
-def momentum_integral(basis, transform=None, tol_screen=None):
+def momentum_integral(basis, transform=None, screen_basis=True, tol_screen=1e-8):
     r"""Return integral over momentum operator of the given basis set.
 
     .. math::
@@ -156,11 +165,13 @@ def momentum_integral(basis, transform=None, tol_screen=None):
         and index 0 of the array for contractions.
         Default is no transformation.
         Default is no transformation.
-    tol_screen : None or float, optional
-        The tolerance used for screening momentum integrals. The `tol_screen` is combined with the
-        minimum contraction exponents to compute a cutoff which is compared to the distance between
-        the contraction centers to decide whether the momentum integral should be set to zero (i.e.,
-        screened). If `None`, no screening is performed.
+    screen_basis : bool, optional
+        A toggle to enable or disable screening. Default value is True to enable screening.
+    tol_screen : float, optional
+        The tolerance used for screening overlap integrals. `tol_screen` is combined with the
+        minimum contraction exponents to compute a cutoff which is compared to the distance
+        between the contraction centers to decide whether the overlap integral should be
+        set to zero. The default value for `tol_screen` is 1e-8.
 
     Returns
     -------
@@ -171,7 +182,7 @@ def momentum_integral(basis, transform=None, tol_screen=None):
 
     """
     coord_type = [ct for ct in [shell.coord_type for shell in basis]]
-    kwargs = {"tol_screen": tol_screen}
+    kwargs = {"tol_screen": tol_screen, "screen_basis": screen_basis}
 
     if transform is not None:
         return MomentumIntegral(basis).construct_array_lincomb(transform, coord_type, **kwargs)

--- a/gbasis/integrals/momentum.py
+++ b/gbasis/integrals/momentum.py
@@ -120,7 +120,7 @@ class MomentumIntegral(BaseTwoIndexSymmetric):
                     len(contractions_two.norm_prim_cart),
                     3,
                 ),
-                dtype=np.complex128,
+                dtype=np.float64,
             )
 
         # compute not-screened integrals

--- a/gbasis/integrals/momentum.py
+++ b/gbasis/integrals/momentum.py
@@ -5,7 +5,7 @@ import numpy as np
 from gbasis.base_two_symm import BaseTwoIndexSymmetric
 from gbasis.contractions import GeneralizedContractionShell
 from gbasis.integrals._diff_operator_int import _compute_differential_operator_integrals
-from gbasis.screening import is_two_index_integral_screened
+from gbasis.screening import is_two_index_overlap_screened
 
 
 # TODO: need to test against reference
@@ -109,7 +109,7 @@ class MomentumIntegral(BaseTwoIndexSymmetric):
             raise TypeError("`contractions_two` must be a `GeneralizedContractionShell` instance.")
 
         # return zero if screening is enabled, and the integral is screened
-        if screen_basis and is_two_index_integral_screened(
+        if screen_basis and is_two_index_overlap_screened(
             contractions_one, contractions_two, tol_screen
         ):
             return np.zeros(
@@ -122,22 +122,22 @@ class MomentumIntegral(BaseTwoIndexSymmetric):
                 ),
                 dtype=np.complex128,
             )
-        # calculate the integral otherwise
-        else:
-            output = _compute_differential_operator_integrals(
-                np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
-                contractions_one.coord,
-                contractions_one.angmom_components_cart,
-                contractions_one.exps,
-                contractions_one.coeffs,
-                contractions_one.norm_prim_cart,
-                contractions_two.coord,
-                contractions_two.angmom_components_cart,
-                contractions_two.exps,
-                contractions_two.coeffs,
-                contractions_two.norm_prim_cart,
-            )
-            return -1j * np.transpose(output, (1, 2, 3, 4, 0))
+
+        # compute not-screened integrals
+        output = _compute_differential_operator_integrals(
+            np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+            contractions_one.coord,
+            contractions_one.angmom_components_cart,
+            contractions_one.exps,
+            contractions_one.coeffs,
+            contractions_one.norm_prim_cart,
+            contractions_two.coord,
+            contractions_two.angmom_components_cart,
+            contractions_two.exps,
+            contractions_two.coeffs,
+            contractions_two.norm_prim_cart,
+        )
+        return -1j * np.transpose(output, (1, 2, 3, 4, 0))
 
 
 def momentum_integral(basis, transform=None, screen_basis=True, tol_screen=1e-8):

--- a/gbasis/integrals/overlap.py
+++ b/gbasis/integrals/overlap.py
@@ -5,7 +5,7 @@ import numpy as np
 from gbasis.base_two_symm import BaseTwoIndexSymmetric
 from gbasis.contractions import GeneralizedContractionShell
 from gbasis.integrals._moment_int import _compute_multipole_moment_integrals
-from gbasis.screening import is_two_index_integral_screened
+from gbasis.screening import is_two_index_overlap_screened
 
 
 class Overlap(BaseTwoIndexSymmetric):
@@ -103,7 +103,7 @@ class Overlap(BaseTwoIndexSymmetric):
             raise TypeError("`contractions_two` must be a `GeneralizedContractionShell` instance.")
 
         # return zero if screening is enabled, and the integral is screened
-        if screen_basis and is_two_index_integral_screened(
+        if screen_basis and is_two_index_overlap_screened(
             contractions_one, contractions_two, tol_screen
         ):
             return np.zeros(
@@ -115,24 +115,23 @@ class Overlap(BaseTwoIndexSymmetric):
                 ),
                 dtype=np.float64,
             )
-        # calculate integral otherwise
-        else:
-            return _compute_multipole_moment_integrals(
-                np.zeros(3),
-                np.zeros((1, 3), dtype=int),
-                # contraction on the left hand side
-                contractions_one.coord,
-                contractions_one.angmom_components_cart,
-                contractions_one.exps,
-                contractions_one.coeffs,
-                contractions_one.norm_prim_cart,
-                # contraction on the right hand side
-                contractions_two.coord,
-                contractions_two.angmom_components_cart,
-                contractions_two.exps,
-                contractions_two.coeffs,
-                contractions_two.norm_prim_cart,
-            )[0]
+        # compute not-screened integrals
+        return _compute_multipole_moment_integrals(
+            np.zeros(3),
+            np.zeros((1, 3), dtype=int),
+            # contraction on the left hand side
+            contractions_one.coord,
+            contractions_one.angmom_components_cart,
+            contractions_one.exps,
+            contractions_one.coeffs,
+            contractions_one.norm_prim_cart,
+            # contraction on the right hand side
+            contractions_two.coord,
+            contractions_two.angmom_components_cart,
+            contractions_two.exps,
+            contractions_two.coeffs,
+            contractions_two.norm_prim_cart,
+        )[0]
 
 
 def overlap_integral(basis, transform=None, screen_basis=True, tol_screen=1e-8):

--- a/gbasis/integrals/overlap.py
+++ b/gbasis/integrals/overlap.py
@@ -106,7 +106,8 @@ class Overlap(BaseTwoIndexSymmetric):
                     len(contractions_one.norm_prim_cart),
                     contractions_two.num_seg_cont,
                     len(contractions_two.norm_prim_cart),
-                )
+                ),
+                dtype=np.float64,
             )
 
         # calculate overlap integrals

--- a/gbasis/integrals/overlap_asymm.py
+++ b/gbasis/integrals/overlap_asymm.py
@@ -1,4 +1,5 @@
 """Functions for computing overlap between two basis sets."""
+
 from gbasis.base_two_asymm import BaseTwoIndexAsymmetric
 from gbasis.integrals.overlap import Overlap
 
@@ -64,7 +65,7 @@ class OverlapAsymmetric(BaseTwoIndexAsymmetric):
 
 
 def overlap_integral_asymmetric(
-    basis_one, basis_two, transform_one=None, transform_two=None, tol_screen=None
+    basis_one, basis_two, transform_one=None, transform_two=None, screen_basis=True, tol_screen=1e-8
 ):
     r"""Return overlap integrals between two basis sets.
 
@@ -92,12 +93,13 @@ def overlap_integral_asymmetric(
         Transformation is applied to the left, i.e. the sum is over the index 1 of `transform`
         and index 0 of the array for contractions.
         Default is no transformation.
-    tol_screen : None or float, optional
-        The tolerance used for screening overlap integrals. The `tol_screen` is combined with the
-        minimum contraction exponents to compute a cutoff which is compared to the distance between
-        the contraction centers to decide whether the overlap integral should be set to zero (i.e.,
-        screened). If `None`, no screening is performed.
-
+    screen_basis : bool, optional
+        A toggle to enable or disable screening. Default value is True to enable screening.
+    tol_screen : float, optional
+        The tolerance used for screening overlap integrals. `tol_screen` is combined with the
+        minimum contraction exponents to compute a cutoff which is compared to the distance
+        between the contraction centers to decide whether the overlap integral should be
+        set to zero. The default value for `tol_screen` is 1e-8.
 
     Returns
     -------
@@ -111,7 +113,7 @@ def overlap_integral_asymmetric(
     """
     coord_type_one = [ct for ct in [shell.coord_type for shell in basis_one]]
     coord_type_two = [ct for ct in [shell.coord_type for shell in basis_two]]
-    kwargs = {"tol_screen": tol_screen}
+    kwargs = {"tol_screen": tol_screen, "screen_basis": screen_basis}
 
     return OverlapAsymmetric(basis_one, basis_two).construct_array_lincomb(
         transform_one, transform_two, coord_type_one, coord_type_two, **kwargs

--- a/gbasis/integrals/overlap_asymm.py
+++ b/gbasis/integrals/overlap_asymm.py
@@ -64,12 +64,9 @@ class OverlapAsymmetric(BaseTwoIndexAsymmetric):
 
 
 def overlap_integral_asymmetric(
-    basis_one,
-    basis_two,
-    transform_one=None,
-    transform_two=None,
+    basis_one, basis_two, transform_one=None, transform_two=None, tol_screen=None
 ):
-    """Return overlap integrals between two basis sets.
+    r"""Return overlap integrals between two basis sets.
 
     .. math::
 
@@ -95,6 +92,12 @@ def overlap_integral_asymmetric(
         Transformation is applied to the left, i.e. the sum is over the index 1 of `transform`
         and index 0 of the array for contractions.
         Default is no transformation.
+    tol_screen : None or float, optional
+        The tolerance used for screening overlap integrals. The `tol_screen` is combined with the
+        minimum contraction exponents to compute a cutoff which is compared to the distance between
+        the contraction centers to decide whether the overlap integral should be set to zero (i.e.,
+        screened). If `None`, no screening is performed.
+
 
     Returns
     -------
@@ -108,7 +111,8 @@ def overlap_integral_asymmetric(
     """
     coord_type_one = [ct for ct in [shell.coord_type for shell in basis_one]]
     coord_type_two = [ct for ct in [shell.coord_type for shell in basis_two]]
+    kwargs = {"tol_screen": tol_screen}
 
     return OverlapAsymmetric(basis_one, basis_two).construct_array_lincomb(
-        transform_one, transform_two, coord_type_one, coord_type_two
+        transform_one, transform_two, coord_type_one, coord_type_two, **kwargs
     )

--- a/gbasis/screening.py
+++ b/gbasis/screening.py
@@ -1,25 +1,6 @@
 """1 and 2-index screening functions"""
 
 import numpy as np
-from scipy.special import factorial2, lambertw
-
-
-def one_index_screening(contractions, points, tol_screen=None):
-    if tol_screen is None:
-        return True
-
-    c_min = np.abs(contractions.coeffs.min())
-    exp_min = contractions.exps.min()
-    angm = contractions.angmom
-    n_min = np.sqrt(
-        (np.sqrt(2 * exp_min) * (4 * exp_min) ** angm) / (np.sqrt(np.pi) * factorial2(2 * angm + 1))
-    )
-    A = tol_screen / (n_min * c_min)
-    d2 = np.log(A) / -exp_min if angm == 0 else lambertw(A, k=-1).real / -exp_min
-
-    cutoff = np.sqrt(d2)
-
-    return np.linalg.norm(points - contractions.coord, axis=1) <= cutoff
 
 
 def two_index_screening(contractions_one, contractions_two, tol_screen):

--- a/gbasis/screening.py
+++ b/gbasis/screening.py
@@ -1,0 +1,71 @@
+"""1 and 2-index screening functions"""
+
+import numpy as np
+from scipy.special import factorial2, lambertw
+
+
+def one_index_screening(contractions, points, tol_screen=None):
+    if tol_screen is None:
+        return True
+
+    c_min = np.abs(contractions.coeffs.min())
+    exp_min = contractions.exps.min()
+    angm = contractions.angmom
+    n_min = np.sqrt(
+        (np.sqrt(2 * exp_min) * (4 * exp_min) ** angm) / (np.sqrt(np.pi) * factorial2(2 * angm + 1))
+    )
+    A = tol_screen / (n_min * c_min)
+    d2 = np.log(A) / -exp_min if angm == 0 else lambertw(A, k=-1).real / -exp_min
+
+    cutoff = np.sqrt(d2)
+
+    return np.linalg.norm(points - contractions.coord, axis=1) <= cutoff
+
+
+def two_index_screening(contractions_one, contractions_two, tol_screen):
+    r"""Return True or False in response to whether integral is required.
+
+    .. math::
+           d_{A_s;B_t} > \sqrt{-\frac{\alpha_{ min(\alpha_{s,A})} +
+           \alpha_{ min(\alpha_{t,B})} }{ \alpha_{ min(\alpha_{s,A})}
+            \alpha_{ min(\alpha_{t,B})} } \ln \varepsilon }
+
+    where :math:`d` is the cut-off distance at which shells do not interact with each other.
+    :math:`A` and `B` are the atoms each contraction are respectively centered on.
+    :math: `\alpha` is the gaussian exponent
+    :math: `s` and `t` index the primitive Gaussian shells centered on atom `A` and `B` respectively.
+
+    Parameters
+    ----------
+    contractions_one : GeneralizedContractionShell
+        Contracted Cartesian Gaussians (of the same shell) associated with the first index of
+        the integral.
+    contractions_two : GeneralizedContractionShell
+        Contracted Cartesian Gaussians (of the same shell) associated with the second index of
+        the integral.
+    tol_screen : bool or float, optional
+        The tolerance used for screening two-index integrals. The `tol_screen` is combined with the
+        minimum contraction exponents to compute a cutoff which is compared to the distance between
+        the contraction centers to decide whether the integral should be set to zero.
+        If `None`, no screening is performed.
+
+    Returns
+    -------
+    value : `bool`
+        If integral is required, return `True`
+    """
+
+    # check screening_tol
+    if isinstance(tol_screen, bool):
+        raise TypeError(f"Argument tol_screen must be a float or None. Got {type(tol_screen)}.")
+
+    # test if screening is required
+    if tol_screen is None:
+        return False
+
+    # calculate distance cutoff
+    alpha_a = min(contractions_one.exps)
+    alpha_b = min(contractions_two.exps)
+    r_12 = contractions_two.coord - contractions_one.coord
+    cutoff = np.sqrt(-(alpha_a + alpha_b) / (alpha_a * alpha_b) * np.log(tol_screen))
+    return np.linalg.norm(r_12) > cutoff

--- a/gbasis/screening.py
+++ b/gbasis/screening.py
@@ -4,7 +4,7 @@ import numpy as np
 
 
 def two_index_screening(contractions_one, contractions_two, tol_screen):
-    r"""Return True or False in response to whether integral is required.
+    r"""Return True if the integral should be screened.
 
     .. math::
            d_{A_s;B_t} > \sqrt{-\frac{\alpha_{ min(\alpha_{s,A})} +
@@ -14,7 +14,7 @@ def two_index_screening(contractions_one, contractions_two, tol_screen):
     where :math:`d` is the cut-off distance at which shells do not interact with each other.
     :math:`A` and `B` are the atoms each contraction are respectively centered on.
     :math: `\alpha` is the gaussian exponent
-    :math: `s` and `t` index the primitive Gaussian shells centered on atom `A` and `B` respectively.
+    :math: `s` and `t` index primitive Gaussian shells centered on atom `A` and `B` respectively.
 
     Parameters
     ----------
@@ -24,7 +24,7 @@ def two_index_screening(contractions_one, contractions_two, tol_screen):
     contractions_two : GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) associated with the second index of
         the integral.
-    tol_screen : bool or float, optional
+    tol_screen : None or float, optional
         The tolerance used for screening two-index integrals. The `tol_screen` is combined with the
         minimum contraction exponents to compute a cutoff which is compared to the distance between
         the contraction centers to decide whether the integral should be set to zero.
@@ -33,7 +33,7 @@ def two_index_screening(contractions_one, contractions_two, tol_screen):
     Returns
     -------
     value : `bool`
-        If integral is required, return `True`
+        If integral should be screened, return `True`
     """
 
     # check screening_tol

--- a/gbasis/screening.py
+++ b/gbasis/screening.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 
-def two_index_screening(contractions_one, contractions_two, tol_screen):
+def is_two_index_integral_screened(contractions_one, contractions_two, tol_screen):
     r"""Return True if the integral should be screened.
 
     .. math::
@@ -24,11 +24,10 @@ def two_index_screening(contractions_one, contractions_two, tol_screen):
     contractions_two : GeneralizedContractionShell
         Contracted Cartesian Gaussians (of the same shell) associated with the second index of
         the integral.
-    tol_screen : None or float, optional
+    tol_screen : float, optional
         The tolerance used for screening two-index integrals. The `tol_screen` is combined with the
         minimum contraction exponents to compute a cutoff which is compared to the distance between
         the contraction centers to decide whether the integral should be set to zero.
-        If `None`, no screening is performed.
 
     Returns
     -------
@@ -36,13 +35,9 @@ def two_index_screening(contractions_one, contractions_two, tol_screen):
         If integral should be screened, return `True`
     """
 
-    # check screening_tol
+    # check tol_screen
     if isinstance(tol_screen, bool):
-        raise TypeError(f"Argument tol_screen must be a float or None. Got {type(tol_screen)}.")
-
-    # test if screening is required
-    if tol_screen is None:
-        return False
+        raise TypeError(f"Argument tol_screen must be a float. Got {type(tol_screen)}.")
 
     # calculate distance cutoff
     alpha_a = min(contractions_one.exps)

--- a/gbasis/screening.py
+++ b/gbasis/screening.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 
-def is_two_index_integral_screened(contractions_one, contractions_two, tol_screen):
+def is_two_index_overlap_screened(contractions_one, contractions_two, tol_screen):
     r"""Return True if the integral should be screened.
 
     .. math::
@@ -35,13 +35,10 @@ def is_two_index_integral_screened(contractions_one, contractions_two, tol_scree
         If integral should be screened, return `True`
     """
 
-    # check tol_screen
-    if isinstance(tol_screen, bool):
-        raise TypeError(f"Argument tol_screen must be a float. Got {type(tol_screen)}.")
-
     # calculate distance cutoff
     alpha_a = min(contractions_one.exps)
     alpha_b = min(contractions_two.exps)
     r_12 = contractions_two.coord - contractions_one.coord
     cutoff = np.sqrt(-(alpha_a + alpha_b) / (alpha_a * alpha_b) * np.log(tol_screen))
+    # integrals are screened if centers are further apart than the cutoff
     return np.linalg.norm(r_12) > cutoff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ line-length = 100
 # PL is pylint
 # RUF is Ruff-specific rules
 select = ["E", "F", "UP", "B", "I", "PGH", "PL", "RUF"]
-line-length = 100
+line-length = 120
 ignore = ["PLR2004", "PLR0913", "PLR0912", "PLW2901", "PLR0915", "RUF013"]
 extend-exclude = ["doc/*", "doc/*/*"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ line-length = 100
 # PL is pylint
 # RUF is Ruff-specific rules
 select = ["E", "F", "UP", "B", "I", "PGH", "PL", "RUF"]
-line-length = 120
+line-length = 100
 ignore = ["PLR2004", "PLR0913", "PLR0912", "PLW2901", "PLR0915", "RUF013"]
 extend-exclude = ["doc/*", "doc/*/*"]
 

--- a/tests/test_angular_momentum.py
+++ b/tests/test_angular_momentum.py
@@ -415,11 +415,8 @@ def test_angular_momentum_integral_lincomb():
 
 @pytest.mark.parametrize("precision", [1.0e-5, 1.0e-6, 1.0e-7, 1.0e-8])
 def test_angular_momentum_screening_accuracy(precision):
-    """Test angular momentum screening.
+    """Test angular momentum screening."""
 
-    This test is meant to  fail.  Using cartesian sto-6G nwchem basis set.
-
-    """
     basis_dict = parse_gbs(find_datafile("data_631g.gbs"))
     atsymbols = ["H", "C", "Kr"]
     atcoords = np.array([[0, 0, 0], [1, 1, 1], [2, 2, 2]])

--- a/tests/test_angular_momentum.py
+++ b/tests/test_angular_momentum.py
@@ -5,7 +5,7 @@ from gbasis.integrals._diff_operator_int import (
 )
 from gbasis.integrals._moment_int import _compute_multipole_moment_integrals_intermediate
 from gbasis.integrals.angular_momentum import angular_momentum_integral, AngularMomentumIntegral
-from gbasis.parsers import make_contractions, parse_nwchem
+from gbasis.parsers import make_contractions, parse_gbs, parse_nwchem
 import numpy as np
 import pytest
 from utils import find_datafile
@@ -411,3 +411,22 @@ def test_angular_momentum_integral_lincomb():
         angular_momentum_integral_obj.construct_array_lincomb(transform, ["spherical"]),
         angular_momentum_integral(basis, transform),
     )
+
+
+@pytest.mark.parametrize("precision", [1.0e-5, 1.0e-6, 1.0e-7, 1.0e-8])
+def test_angular_momentum_screening_accuracy(precision):
+    """Test angular momentum screening.
+
+    This test is meant to  fail.  Using cartesian sto-6G nwchem basis set.
+
+    """
+    basis_dict = parse_gbs(find_datafile("data_631g.gbs"))
+    atsymbols = ["H", "C", "Kr"]
+    atcoords = np.array([[0, 0, 0], [1, 1, 1], [2, 2, 2]])
+    contraction = make_contractions(basis_dict, atsymbols, atcoords, "cartesian")
+
+    #  the screening tolerance needs to be 1e-4 times the desired precision
+    tol_screen = precision * 1e-4
+    angular_momentum = angular_momentum_integral(contraction, tol_screen=tol_screen)
+    angular_momentum_no_screen = angular_momentum_integral(contraction, screen_basis=False)
+    assert np.allclose(angular_momentum, angular_momentum_no_screen, atol=precision)

--- a/tests/test_kinetic_energy.py
+++ b/tests/test_kinetic_energy.py
@@ -252,11 +252,8 @@ def test_kinetic_energy_integral_horton_anorcc_bec():
 
 @pytest.mark.parametrize("precision", [1.0e-5, 1.0e-6, 1.0e-7, 1.0e-8])
 def test_kinetic_screening_accuracy(precision):
-    """Test kinetic energy screening.
-
-    This test is meant to  fail.  Using cartesian sto-6G nwchem basis set.
-
-    """
+    """Test kinetic energy screening."""
+    
     basis_dict = parse_gbs(find_datafile("data_631g.gbs"))
     atsymbols = ["H", "C", "Kr"]
     atcoords = np.array([[0, 0, 0], [1, 1, 1], [2, 2, 2]])

--- a/tests/test_kinetic_energy.py
+++ b/tests/test_kinetic_energy.py
@@ -146,15 +146,14 @@ def test_kinetic_energy_construct_array_contraction():
             for angmom_comp_one in test_one.angmom_components_cart
         ]
     )
-    assert np.allclose(
-        np.squeeze(KineticEnergyIntegral.construct_array_contraction(test_one, test_two)),
-        np.squeeze(-0.5 * answer),
-    )
+
+    val = KineticEnergyIntegral.construct_array_contraction(test_one, test_two, screen_basis=False)
+    assert np.allclose(np.squeeze(val), np.squeeze(-0.5 * answer))
 
     with pytest.raises(TypeError):
-        KineticEnergyIntegral.construct_array_contraction(test_one, None)
+        KineticEnergyIntegral.construct_array_contraction(test_one, None, screen_basis=False)
     with pytest.raises(TypeError):
-        KineticEnergyIntegral.construct_array_contraction(None, test_two)
+        KineticEnergyIntegral.construct_array_contraction(None, test_two, screen_basis=False)
 
 
 def test_kinetic_energy_integral_cartesian():
@@ -163,8 +162,8 @@ def test_kinetic_energy_integral_cartesian():
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]), "cartesian")
     kinetic_energy_integral_obj = KineticEnergyIntegral(basis)
     assert np.allclose(
-        kinetic_energy_integral_obj.construct_array_cartesian(),
-        kinetic_energy_integral(basis),
+        kinetic_energy_integral_obj.construct_array_cartesian(screen_basis=False),
+        kinetic_energy_integral(basis, screen_basis=False),
     )
 
 
@@ -175,8 +174,8 @@ def test_kinetic_energy_integral_spherical():
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]), "spherical")
     kinetic_energy_integral_obj = KineticEnergyIntegral(basis)
     assert np.allclose(
-        kinetic_energy_integral_obj.construct_array_spherical(),
-        kinetic_energy_integral(basis),
+        kinetic_energy_integral_obj.construct_array_spherical(screen_basis=False),
+        kinetic_energy_integral(basis, screen_basis=False),
     )
 
 
@@ -187,8 +186,8 @@ def test_kinetic_energy_integral_mix():
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]), ["spherical"] * 8)
     kinetic_energy_integral_obj = KineticEnergyIntegral(basis)
     assert np.allclose(
-        kinetic_energy_integral_obj.construct_array_mix(["spherical"] * 8),
-        kinetic_energy_integral(basis),
+        kinetic_energy_integral_obj.construct_array_mix(["spherical"] * 8, screen_basis=False),
+        kinetic_energy_integral(basis, screen_basis=False),
     )
 
 
@@ -199,8 +198,10 @@ def test_kinetic_energy_integral_lincomb():
     kinetic_energy_integral_obj = KineticEnergyIntegral(basis)
     transform = np.random.rand(14, 18)
     assert np.allclose(
-        kinetic_energy_integral_obj.construct_array_lincomb(transform, ["spherical"]),
-        kinetic_energy_integral(basis, transform),
+        kinetic_energy_integral_obj.construct_array_lincomb(
+            transform, ["spherical"] * 8, screen_basis=False
+        ),
+        kinetic_energy_integral(basis, transform, screen_basis=False),
     )
 
 
@@ -223,7 +224,8 @@ def test_kinetic_energy_integral_horton_anorcc_hhe():
     horton_kinetic_energy_integral = np.load(
         find_datafile("data_horton_hhe_cart_kinetic_energy_integral.npy")
     )
-    assert np.allclose(kinetic_energy_integral(basis), horton_kinetic_energy_integral)
+    ke_integral = kinetic_energy_integral(basis, screen_basis=False)
+    assert np.allclose(ke_integral, horton_kinetic_energy_integral)
 
 
 def test_kinetic_energy_integral_horton_anorcc_bec():
@@ -245,4 +247,5 @@ def test_kinetic_energy_integral_horton_anorcc_bec():
     horton_kinetic_energy_integral = np.load(
         find_datafile("data_horton_bec_cart_kinetic_energy_integral.npy")
     )
-    assert np.allclose(kinetic_energy_integral(basis), horton_kinetic_energy_integral)
+    ke_int_values = kinetic_energy_integral(basis, screen_basis=False)
+    assert np.allclose(ke_int_values, horton_kinetic_energy_integral)

--- a/tests/test_libcint.py
+++ b/tests/test_libcint.py
@@ -93,13 +93,13 @@ def test_integral(basis, atsyms, atcoords, coord_type, integral):
     lc_basis = CBasis(py_basis, atsyms, atcoords, coord_type=coord_type)
 
     if integral == "overlap":
-        py_int = overlap_integral(py_basis)
+        py_int = overlap_integral(py_basis, screen_basis=False)
         npt.assert_array_equal(py_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
         lc_int = lc_basis.overlap_integral()
         npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
 
     elif integral == "kinetic_energy":
-        py_int = kinetic_energy_integral(py_basis)
+        py_int = kinetic_energy_integral(py_basis, screen_basis=False)
         npt.assert_array_equal(py_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
         lc_int = lc_basis.kinetic_energy_integral()
         npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
@@ -119,7 +119,7 @@ def test_integral(basis, atsyms, atcoords, coord_type, integral):
         return
 
     elif integral == "momentum":
-        py_int = momentum_integral(py_basis)
+        py_int = momentum_integral(py_basis, screen_basis=False)
         npt.assert_array_equal(py_int.shape, (lc_basis.nbfn, lc_basis.nbfn, 3))
         lc_int = lc_basis.momentum_integral(origin=np.zeros(3))
         npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn, 3))
@@ -159,7 +159,7 @@ def test_integral(basis, atsyms, atcoords, coord_type, integral):
                 [0, 1, 1],
             ]
         )
-        py_int = moment_integral(py_basis, origin, orders)
+        py_int = moment_integral(py_basis, origin, orders, screen_basis=False)
         npt.assert_array_equal(py_int.shape, (lc_basis.nbfn, lc_basis.nbfn, len(orders)))
         lc_int = lc_basis.moment_integral(orders, origin=origin)
         npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn, len(orders)))
@@ -213,24 +213,24 @@ def test_integral_iodata(fname, elements, coord_type, integral, transform):
 
     if integral == "overlap":
         if transform:
-            py_int = overlap_integral(py_basis, transform=mol.mo.coeffs.T)
+            py_int = overlap_integral(py_basis, transform=mol.mo.coeffs.T, screen_basis=False)
             npt.assert_array_equal(py_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
             lc_int = lc_basis.overlap_integral(transform=mol.mo.coeffs.T)
             npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
         else:
-            py_int = overlap_integral(py_basis)
+            py_int = overlap_integral(py_basis, screen_basis=False)
             npt.assert_array_equal(py_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
             lc_int = lc_basis.overlap_integral()
             npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
 
     elif integral == "kinetic_energy":
         if transform:
-            py_int = kinetic_energy_integral(py_basis, transform=mol.mo.coeffs.T)
+            py_int = kinetic_energy_integral(py_basis, transform=mol.mo.coeffs.T, screen_basis=False)
             npt.assert_array_equal(py_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
             lc_int = lc_basis.kinetic_energy_integral(transform=mol.mo.coeffs.T)
             npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
         else:
-            py_int = kinetic_energy_integral(py_basis)
+            py_int = kinetic_energy_integral(py_basis, screen_basis=False)
             npt.assert_array_equal(py_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
             lc_int = lc_basis.kinetic_energy_integral()
             npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
@@ -258,12 +258,12 @@ def test_integral_iodata(fname, elements, coord_type, integral, transform):
 
     elif integral == "momentum":
         if transform:
-            py_int = momentum_integral(py_basis, transform=mol.mo.coeffs.T)
+            py_int = momentum_integral(py_basis, transform=mol.mo.coeffs.T, screen_basis=False)
             npt.assert_array_equal(py_int.shape, (lc_basis.nbfn, lc_basis.nbfn, 3))
             lc_int = lc_basis.momentum_integral(origin=np.zeros(3), transform=mol.mo.coeffs.T)
             npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn, 3))
         else:
-            py_int = momentum_integral(py_basis)
+            py_int = momentum_integral(py_basis, screen_basis=False)
             npt.assert_array_equal(py_int.shape, (lc_basis.nbfn, lc_basis.nbfn, 3))
             lc_int = lc_basis.momentum_integral(origin=np.zeros(3))
             npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn, 3))
@@ -324,12 +324,12 @@ def test_integral_iodata(fname, elements, coord_type, integral, transform):
             ]
         )
         if transform:
-            py_int = moment_integral(py_basis, origin, orders, transform=mol.mo.coeffs.T)
+            py_int = moment_integral(py_basis, origin, orders, transform=mol.mo.coeffs.T, screen_basis=False)
             npt.assert_array_equal(py_int.shape, (lc_basis.nbfn, lc_basis.nbfn, len(orders)))
             lc_int = lc_basis.moment_integral(orders, origin=origin, transform=mol.mo.coeffs.T)
             npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn, len(orders)))
         else:
-            py_int = moment_integral(py_basis, origin, orders)
+            py_int = moment_integral(py_basis, origin, orders, screen_basis=False)
             npt.assert_array_equal(py_int.shape, (lc_basis.nbfn, lc_basis.nbfn, len(orders)))
             lc_int = lc_basis.moment_integral(orders, origin=origin)
             npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn, len(orders)))

--- a/tests/test_moment.py
+++ b/tests/test_moment.py
@@ -94,6 +94,7 @@ def test_moment_construct_array_contraction():
                         [0, 1, 1],
                     ]
                 ),
+                screen_basis=False,
             )
         ),
         np.squeeze(answer),
@@ -154,6 +155,7 @@ def test_moment_cartesian():
                     [0, 1, 1],
                 ]
             ),
+            screen_basis=False,
         ),
         moment_integral(
             basis,
@@ -172,6 +174,7 @@ def test_moment_cartesian():
                     [0, 1, 1],
                 ]
             ),
+            screen_basis=False,
         ),
     )
 
@@ -199,6 +202,7 @@ def test_moment_spherical():
                     [0, 1, 1],
                 ]
             ),
+            screen_basis=False,
         ),
         moment_integral(
             basis,
@@ -217,6 +221,7 @@ def test_moment_spherical():
                     [0, 1, 1],
                 ]
             ),
+            screen_basis=False,
         ),
     )
 
@@ -245,6 +250,7 @@ def test_moment_mix():
                     [0, 1, 1],
                 ]
             ),
+            screen_basis=False,
         ),
         moment_integral(
             basis,
@@ -263,6 +269,7 @@ def test_moment_mix():
                     [0, 1, 1],
                 ]
             ),
+            screen_basis=False,
         ),
     )
 
@@ -292,6 +299,7 @@ def test_moment_spherical_lincomb():
                     [0, 1, 1],
                 ]
             ),
+            screen_basis=False,
         ),
         moment_integral(
             basis,
@@ -311,5 +319,6 @@ def test_moment_spherical_lincomb():
                 ]
             ),
             transform=transform,
+            screen_basis=False,
         ),
     )

--- a/tests/test_moment.py
+++ b/tests/test_moment.py
@@ -326,11 +326,8 @@ def test_moment_spherical_lincomb():
 
 @pytest.mark.parametrize("precision", [1.0e-5, 1.0e-6, 1.0e-7, 1.0e-8])
 def test_moment_screening_accuracy(precision):
-    """Test (dipole) moment screening.
+    """Test (dipole) moment screening."""
 
-    This test is meant to  fail.  Using cartesian sto-6G nwchem basis set.
-
-    """
     basis_dict = parse_gbs(find_datafile("data_631g.gbs"))
     atsymbols = ["H", "C", "Kr"]
     atcoords = np.array([[0, 0, 0], [1, 1, 1], [2, 2, 2]])

--- a/tests/test_momentum.py
+++ b/tests/test_momentum.py
@@ -2,7 +2,7 @@
 from gbasis.contractions import GeneralizedContractionShell
 from gbasis.integrals._diff_operator_int import _compute_differential_operator_integrals
 from gbasis.integrals.momentum import momentum_integral, MomentumIntegral
-from gbasis.parsers import make_contractions, parse_nwchem
+from gbasis.parsers import make_contractions, parse_gbs, parse_nwchem
 from gbasis.utils import factorial2
 import numpy as np
 import pytest
@@ -206,3 +206,22 @@ def test_momentum_integral_lincomb():
         momentum_integral_obj.construct_array_lincomb(transform, ["spherical"], screen_basis=False),
         momentum_integral(basis, transform=transform, screen_basis=False),
     )
+
+
+@pytest.mark.parametrize("precision", [1.0e-5, 1.0e-6, 1.0e-7, 1.0e-8])
+def test_momentum_screening_accuracy(precision):
+    """Test momentum screening.
+
+    This test is meant to  fail.  Using cartesian sto-6G nwchem basis set.
+
+    """
+    basis_dict = parse_gbs(find_datafile("data_631g.gbs"))
+    atsymbols = ["H", "C", "Kr"]
+    atcoords = np.array([[0, 0, 0], [1, 1, 1], [2, 2, 2]])
+    contraction = make_contractions(basis_dict, atsymbols, atcoords, "cartesian")
+
+    #  the screening tolerance needs to be 1e-4 times the desired precision
+    tol_screen = precision * 1e-4
+    momentum = momentum_integral(contraction, tol_screen=tol_screen)
+    momentum_no_screen = momentum_integral(contraction, screen_basis=False)
+    assert np.allclose(momentum, momentum_no_screen, atol=precision)

--- a/tests/test_momentum.py
+++ b/tests/test_momentum.py
@@ -210,11 +210,8 @@ def test_momentum_integral_lincomb():
 
 @pytest.mark.parametrize("precision", [1.0e-5, 1.0e-6, 1.0e-7, 1.0e-8])
 def test_momentum_screening_accuracy(precision):
-    """Test momentum screening.
+    """Test momentum screening."""
 
-    This test is meant to  fail.  Using cartesian sto-6G nwchem basis set.
-
-    """
     basis_dict = parse_gbs(find_datafile("data_631g.gbs"))
     atsymbols = ["H", "C", "Kr"]
     atcoords = np.array([[0, 0, 0], [1, 1, 1], [2, 2, 2]])

--- a/tests/test_momentum.py
+++ b/tests/test_momentum.py
@@ -17,7 +17,9 @@ def test_momentum_construct_array_contraction():
     test_two = GeneralizedContractionShell(
         2, np.array([1.5, 2, 3]), np.array([3.0, 4.0]), np.array([0.2, 0.02]), "spherical"
     )
-    test = MomentumIntegral.construct_array_contraction(test_one, test_two).squeeze()
+    test = MomentumIntegral.construct_array_contraction(
+        test_one, test_two, screen_basis=False
+    ).squeeze()
     answer = np.array(
         [
             [
@@ -165,8 +167,8 @@ def test_momentum_integral_cartesian():
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]), "cartesian")
     momentum_integral_obj = MomentumIntegral(basis)
     assert np.allclose(
-        momentum_integral_obj.construct_array_cartesian(),
-        momentum_integral(basis),
+        momentum_integral_obj.construct_array_cartesian(screen_basis=False),
+        momentum_integral(basis, screen_basis=False),
     )
 
 
@@ -177,8 +179,8 @@ def test_momentum_integral_spherical():
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]), "spherical")
     momentum_integral_obj = MomentumIntegral(basis)
     assert np.allclose(
-        momentum_integral_obj.construct_array_spherical(),
-        momentum_integral(basis),
+        momentum_integral_obj.construct_array_spherical(screen_basis=False),
+        momentum_integral(basis, screen_basis=False),
     )
 
 
@@ -189,8 +191,8 @@ def test_momentum_integral_mix():
     basis = make_contractions(basis_dict, ["Kr"], np.array([[0, 0, 0]]), ["spherical"] * 8)
     momentum_integral_obj = MomentumIntegral(basis)
     assert np.allclose(
-        momentum_integral_obj.construct_array_mix(["spherical"] * 8),
-        momentum_integral(basis),
+        momentum_integral_obj.construct_array_mix(["spherical"] * 8, screen_basis=False),
+        momentum_integral(basis, screen_basis=False),
     )
 
 
@@ -201,6 +203,6 @@ def test_momentum_integral_lincomb():
     momentum_integral_obj = MomentumIntegral(basis)
     transform = np.random.rand(14, 18)
     assert np.allclose(
-        momentum_integral_obj.construct_array_lincomb(transform, ["spherical"]),
-        momentum_integral(basis, transform=transform),
+        momentum_integral_obj.construct_array_lincomb(transform, ["spherical"], screen_basis=False),
+        momentum_integral(basis, transform=transform, screen_basis=False),
     )

--- a/tests/test_overlap.py
+++ b/tests/test_overlap.py
@@ -212,23 +212,6 @@ def test_overlap_horton_anorcc_bec():
     horton_overlap = np.load(find_datafile("data_horton_bec_cart_overlap.npy"))
     assert np.allclose(overlap_integral(basis), horton_overlap)
 
-
-def test_overlap_screening_vs_without_screening():
-    """Test overlap screening.
-
-    This test is meant to  pass.  Using spherical 6-31G Gaussian basis set.
-
-    """
-    basis_dict = parse_gbs(find_datafile("data_631g.gbs"))
-    atsymbols = ["H", "C", "Kr"]
-    atcoords = np.array([[0, 0, 0], [1, 1, 1], [2, 2, 2]])
-    contraction = make_contractions(basis_dict, atsymbols, atcoords, "spherical")
-
-    # check overlap integrals with and without screening match
-    overlaps = overlap_integral(contraction, tol_screen=1.0e-10)
-    overlaps_no_screen = overlap_integral(contraction, tol_screen=None)
-    assert np.allclose(overlaps, overlaps_no_screen)
-
 @pytest.mark.parametrize("precision", [1.0e-5, 1.0e-6, 1.0e-7, 1.0e-8])
 def test_overlap_screening_tight(precision):
     """Test overlap screening.

--- a/tests/test_overlap.py
+++ b/tests/test_overlap.py
@@ -229,8 +229,8 @@ def test_overlap_screening_vs_without_screening():
     overlaps_no_screen = overlap_integral(contraction, tol_screen=None)
     assert np.allclose(overlaps, overlaps_no_screen)
 
-
-def test_overlap_screening_with_fail():
+@pytest.mark.parametrize("precision", [1.0e-5, 1.0e-6, 1.0e-7, 1.0e-8])
+def test_overlap_screening_tight(precision):
     """Test overlap screening.
 
     This test is meant to  fail.  Using cartesian sto-6G nwchem basis set.
@@ -241,7 +241,8 @@ def test_overlap_screening_with_fail():
     atcoords = np.array([[0, 0, 0], [1, 1, 1], [2, 2, 2]])
     contraction = make_contractions(basis_dict, atsymbols, atcoords, "cartesian")
 
-    # check overlap integrals with and without screening do not match
-    overlaps = overlap_integral(contraction, tol_screen=1.0e-2)
-    overlaps_no_screen = overlap_integral(contraction, tol_screen=None)
-    assert not np.allclose(overlaps, overlaps_no_screen)
+    #  the screening tolerance needs to be 1e-4 times the desired precision
+    tol_screen = precision * 1e-4
+    overlaps = overlap_integral(contraction, tol_screen=tol_screen)
+    overlaps_no_screen = overlap_integral(contraction, screen_basis=False)
+    assert np.allclose(overlaps, overlaps_no_screen, atol=precision)

--- a/tests/test_overlap.py
+++ b/tests/test_overlap.py
@@ -218,11 +218,8 @@ def test_overlap_horton_anorcc_bec():
 
 @pytest.mark.parametrize("precision", [1.0e-5, 1.0e-6, 1.0e-7, 1.0e-8])
 def test_overlap_screening_accuracy(precision):
-    """Test overlap screening.
+    """Test overlap screening."""
 
-    This test is meant to  fail.  Using cartesian sto-6G nwchem basis set.
-
-    """
     basis_dict = parse_gbs(find_datafile("data_631g.gbs"))
     atsymbols = ["H", "C", "Kr"]
     atcoords = np.array([[0, 0, 0], [1, 1, 1], [2, 2, 2]])

--- a/tests/test_overlap_asymm.py
+++ b/tests/test_overlap_asymm.py
@@ -110,11 +110,8 @@ def test_overlap_integral_asymmetric_compare():
 
 @pytest.mark.parametrize("precision", [1.0e-5, 1.0e-6, 1.0e-7, 1.0e-8])
 def test_overlap_asymmetric_screening_accuracy(precision):
-    """Test asymmetric overlap screening.
+    """Test asymmetric overlap screening."""
 
-    This test is meant to  fail.  Using cartesian sto-6G nwchem basis set.
-
-    """
     basis_dict = parse_gbs(find_datafile("data_631g.gbs"))
     atsymbols = ["H", "C", "Kr"]
     atcoords = np.array([[0, 0, 0], [1, 1, 1], [2, 2, 2]])

--- a/tests/test_overlap_asymm.py
+++ b/tests/test_overlap_asymm.py
@@ -24,7 +24,7 @@ def test_overlap_integral_asymmetric_horton_anorcc_hhe():
 
     horton_overlap_integral_asymmetric = np.load(find_datafile("data_horton_hhe_cart_overlap.npy"))
     assert np.allclose(
-        overlap_integral_asymmetric(basis, basis),
+        overlap_integral_asymmetric(basis, basis, screen_basis=False),
         horton_overlap_integral_asymmetric,
     )
 
@@ -47,7 +47,7 @@ def test_overlap_integral_asymmetric_horton_anorcc_bec():
 
     horton_overlap_integral_asymmetric = np.load(find_datafile("data_horton_bec_cart_overlap.npy"))
     assert np.allclose(
-        overlap_integral_asymmetric(basis, basis),
+        overlap_integral_asymmetric(basis, basis, screen_basis=False),
         horton_overlap_integral_asymmetric,
     )
 
@@ -80,26 +80,28 @@ def test_overlap_integral_asymmetric_compare():
     ]
 
     assert np.allclose(
-        overlap_integral(cartesian_basis),
-        overlap_integral_asymmetric(cartesian_basis, cartesian_basis),
+        overlap_integral(cartesian_basis, screen_basis=False),
+        overlap_integral_asymmetric(cartesian_basis, cartesian_basis, screen_basis=False),
     )
     assert np.allclose(
-        overlap_integral(spherical_basis),
-        overlap_integral_asymmetric(spherical_basis, spherical_basis),
+        overlap_integral(spherical_basis, screen_basis=False),
+        overlap_integral_asymmetric(spherical_basis, spherical_basis, screen_basis=False),
     )
     assert np.allclose(
-        overlap_integral(spherical_basis, transform=np.identity(218)),
+        overlap_integral(spherical_basis, transform=np.identity(218), screen_basis=False),
         overlap_integral_asymmetric(
             spherical_basis,
             spherical_basis,
             transform_one=np.identity(218),
             transform_two=np.identity(218),
+            screen_basis=False,
         ),
     )
     assert np.allclose(
-        overlap_integral(mixed_basis),
+        overlap_integral(mixed_basis, screen_basis=False),
         overlap_integral_asymmetric(
             mixed_basis,
             mixed_basis,
+            screen_basis=False,
         ),
     )


### PR DESCRIPTION
<!--

Thank you for submitting a PR!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing in this document:
https://github.com/theochem/gbasis/blob/master/CONTRIBUTING.md

-->

<!-- Description of the PR: what it does, what issues it addresses, etc -->
## Description

This PR adds screening feature to Gbasis for cases involving two contractions. It adds screening of overlaps, kinetic energy, arbitrary-order moments, momentum, and angular momentum integrals via the `tol_screen` parameter. A new module, `screening`, has been created, with `two_index_screening()` as its first function.

## Checklist

- [x] Write a good description of what the PR does.
- [x] Add tests for each unit of code added (e.g. function, class)
- [ ] Update documentation
- [ ] Squash commits that can be grouped together
- [ ] Rebase onto master

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Related
Issues #207  

<!--
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX
-->
