### PR TITLE
Add N-center overlap integrals

### DIFF
--- a/gbasis/integrals/_overlap_n_center.py
+++ b/gbasis/integrals/_overlap_n_center.py
@@ -1,0 +1,188 @@
+"""N-center overlap integrals involving primitive Gaussians."""
+
+import numpy as np
+
+
+def _compute_gaussian_product_params(coords, exponents):
+    r"""Compute the Gaussian product theorem parameters for N centers.
+
+    For N primitive Gaussians centered at A_1, A_2, ..., A_N with exponents
+    alpha_1, alpha_2, ..., alpha_N, the product is a single Gaussian with
+    combined exponent gamma, combined center P, and pre-exponential factor K.
+
+    Parameters
+    ----------
+    coords : np.ndarray(N, 3)
+        Coordinates of the N Gaussian centers.
+    exponents : np.ndarray(N,)
+        Exponents of the N primitive Gaussians.
+
+    Returns
+    -------
+    gamma : float
+        Combined exponent.
+    center_p : np.ndarray(3,)
+        Combined center.
+    factor_k : float
+        Pre-exponential factor.
+
+    """
+    num_centers = len(exponents)
+
+    # combined exponent
+    gamma = np.sum(exponents)
+
+    # combined center
+    center_p = np.sum(exponents[:, np.newaxis] * coords, axis=0) / gamma
+
+    # pre-exponential factor
+    exponent_sum = 0.0
+    for i in range(num_centers):
+        for j in range(i + 1, num_centers):
+            r_ij_squared = np.sum((coords[i] - coords[j]) ** 2)
+            exponent_sum += exponents[i] * exponents[j] * r_ij_squared
+
+    factor_k = np.exp(-exponent_sum / gamma)
+
+    return gamma, center_p, factor_k
+
+
+def _compute_primitive_s_overlap(coords, exponents):
+    r"""Compute the overlap of N s-type (L=0) primitive Gaussians.
+
+    Parameters
+    ----------
+    coords : np.ndarray(N, 3)
+        Coordinates of the N Gaussian centers.
+    exponents : np.ndarray(N,)
+        Exponents of the N primitive Gaussians.
+
+    Returns
+    -------
+    overlap : float
+        The N-center s-type overlap integral.
+
+    """
+    gamma, _, factor_k = _compute_gaussian_product_params(coords, exponents)
+
+    return (np.pi / gamma) ** 1.5 * factor_k
+
+
+def _build_angular_momentum_recursion(
+    coords, angmom_comps_list, gamma, center_p, factor_k
+):
+    r"""Build N-center overlap integrals for arbitrary angular momentum.
+
+    Uses Obara-Saika recursion extended to N centers.
+
+    Parameters
+    ----------
+    coords : np.ndarray(N, 3)
+        Coordinates of the N Gaussian centers.
+    angmom_comps_list : list of np.ndarray
+        List of N arrays of angular momentum components.
+    gamma : float
+        Combined exponent.
+    center_p : np.ndarray(3,)
+        Combined center.
+    factor_k : float
+        Pre-exponential factor.
+
+    Returns
+    -------
+    integrals : np.ndarray
+        Array of overlap integrals.
+
+    """
+    n_centers = len(coords)
+    output_shape = tuple(len(comps) for comps in angmom_comps_list)
+    integrals = np.zeros(output_shape)
+
+    # base case
+    s_base = (np.pi / gamma) ** 1.5 * factor_k
+
+    # memoization cache
+    cache = {}
+
+    def get_integral(angmom_tuple):
+        """Recursively compute integral for given angular momentum tuple."""
+        if angmom_tuple in cache:
+            return cache[angmom_tuple]
+
+        # base case: all angular momenta are zero
+        if all(sum(a) == 0 for a in angmom_tuple):
+            cache[angmom_tuple] = s_base
+            return s_base
+
+        # find first center with non-zero angular momentum
+        for k in range(n_centers):
+            for direction in range(3):
+                if angmom_tuple[k][direction] > 0:
+                    # create lowered angular momentum for center k
+                    lowered_k = list(angmom_tuple[k])
+                    lowered_k[direction] -= 1
+                    lowered_k = tuple(lowered_k)
+
+                    lowered_tuple = list(angmom_tuple)
+                    lowered_tuple[k] = lowered_k
+                    lowered_tuple = tuple(lowered_tuple)
+
+                    # first term: (P_i - A_i^(k)) * S(lowered)
+                    val = (center_p[direction] - coords[k, direction]) * get_integral(lowered_tuple)
+
+                    # second term: sum over ALL centers
+                    for m in range(n_centers):
+                        a_m_i = lowered_tuple[m][direction]
+                        if a_m_i > 0:
+                            double_lowered = list(lowered_tuple)
+                            lowered_m = list(double_lowered[m])
+                            lowered_m[direction] -= 1
+                            double_lowered[m] = tuple(lowered_m)
+                            double_lowered = tuple(double_lowered)
+
+                            val += (a_m_i / (2 * gamma)) * get_integral(double_lowered)
+
+                    cache[angmom_tuple] = val
+                    return val
+
+        raise RuntimeError("Unexpected state in angular momentum recursion")
+
+    # compute all required integrals
+    for idx in np.ndindex(output_shape):
+        angmom_tuple = tuple(tuple(angmom_comps_list[k][idx[k]]) for k in range(n_centers))
+        integrals[idx] = get_integral(angmom_tuple)
+
+    return integrals
+
+
+def _compute_n_center_primitive_overlap(coords, exponents, angmom_comps_list, tol_screen=1e-8):
+    r"""Compute N-center overlap integral for primitive Gaussians.
+
+    Parameters
+    ----------
+    coords : np.ndarray(N, 3)
+        Coordinates of the N Gaussian centers.
+    exponents : np.ndarray(N,)
+        Exponents of the N primitive Gaussians.
+    angmom_comps_list : list of np.ndarray
+        List of N arrays of angular momentum components.
+    tol_screen : float, optional
+        Screening tolerance. Default is 1e-8.
+
+    Returns
+    -------
+    integrals : np.ndarray
+        Array of overlap integrals.
+
+    """
+    gamma, center_p, factor_k = _compute_gaussian_product_params(coords, exponents)
+
+    # screen based on K factor
+    if factor_k < tol_screen:
+        output_shape = tuple(len(comps) for comps in angmom_comps_list)
+        return np.zeros(output_shape)
+
+    # compute via recursion
+    return _build_angular_momentum_recursion(
+        coords, angmom_comps_list, gamma, center_p, factor_k
+    )

--- a/gbasis/integrals/overlap_n_center.py
+++ b/gbasis/integrals/overlap_n_center.py
@@ -1,0 +1,231 @@
+"""Functions for computing N-center overlap integrals of a basis set."""
+
+from gbasis.contractions import GeneralizedContractionShell
+from gbasis.integrals._overlap_n_center import (
+    _compute_gaussian_product_params,
+    _compute_n_center_primitive_overlap,
+)
+from gbasis.screening import is_n_center_overlap_screened
+from gbasis.spherical import generate_transformation
+import numpy as np
+
+
+def _construct_n_center_overlap_contraction(shells, screen_basis=True, tol_screen=1e-8):
+    r"""Compute N-center overlap for a tuple of contraction shells.
+
+    Parameters
+    ----------
+    shells : tuple of GeneralizedContractionShell
+        The N shells to compute the overlap for.
+    screen_basis : bool, optional
+        Whether to apply screening. Default is True.
+    tol_screen : float, optional
+        Screening tolerance. Default is 1e-8.
+
+    Returns
+    -------
+    overlap : np.ndarray
+        The overlap integrals with shape (M_0, L_cart_0, M_1, L_cart_1, ...).
+
+    Raises
+    ------
+    TypeError
+        If any shell is not a GeneralizedContractionShell instance.
+
+    """
+    for i, shell in enumerate(shells):
+        if not isinstance(shell, GeneralizedContractionShell):
+            raise TypeError(
+                f"Shell at index {i} must be a `GeneralizedContractionShell` instance."
+            )
+
+    n_centers = len(shells)
+
+    # determine output shape
+    output_shape = []
+    for shell in shells:
+        output_shape.extend([shell.num_seg_cont, shell.num_cart])
+    output_shape = tuple(output_shape)
+
+    # screen if enabled
+    if screen_basis and is_n_center_overlap_screened(list(shells), tol_screen):
+        return np.zeros(output_shape, dtype=np.float64)
+
+    # get coordinates and angular momentum components
+    coords = np.array([shell.coord for shell in shells])
+    angmom_comps_list = [shell.angmom_components_cart for shell in shells]
+
+    # initialize output array
+    result = np.zeros(output_shape, dtype=np.float64)
+
+    # loop over all primitive combinations
+    prim_ranges = tuple(len(shell.exps) for shell in shells)
+    for prim_indices in np.ndindex(prim_ranges):
+        # get exponents for this primitive combination
+        exponents = np.array([shells[k].exps[prim_indices[k]] for k in range(n_centers)])
+
+        # screen at primitive level
+        _, _, factor_k = _compute_gaussian_product_params(coords, exponents)
+        if factor_k < tol_screen:
+            continue
+
+        # compute primitive overlap
+        prim_overlap = _compute_n_center_primitive_overlap(
+            coords, exponents, angmom_comps_list, tol_screen
+        )
+
+        # loop over segmented contractions
+        seg_ranges = tuple(shell.num_seg_cont for shell in shells)
+        for seg_indices in np.ndindex(seg_ranges):
+            # get coefficient product
+            coeff_product = 1.0
+            for k in range(n_centers):
+                coeff_product *= shells[k].coeffs[prim_indices[k], seg_indices[k]]
+
+            # build the index into the result array
+            result_index = []
+            for k in range(n_centers):
+                result_index.extend([seg_indices[k], slice(None)])
+            result_index = tuple(result_index)
+
+            # add contribution with normalization
+            contrib = coeff_product * prim_overlap
+            for k in range(n_centers):
+                # norm_prim_cart has shape (num_cart, num_prims)
+                norm = shells[k].norm_prim_cart[:, prim_indices[k]]
+                shape = [1] * len(prim_overlap.shape)
+                shape[k] = len(norm)
+                contrib = contrib * norm.reshape(shape)
+
+            result[result_index] += contrib
+
+    return result
+
+
+def n_center_overlap_integral(basis, n=2, transform=None, screen_basis=True, tol_screen=1e-8):
+    r"""Return N-center overlap integral of the given basis set.
+
+    Computes the overlap of N Gaussian basis functions:
+
+    .. math::
+        S_{i_1 i_2 ... i_N} = \int \phi_{i_1}(\mathbf{r}) \phi_{i_2}(\mathbf{r})
+            \cdots \phi_{i_N}(\mathbf{r}) \, d\mathbf{r}
+
+    Parameters
+    ----------
+    basis : list/tuple of GeneralizedContractionShell
+        Shells of generalized contractions.
+    n : int, optional
+        Number of centers (N). Must be a positive integer. Default is 2.
+    transform : np.ndarray, optional
+        Transformation matrix for linear combinations. Default is None.
+    screen_basis : bool, optional
+        Toggle to enable/disable screening. Default is True.
+    tol_screen : float, optional
+        Screening tolerance. Default is 1e-8.
+
+    Returns
+    -------
+    overlap : np.ndarray
+        N-center overlap integrals with shape (K, K, ..., K) with N dimensions.
+
+    Raises
+    ------
+    TypeError
+        If `basis` is not a list/tuple of GeneralizedContractionShell.
+        If `n` is not an integer.
+    ValueError
+        If `n` is not a positive integer.
+
+    """
+    if not isinstance(n, (int, np.integer)):
+        raise TypeError("`n` must be an integer.")
+    if n < 1:
+        raise ValueError("`n` must be a positive integer.")
+
+    if not isinstance(basis, (list, tuple)):
+        raise TypeError("`basis` must be a list or tuple of GeneralizedContractionShell.")
+    for shell in basis:
+        if not isinstance(shell, GeneralizedContractionShell):
+            raise TypeError(
+                "All elements of `basis` must be GeneralizedContractionShell instances."
+            )
+
+    coord_types = [shell.coord_type for shell in basis]
+
+    # compute basis function counts per shell
+    basis_sizes = []
+    for shell in basis:
+        if shell.coord_type == "spherical":
+            size = shell.num_seg_cont * shell.num_sph
+        else:
+            size = shell.num_seg_cont * shell.num_cart
+        basis_sizes.append(size)
+
+    # compute starting indices for each shell
+    shell_starts = [0]
+    for size in basis_sizes[:-1]:
+        shell_starts.append(shell_starts[-1] + size)
+    total_basis = sum(basis_sizes)
+
+    # initialize output array
+    output_shape = tuple([total_basis] * n)
+    result = np.zeros(output_shape, dtype=np.float64)
+
+    # iterate over all shell combinations
+    num_shells = len(basis)
+    for shell_indices in np.ndindex(tuple([num_shells] * n)):
+        shells = tuple(basis[i] for i in shell_indices)
+
+        # compute the block
+        block = _construct_n_center_overlap_contraction(
+            shells, screen_basis=screen_basis, tol_screen=tol_screen
+        )
+
+        # apply contraction normalization
+        for k in range(n):
+            norm = shells[k].norm_cont
+            shape = [1] * (2 * n)
+            shape[2 * k] = norm.shape[0]
+            shape[2 * k + 1] = norm.shape[1]
+            block = block * norm.reshape(shape)
+
+        # apply spherical transformation if needed
+        for k in range(n):
+            if coord_types[shell_indices[k]] == "spherical":
+                transform_sph = generate_transformation(
+                    shells[k].angmom,
+                    shells[k].angmom_components_cart,
+                    shells[k].angmom_components_sph,
+                    "left",
+                )
+                # apply transformation to axis 2*k + 1
+                block = np.tensordot(transform_sph, block, (1, 2 * k + 1))
+                # move the new axis to the correct position
+                block = np.moveaxis(block, 0, 2 * k + 1)
+
+        # flatten the block
+        block_shape = []
+        for k in range(n):
+            if coord_types[shell_indices[k]] == "spherical":
+                block_shape.append(shells[k].num_seg_cont * shells[k].num_sph)
+            else:
+                block_shape.append(shells[k].num_seg_cont * shells[k].num_cart)
+        block = block.reshape(block_shape)
+
+        # compute index ranges for placement
+        ranges = []
+        for k in range(n):
+            start = shell_starts[shell_indices[k]]
+            end = start + basis_sizes[shell_indices[k]]
+            ranges.append(slice(start, end))
+
+        result[tuple(ranges)] = block
+
+    # apply transform if provided
+    if transform is not None:
+        for k in range(n):
+            result = np.tensordot(transform, result, (1, k))
+            result = np.moveaxis(result, 0, k)
+
+    return result

--- a/tests/test_overlap_n_center.py
+++ b/tests/test_overlap_n_center.py
@@ -1,0 +1,143 @@
+"""Test gbasis.integrals.overlap_n_center."""
+
+import numpy as np
+import pytest
+from gbasis.integrals._overlap_n_center import (
+    _compute_gaussian_product_params,
+    _compute_primitive_s_overlap,
+)
+from gbasis.integrals.overlap import overlap_integral
+from gbasis.integrals.overlap_n_center import n_center_overlap_integral
+from gbasis.parsers import make_contractions, parse_nwchem
+from gbasis.screening import is_n_center_overlap_screened
+from utils import find_datafile
+
+
+def test_gaussian_product_params_two_centers():
+    """Test _compute_gaussian_product_params for two centers."""
+    coords = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+    exponents = np.array([1.0, 2.0])
+
+    gamma, center_p, factor_k = _compute_gaussian_product_params(coords, exponents)
+
+    assert np.isclose(gamma, 3.0)
+    assert np.allclose(center_p, [2 / 3, 0.0, 0.0])
+    assert np.isclose(factor_k, np.exp(-2 / 3))
+
+
+def test_gaussian_product_params_three_centers():
+    """Test _compute_gaussian_product_params for three centers."""
+    coords = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+        ]
+    )
+    exponents = np.array([1.0, 1.0, 1.0])
+
+    gamma, center_p, factor_k = _compute_gaussian_product_params(coords, exponents)
+
+    assert np.isclose(gamma, 3.0)
+    assert np.allclose(center_p, [1 / 3, 1 / 3, 0.0])
+    expected_k = np.exp(-(1 + 1 + 2) / 3)
+    assert np.isclose(factor_k, expected_k)
+
+
+def test_primitive_s_overlap_same_center():
+    """Test _compute_primitive_s_overlap when centers coincide."""
+    coords = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+    exponents = np.array([1.0, 1.0])
+
+    overlap_val = _compute_primitive_s_overlap(coords, exponents)
+
+    expected = (np.pi / 2) ** 1.5
+    assert np.isclose(overlap_val, expected)
+
+
+def test_primitive_s_overlap_decay():
+    """Test _compute_primitive_s_overlap decay with separation."""
+    coords_close = np.array([[0.0, 0.0, 0.0], [0.1, 0.0, 0.0]])
+    coords_far = np.array([[0.0, 0.0, 0.0], [10.0, 0.0, 0.0]])
+    exponents = np.array([1.0, 1.0])
+
+    overlap_close = _compute_primitive_s_overlap(coords_close, exponents)
+    overlap_far = _compute_primitive_s_overlap(coords_far, exponents)
+
+    assert overlap_close > overlap_far
+    assert overlap_far < 1e-20
+
+
+def test_screening_close_centers():
+    """Test that close centers are not screened."""
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
+    coords = np.array([[0.0, 0.0, 0.0], [0.1, 0.0, 0.0]])
+    basis = make_contractions(basis_dict, ["H", "H"], coords, "cartesian")
+
+    assert not is_n_center_overlap_screened([basis[0], basis[1]], 1e-8)
+
+
+def test_screening_far_centers():
+    """Test that far centers are screened."""
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
+    coords = np.array([[0.0, 0.0, 0.0], [100.0, 0.0, 0.0]])
+    basis = make_contractions(basis_dict, ["H", "H"], coords, "cartesian")
+
+    assert is_n_center_overlap_screened([basis[0], basis[1]], 1e-8)
+
+
+def test_screening_three_centers():
+    """Test screening for three centers."""
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
+    coords = np.array([[0.0, 0.0, 0.0], [0.5, 0.0, 0.0], [100.0, 0.0, 0.0]])
+    basis = make_contractions(basis_dict, ["H", "H", "H"], coords, "cartesian")
+
+    assert is_n_center_overlap_screened([basis[0], basis[1], basis[2]], 1e-8)
+
+
+def test_n2_matches_existing_cartesian():
+    """Test that n_center_overlap_integral(n=2) matches overlap_integral for Cartesian."""
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
+    coords = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.4]])
+    basis = make_contractions(basis_dict, ["H", "H"], coords, "cartesian")
+
+    existing_overlap = overlap_integral(basis, screen_basis=False)
+    new_overlap = n_center_overlap_integral(basis, n=2, screen_basis=False)
+
+    assert np.allclose(existing_overlap, new_overlap), (
+        f"N=2 overlap does not match existing!\n"
+        f"Max difference: {np.max(np.abs(existing_overlap - new_overlap))}"
+    )
+
+
+def test_n_center_overlap_type_error_n():
+    """Test that TypeError is raised for invalid n type."""
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
+    basis = make_contractions(basis_dict, ["H"], np.array([[0, 0, 0]]), "cartesian")
+
+    with pytest.raises(TypeError):
+        n_center_overlap_integral(basis, n=2.5)
+
+    with pytest.raises(TypeError):
+        n_center_overlap_integral(basis, n="3")
+
+
+def test_n_center_overlap_value_error_n():
+    """Test that ValueError is raised for invalid n value."""
+    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
+    basis = make_contractions(basis_dict, ["H"], np.array([[0, 0, 0]]), "cartesian")
+
+    with pytest.raises(ValueError):
+        n_center_overlap_integral(basis, n=0)
+
+    with pytest.raises(ValueError):
+        n_center_overlap_integral(basis, n=-1)
+
+
+def test_n_center_overlap_type_error_basis():
+    """Test that TypeError is raised for invalid basis type."""
+    with pytest.raises(TypeError):
+        n_center_overlap_integral("not a list", n=2)
+
+    with pytest.raises(TypeError):
+        n_center_overlap_integral(["not a shell"], n=2)


### PR DESCRIPTION
Adds support for computing overlap integrals of arbitrarily many Gaussian basis functions.

The main addition is `n_center_overlap_integral(basis, n, ...)` which generalizes the existing 2-center overlap to arbitrary N. It uses Obara-Saika recursion with memoization for the angular momentum build-up, and includes screening based on the K factor from the Gaussian product theorem.

Usage:

```python
from gbasis.integrals.overlap_n_center import n_center_overlap_integral

S3 = n_center_overlap_integral(basis, n=3)
S4 = n_center_overlap_integral(basis, n=4, tol_screen=1e-10)
```

I've added a regression test to ensure that the N=2 case matches the existing `overlap_integral()` exactly. All 11 new tests pass and existing tests are unaffected.

The implementation follows the patterns in `overlap.py` and should serve as the foundation for intracule/extracule functionality mentioned in the issue.

## Checklist

- [x] Write a good description of what the PR does.
- [x] Add tests for each unit of code added (e.g. function, class)
- [ ] Update documentation
- [ ] Squash commits that can be grouped together
- [x] Rebase onto master

## Type of Changes

|   | Type |
| ------------- | ------------- |
|   | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Related

Closes #220
