### PR TITLE
docs: fix typo in Gaussian primitive docstrings

### DIFF
--- a/tests/test_deriv.py
+++ b/tests/test_deriv.py
@@ -21,7 +21,7 @@ def evaluate_deriv_prim(coord, orders, center, angmom_comps, alpha):
     angmom_comps : np.ndarray(3,)
         Component of the angular momentum that corresponds to this dimension.
     alpha : float
-        Value of the exponential in the Guassian primitive.
+        Value of the exponential in the Gaussian primitive.
 
     Returns
     -------


### PR DESCRIPTION
<!-- Description of the PR: what it does, what issues it addresses, etc -->

### Description

This PR fixes a spelling typo in docstrings in `gbasis/evals/_deriv.py`, replacing
“Guassian” with the correct scientific term “Gaussian”.

This is a documentation-only change and does not affect any code paths or
numerical behavior.

## Type of Changes

|   | Type |
| --- | --- |
|    | :bug: Bug fix |
|    | :sparkles: New feature |
|    | :hammer: Refactoring |
| ✓  | :scroll: Docs |
