### PR TITLE
[PR-4] feat: implement HRR (Eq. 67) and complete OS+HGP two-electron integral pipeline

### DIFF
--- a/gbasis/integrals/_two_elec_int_improved.py
+++ b/gbasis/integrals/_two_elec_int_improved.py
@@ -1,0 +1,386 @@
+"""Improved two-electron integrals using Obara-Saika + Head-Gordon-Pople recursions.
+
+This module implements VRR, ETR, and primitive contraction steps of the
+OS+HGP algorithm for two-electron integrals.
+
+Algorithm overview (full pipeline):
+1. Start with Boys function F_m(T) for m = 0 to angmom_total
+2. VRR: Build [a0|00]^m from [00|00]^m (Eq. 65)        <-- Done (PR 2)
+3. ETR: Build [a0|c0]^0 from [a0|00]^m (Eq. 66)        <-- THIS PR
+4. Contract primitives                                    <-- THIS PR
+5. HRR: Build [ab|cd] from [a0|c0] (Eq. 67)             <-- Future
+
+References:
+- Obara, S. & Saika, A. J. Chem. Phys. 1986, 84, 3963.
+- Head-Gordon, M. & Pople, J. A. J. Chem. Phys. 1988, 89, 5777.
+- Ahlrichs, R. Phys. Chem. Chem. Phys. 2006, 8, 3072.
+"""
+
+import numpy as np
+
+from gbasis.utils import factorial2
+
+# Cache for factorial2 values to avoid repeated computation
+_FACTORIAL2_CACHE = {}
+
+
+def _get_factorial2_norm(angmom_components):
+    """Get cached factorial2 normalization for angular momentum components.
+
+    Parameters
+    ----------
+    angmom_components : np.ndarray(n, 3)
+        Angular momentum components.
+
+    Returns
+    -------
+    norm : np.ndarray(n,)
+        Normalization factors 1/sqrt(prod((2*l-1)!!)).
+    """
+    key = tuple(map(tuple, angmom_components))
+    if key not in _FACTORIAL2_CACHE:
+        _FACTORIAL2_CACHE[key] = 1.0 / np.sqrt(
+            np.prod(factorial2(2 * angmom_components - 1), axis=1)
+        )
+    return _FACTORIAL2_CACHE[key]
+
+
+def _optimized_contraction(
+    integrals_etransf,
+    exps_a,
+    exps_b,
+    exps_c,
+    exps_d,
+    coeffs_a,
+    coeffs_b,
+    coeffs_c,
+    coeffs_d,
+    angmom_a,
+    angmom_b,
+    angmom_c,
+    angmom_d,
+):
+    """Optimized primitive contraction using einsum.
+
+    Parameters
+    ----------
+    integrals_etransf : np.ndarray
+        ETR output with shape (c_x, c_y, c_z, a_x, a_y, a_z, K_d, K_b, K_c, K_a).
+    exps_a/b/c/d : np.ndarray
+        Primitive exponents.
+    coeffs_a/b/c/d : np.ndarray
+        Contraction coefficients.
+    angmom_a/b/c/d : int
+        Angular momenta.
+
+    Returns
+    -------
+    contracted : np.ndarray
+        Contracted integrals with shape (c_x, c_y, c_z, a_x, a_y, a_z, M_a, M_c, M_b, M_d).
+    """
+    # Precompute normalization constants (1D arrays)
+    norm_a = (2 * exps_a / np.pi) ** 0.75 * (4 * exps_a) ** (angmom_a / 2)
+    norm_b = (2 * exps_b / np.pi) ** 0.75 * (4 * exps_b) ** (angmom_b / 2)
+    norm_c = (2 * exps_c / np.pi) ** 0.75 * (4 * exps_c) ** (angmom_c / 2)
+    norm_d = (2 * exps_d / np.pi) ** 0.75 * (4 * exps_d) ** (angmom_d / 2)
+
+    # Multiply coefficients by normalization (more efficient than per-element)
+    coeffs_a_norm = coeffs_a * norm_a[:, np.newaxis]
+    coeffs_b_norm = coeffs_b * norm_b[:, np.newaxis]
+    coeffs_c_norm = coeffs_c * norm_c[:, np.newaxis]
+    coeffs_d_norm = coeffs_d * norm_d[:, np.newaxis]
+
+    # Use einsum with optimization for contraction
+    # Input: (c_x, c_y, c_z, a_x, a_y, a_z, K_d, K_b, K_c, K_a)
+    # Contract one primitive at a time for memory efficiency
+    # K_a contraction
+    contracted = np.einsum("...a,aA->...A", integrals_etransf, coeffs_a_norm, optimize=True)
+    # K_c contraction (now axis -2 is K_c)
+    contracted = np.einsum("...cA,cC->...CA", contracted, coeffs_c_norm, optimize=True)
+    # K_b contraction (now axis -3 is K_b)
+    contracted = np.einsum("...bCA,bB->...CBA", contracted, coeffs_b_norm, optimize=True)
+    # K_d contraction (now axis -4 is K_d)
+    contracted = np.einsum("...dCBA,dD->...CBAD", contracted, coeffs_d_norm, optimize=True)
+
+    # Reorder to (c_x, c_y, c_z, a_x, a_y, a_z, M_a, M_c, M_b, M_d)
+    # Current: (..., M_c, M_b, M_a, M_d) -> need (..., M_a, M_c, M_b, M_d)
+    contracted = np.moveaxis(contracted, -2, -4)
+
+    return contracted
+
+
+def _vertical_recursion_relation(
+    integrals_m,
+    m_max,
+    rel_coord_a,
+    coord_wac,
+    harm_mean,
+    exps_sum_one,
+):
+    """Apply Vertical Recursion Relation (VRR) to build angular momentum on center A.
+
+    This implements Eq. 65 from the algorithm notes:
+    [a+1,0|00]^m = (P-A)_i [a0|00]^m - (rho/zeta)(Q-P)_i [a0|00]^{m+1}
+                   + a_i/(2*zeta) * ([a-1,0|00]^m - (rho/zeta)[a-1,0|00]^{m+1})
+
+    Parameters
+    ----------
+    integrals_m : np.ndarray
+        Array containing [00|00]^m for all m values.
+        Shape: (m_max, K_d, K_b, K_c, K_a)
+    m_max : int
+        Maximum angular momentum order.
+    rel_coord_a : np.ndarray(3, K_d, K_b, K_c, K_a)
+        P - A coordinates for each primitive combination.
+    coord_wac : np.ndarray(3, K_d, K_b, K_c, K_a)
+        Q - P coordinates (weighted average centers difference).
+    harm_mean : np.ndarray(K_d, K_b, K_c, K_a)
+        Harmonic mean: rho = zeta*eta/(zeta+eta).
+    exps_sum_one : np.ndarray(K_d, K_b, K_c, K_a)
+        Sum of exponents: zeta = alpha_a + alpha_b.
+
+    Returns
+    -------
+    integrals_vert : np.ndarray
+        Integrals with angular momentum built on center A.
+        Shape: (m_max, m_max, m_max, m_max, K_d, K_b, K_c, K_a)
+        Axes 1, 2, 3 correspond to a_x, a_y, a_z.
+    """
+    # Precompute coefficients for efficiency (avoid repeated division)
+    rho_over_zeta = harm_mean / exps_sum_one
+    half_over_zeta = 0.5 / exps_sum_one
+
+    # Precompute products (avoids repeated multiplication in loops)
+    roz_wac_x = rho_over_zeta * coord_wac[0]
+    roz_wac_y = rho_over_zeta * coord_wac[1]
+    roz_wac_z = rho_over_zeta * coord_wac[2]
+
+    # Initialize output array with contiguous memory
+    # axis 0: m, axis 1: a_x, axis 2: a_y, axis 3: a_z
+    integrals_vert = np.zeros((m_max, m_max, m_max, m_max, *integrals_m.shape[1:]), order="C")
+
+    # Base case: [00|00]^m
+    integrals_vert[:, 0, 0, 0, ...] = integrals_m
+
+    # VRR for x-component (a_x)
+    if m_max > 1:
+        # First step: a_x = 0 -> a_x = 1
+        integrals_vert[:-1, 1, 0, 0, ...] = (
+            rel_coord_a[0] * integrals_vert[:-1, 0, 0, 0, ...]
+            - roz_wac_x * integrals_vert[1:, 0, 0, 0, ...]
+        )
+        # Higher a_x values (precompute a * half_over_zeta)
+        for a in range(1, m_max - 1):
+            coeff_a = a * half_over_zeta
+            integrals_vert[:-1, a + 1, 0, 0, ...] = (
+                rel_coord_a[0] * integrals_vert[:-1, a, 0, 0, ...]
+                - roz_wac_x * integrals_vert[1:, a, 0, 0, ...]
+                + coeff_a
+                * (
+                    integrals_vert[:-1, a - 1, 0, 0, ...]
+                    - rho_over_zeta * integrals_vert[1:, a - 1, 0, 0, ...]
+                )
+            )
+
+    # VRR for y-component (a_y)
+    if m_max > 1:
+        integrals_vert[:-1, :, 1, 0, ...] = (
+            rel_coord_a[1] * integrals_vert[:-1, :, 0, 0, ...]
+            - roz_wac_y * integrals_vert[1:, :, 0, 0, ...]
+        )
+        for a in range(1, m_max - 1):
+            coeff_a = a * half_over_zeta
+            integrals_vert[:-1, :, a + 1, 0, ...] = (
+                rel_coord_a[1] * integrals_vert[:-1, :, a, 0, ...]
+                - roz_wac_y * integrals_vert[1:, :, a, 0, ...]
+                + coeff_a
+                * (
+                    integrals_vert[:-1, :, a - 1, 0, ...]
+                    - rho_over_zeta * integrals_vert[1:, :, a - 1, 0, ...]
+                )
+            )
+
+    # VRR for z-component (a_z)
+    if m_max > 1:
+        integrals_vert[:-1, :, :, 1, ...] = (
+            rel_coord_a[2] * integrals_vert[:-1, :, :, 0, ...]
+            - roz_wac_z * integrals_vert[1:, :, :, 0, ...]
+        )
+        for a in range(1, m_max - 1):
+            coeff_a = a * half_over_zeta
+            integrals_vert[:-1, :, :, a + 1, ...] = (
+                rel_coord_a[2] * integrals_vert[:-1, :, :, a, ...]
+                - roz_wac_z * integrals_vert[1:, :, :, a, ...]
+                + coeff_a
+                * (
+                    integrals_vert[:-1, :, :, a - 1, ...]
+                    - rho_over_zeta * integrals_vert[1:, :, :, a - 1, ...]
+                )
+            )
+
+    return integrals_vert
+
+
+def _electron_transfer_recursion(
+    integrals_vert,
+    m_max,
+    m_max_c,
+    rel_coord_c,
+    rel_coord_a,
+    exps_sum_one,
+    exps_sum_two,
+):
+    """Apply Electron Transfer Recursion (ETR) to transfer angular momentum to center C.
+
+    This implements Eq. 66 from the algorithm notes:
+    [a0|c+1,0]^0 = (Q-C)_i [a0|c0]^0 + (zeta/eta)(P-A)_i [a0|c0]^0
+                   - (zeta/eta) [a+1,0|c0]^0
+                   + c_i/(2*eta) [a0|c-1,0]^0
+                   + a_i/(2*eta) [a-1,0|c0]^0
+
+    Parameters
+    ----------
+    integrals_vert : np.ndarray
+        Output from VRR with angular momentum on A.
+        Shape: (m_max, a_x_max, a_y_max, a_z_max, K_d, K_b, K_c, K_a)
+    m_max : int
+        Maximum m value (angmom_a + angmom_b + angmom_c + angmom_d + 1).
+    m_max_c : int
+        Maximum c angular momentum (angmom_c + angmom_d + 1).
+    rel_coord_c : np.ndarray(3, K_d, K_b, K_c, K_a)
+        Q - C coordinates.
+    rel_coord_a : np.ndarray(3, K_d, K_b, K_c, K_a)
+        P - A coordinates.
+    exps_sum_one : np.ndarray
+        zeta = alpha_a + alpha_b.
+    exps_sum_two : np.ndarray
+        eta = alpha_c + alpha_d.
+
+    Returns
+    -------
+    integrals_etransf : np.ndarray
+        Integrals with angular momentum on both A and C.
+        Shape: (c_x_max, c_y_max, c_z_max, a_x_max, a_y_max, a_z_max, K_d, K_b, K_c, K_a)
+    """
+    n_primitives = integrals_vert.shape[4:]
+    zeta_over_eta = exps_sum_one / exps_sum_two
+
+    # Precompute coefficients (avoid repeated division in loops)
+    half_over_eta = 0.5 / exps_sum_two
+
+    # Precompute combined coordinate terms for each axis
+    qc_plus_zoe_pa_x = rel_coord_c[0] + zeta_over_eta * rel_coord_a[0]
+    qc_plus_zoe_pa_y = rel_coord_c[1] + zeta_over_eta * rel_coord_a[1]
+    qc_plus_zoe_pa_z = rel_coord_c[2] + zeta_over_eta * rel_coord_a[2]
+
+    # Initialize ETR output with contiguous memory
+    integrals_etransf = np.zeros(
+        (m_max_c, m_max_c, m_max_c, m_max, m_max, m_max, *n_primitives), order="C"
+    )
+
+    # Base case: discard m index (take m=0)
+    integrals_etransf[0, 0, 0, ...] = integrals_vert[0, ...]
+
+    # Precompute a_indices coefficient array once
+    if m_max > 2:
+        a_coeff_x = (
+            np.arange(1, m_max - 1).reshape(-1, 1, 1, *([1] * len(n_primitives))) * half_over_eta
+        )
+        a_coeff_y = (
+            np.arange(1, m_max - 1).reshape(1, 1, 1, 1, -1, 1, *([1] * len(n_primitives)))
+            * half_over_eta
+        )
+        a_coeff_z = (
+            np.arange(1, m_max - 1).reshape(1, 1, 1, 1, 1, -1, *([1] * len(n_primitives)))
+            * half_over_eta
+        )
+
+    # ETR for c_x
+    for c in range(m_max_c - 1):
+        c_coeff = c * half_over_eta  # Precompute c/(2*eta)
+        if c == 0:
+            # First step: c_x = 0 -> c_x = 1
+            # For a_x = 0
+            integrals_etransf[1, 0, 0, 0, ...] = (
+                qc_plus_zoe_pa_x * integrals_etransf[0, 0, 0, 0, ...]
+                - zeta_over_eta * integrals_etransf[0, 0, 0, 1, ...]
+            )
+            # For a_x >= 1
+            if m_max > 2:
+                integrals_etransf[1, 0, 0, 1:-1, ...] = (
+                    qc_plus_zoe_pa_x * integrals_etransf[0, 0, 0, 1:-1, ...]
+                    + a_coeff_x * integrals_etransf[0, 0, 0, :-2, ...]
+                    - zeta_over_eta * integrals_etransf[0, 0, 0, 2:, ...]
+                )
+        else:
+            # General case: c_x -> c_x + 1
+            integrals_etransf[c + 1, 0, 0, 0, ...] = (
+                qc_plus_zoe_pa_x * integrals_etransf[c, 0, 0, 0, ...]
+                + c_coeff * integrals_etransf[c - 1, 0, 0, 0, ...]
+                - zeta_over_eta * integrals_etransf[c, 0, 0, 1, ...]
+            )
+            if m_max > 2:
+                integrals_etransf[c + 1, 0, 0, 1:-1, ...] = (
+                    qc_plus_zoe_pa_x * integrals_etransf[c, 0, 0, 1:-1, ...]
+                    + a_coeff_x * integrals_etransf[c, 0, 0, :-2, ...]
+                    + c_coeff * integrals_etransf[c - 1, 0, 0, 1:-1, ...]
+                    - zeta_over_eta * integrals_etransf[c, 0, 0, 2:, ...]
+                )
+
+    # ETR for c_y (similar structure, using precomputed coefficients)
+    for c in range(m_max_c - 1):
+        c_coeff = c * half_over_eta
+        if c == 0:
+            integrals_etransf[:, 1, 0, :, 0, ...] = (
+                qc_plus_zoe_pa_y * integrals_etransf[:, 0, 0, :, 0, ...]
+                - zeta_over_eta * integrals_etransf[:, 0, 0, :, 1, ...]
+            )
+            if m_max > 2:
+                integrals_etransf[:, 1, 0, :, 1:-1, ...] = (
+                    qc_plus_zoe_pa_y * integrals_etransf[:, 0, 0, :, 1:-1, ...]
+                    + a_coeff_y * integrals_etransf[:, 0, 0, :, :-2, ...]
+                    - zeta_over_eta * integrals_etransf[:, 0, 0, :, 2:, ...]
+                )
+        else:
+            integrals_etransf[:, c + 1, 0, :, 0, ...] = (
+                qc_plus_zoe_pa_y * integrals_etransf[:, c, 0, :, 0, ...]
+                + c_coeff * integrals_etransf[:, c - 1, 0, :, 0, ...]
+                - zeta_over_eta * integrals_etransf[:, c, 0, :, 1, ...]
+            )
+            if m_max > 2:
+                integrals_etransf[:, c + 1, 0, :, 1:-1, ...] = (
+                    qc_plus_zoe_pa_y * integrals_etransf[:, c, 0, :, 1:-1, ...]
+                    + a_coeff_y * integrals_etransf[:, c, 0, :, :-2, ...]
+                    + c_coeff * integrals_etransf[:, c - 1, 0, :, 1:-1, ...]
+                    - zeta_over_eta * integrals_etransf[:, c, 0, :, 2:, ...]
+                )
+
+    # ETR for c_z (similar structure, using precomputed coefficients)
+    for c in range(m_max_c - 1):
+        c_coeff = c * half_over_eta
+        if c == 0:
+            integrals_etransf[:, :, 1, :, :, 0, ...] = (
+                qc_plus_zoe_pa_z * integrals_etransf[:, :, 0, :, :, 0, ...]
+                - zeta_over_eta * integrals_etransf[:, :, 0, :, :, 1, ...]
+            )
+            if m_max > 2:
+                integrals_etransf[:, :, 1, :, :, 1:-1, ...] = (
+                    qc_plus_zoe_pa_z * integrals_etransf[:, :, 0, :, :, 1:-1, ...]
+                    + a_coeff_z * integrals_etransf[:, :, 0, :, :, :-2, ...]
+                    - zeta_over_eta * integrals_etransf[:, :, 0, :, :, 2:, ...]
+                )
+        else:
+            integrals_etransf[:, :, c + 1, :, :, 0, ...] = (
+                qc_plus_zoe_pa_z * integrals_etransf[:, :, c, :, :, 0, ...]
+                + c_coeff * integrals_etransf[:, :, c - 1, :, :, 0, ...]
+                - zeta_over_eta * integrals_etransf[:, :, c, :, :, 1, ...]
+            )
+            if m_max > 2:
+                integrals_etransf[:, :, c + 1, :, :, 1:-1, ...] = (
+                    qc_plus_zoe_pa_z * integrals_etransf[:, :, c, :, :, 1:-1, ...]
+                    + a_coeff_z * integrals_etransf[:, :, c, :, :, :-2, ...]
+                    + c_coeff * integrals_etransf[:, :, c - 1, :, :, 1:-1, ...]
+                    - zeta_over_eta * integrals_etransf[:, :, c, :, :, 2:, ...]
+                )
+
+    return integrals_etransf

--- a/gbasis/integrals/_two_elec_int_improved.py
+++ b/gbasis/integrals/_two_elec_int_improved.py
@@ -16,68 +16,55 @@ References:
 - Ahlrichs, R. Phys. Chem. Chem. Phys. 2006, 8, 3072.
 """
 
+import functools
+
 import numpy as np
 
 from gbasis.utils import factorial2
 
-# Cache for factorial2 values to avoid repeated computation
-_FACTORIAL2_CACHE = {}
 
-
-def _get_factorial2_norm(angmom_components):
+@functools.cache
+def _get_factorial2_norm(angmom_key):
     """Get cached factorial2 normalization for angular momentum components.
 
     Parameters
     ----------
-    angmom_components : np.ndarray(n, 3)
-        Angular momentum components.
+    angmom_key : tuple of tuples
+        Angular momentum components as a tuple of tuples, e.g.
+        ((lx1, ly1, lz1), (lx2, ly2, lz2), ...).
 
     Returns
     -------
     norm : np.ndarray(n,)
         Normalization factors 1/sqrt(prod((2*l-1)!!)).
     """
-    key = tuple(map(tuple, angmom_components))
-    if key not in _FACTORIAL2_CACHE:
-        _FACTORIAL2_CACHE[key] = 1.0 / np.sqrt(
-            np.prod(factorial2(2 * angmom_components - 1), axis=1)
-        )
-    return _FACTORIAL2_CACHE[key]
+    angmom_components = np.array(angmom_key)
+    return 1.0 / np.sqrt(np.prod(factorial2(2 * angmom_components - 1), axis=1))
 
 
-def _optimized_contraction(
-    integrals_etransf,
-    exps_a,
-    exps_b,
-    exps_c,
-    exps_d,
-    coeffs_a,
-    coeffs_b,
-    coeffs_c,
-    coeffs_d,
-    angmom_a,
-    angmom_b,
-    angmom_c,
-    angmom_d,
-):
+def _optimized_contraction(integrals_etransf, exps, coeffs, angmoms):
     """Optimized primitive contraction using einsum.
 
     Parameters
     ----------
     integrals_etransf : np.ndarray
         ETR output with shape (c_x, c_y, c_z, a_x, a_y, a_z, K_d, K_b, K_c, K_a).
-    exps_a/b/c/d : np.ndarray
-        Primitive exponents.
-    coeffs_a/b/c/d : np.ndarray
-        Contraction coefficients.
-    angmom_a/b/c/d : int
-        Angular momenta.
+    exps : tuple of np.ndarray
+        Primitive exponents (exps_a, exps_b, exps_c, exps_d).
+    coeffs : tuple of np.ndarray
+        Contraction coefficients (coeffs_a, coeffs_b, coeffs_c, coeffs_d).
+    angmoms : tuple of int
+        Angular momenta (angmom_a, angmom_b, angmom_c, angmom_d).
 
     Returns
     -------
     contracted : np.ndarray
         Contracted integrals with shape (c_x, c_y, c_z, a_x, a_y, a_z, M_a, M_c, M_b, M_d).
     """
+    exps_a, exps_b, exps_c, exps_d = exps
+    coeffs_a, coeffs_b, coeffs_c, coeffs_d = coeffs
+    angmom_a, angmom_b, angmom_c, angmom_d = angmoms
+
     # Precompute normalization constants (1D arrays)
     norm_a = (2 * exps_a / np.pi) ** 0.75 * (4 * exps_a) ** (angmom_a / 2)
     norm_b = (2 * exps_b / np.pi) ** 0.75 * (4 * exps_b) ** (angmom_b / 2)

--- a/gbasis/integrals/_two_elec_int_improved.py
+++ b/gbasis/integrals/_two_elec_int_improved.py
@@ -1,0 +1,757 @@
+"""Improved two-electron integrals using Obara-Saika + Head-Gordon-Pople recursions.
+
+This module implements the complete OS+HGP algorithm for two-electron integrals.
+
+Algorithm overview (full pipeline):
+1. Start with Boys function F_m(T) for m = 0 to angmom_total    (PR 1)
+2. VRR: Build [a0|00]^m from [00|00]^m (Eq. 65)                 (PR 2)
+3. ETR: Build [a0|c0]^0 from [a0|00]^m (Eq. 66)                 (PR 3)
+4. Contract primitives                                            (PR 3)
+5. HRR: Build [ab|cd] from [a0|c0] (Eq. 67)                     (PR 4)
+
+References:
+- Obara, S. & Saika, A. J. Chem. Phys. 1986, 84, 3963.
+- Head-Gordon, M. & Pople, J. A. J. Chem. Phys. 1988, 89, 5777.
+- Ahlrichs, R. Phys. Chem. Chem. Phys. 2006, 8, 3072.
+"""
+
+import numpy as np
+
+from gbasis.utils import factorial2
+
+# Cache for factorial2 values to avoid repeated computation
+_FACTORIAL2_CACHE = {}
+
+
+def _get_factorial2_norm(angmom_components):
+    """Get cached factorial2 normalization for angular momentum components.
+
+    Parameters
+    ----------
+    angmom_components : np.ndarray(n, 3)
+        Angular momentum components.
+
+    Returns
+    -------
+    norm : np.ndarray(n,)
+        Normalization factors 1/sqrt(prod((2*l-1)!!)).
+    """
+    key = tuple(map(tuple, angmom_components))
+    if key not in _FACTORIAL2_CACHE:
+        _FACTORIAL2_CACHE[key] = 1.0 / np.sqrt(
+            np.prod(factorial2(2 * angmom_components - 1), axis=1)
+        )
+    return _FACTORIAL2_CACHE[key]
+
+
+def _optimized_contraction(
+    integrals_etransf,
+    exps_a,
+    exps_b,
+    exps_c,
+    exps_d,
+    coeffs_a,
+    coeffs_b,
+    coeffs_c,
+    coeffs_d,
+    angmom_a,
+    angmom_b,
+    angmom_c,
+    angmom_d,
+):
+    """Optimized primitive contraction using einsum.
+
+    Parameters
+    ----------
+    integrals_etransf : np.ndarray
+        ETR output with shape (c_x, c_y, c_z, a_x, a_y, a_z, K_d, K_b, K_c, K_a).
+    exps_a/b/c/d : np.ndarray
+        Primitive exponents.
+    coeffs_a/b/c/d : np.ndarray
+        Contraction coefficients.
+    angmom_a/b/c/d : int
+        Angular momenta.
+
+    Returns
+    -------
+    contracted : np.ndarray
+        Contracted integrals with shape (c_x, c_y, c_z, a_x, a_y, a_z, M_a, M_c, M_b, M_d).
+    """
+    # Precompute normalization constants (1D arrays)
+    norm_a = (2 * exps_a / np.pi) ** 0.75 * (4 * exps_a) ** (angmom_a / 2)
+    norm_b = (2 * exps_b / np.pi) ** 0.75 * (4 * exps_b) ** (angmom_b / 2)
+    norm_c = (2 * exps_c / np.pi) ** 0.75 * (4 * exps_c) ** (angmom_c / 2)
+    norm_d = (2 * exps_d / np.pi) ** 0.75 * (4 * exps_d) ** (angmom_d / 2)
+
+    # Multiply coefficients by normalization (more efficient than per-element)
+    coeffs_a_norm = coeffs_a * norm_a[:, np.newaxis]
+    coeffs_b_norm = coeffs_b * norm_b[:, np.newaxis]
+    coeffs_c_norm = coeffs_c * norm_c[:, np.newaxis]
+    coeffs_d_norm = coeffs_d * norm_d[:, np.newaxis]
+
+    # Use einsum with optimization for contraction
+    # Input: (c_x, c_y, c_z, a_x, a_y, a_z, K_d, K_b, K_c, K_a)
+    # Contract one primitive at a time for memory efficiency
+    # K_a contraction
+    contracted = np.einsum("...a,aA->...A", integrals_etransf, coeffs_a_norm, optimize=True)
+    # K_c contraction (now axis -2 is K_c)
+    contracted = np.einsum("...cA,cC->...CA", contracted, coeffs_c_norm, optimize=True)
+    # K_b contraction (now axis -3 is K_b)
+    contracted = np.einsum("...bCA,bB->...CBA", contracted, coeffs_b_norm, optimize=True)
+    # K_d contraction (now axis -4 is K_d)
+    contracted = np.einsum("...dCBA,dD->...CBAD", contracted, coeffs_d_norm, optimize=True)
+
+    # Reorder to (c_x, c_y, c_z, a_x, a_y, a_z, M_a, M_c, M_b, M_d)
+    # Current: (..., M_c, M_b, M_a, M_d) -> need (..., M_a, M_c, M_b, M_d)
+    contracted = np.moveaxis(contracted, -2, -4)
+
+    return contracted
+
+
+def _vertical_recursion_relation(
+    integrals_m,
+    m_max,
+    rel_coord_a,
+    coord_wac,
+    harm_mean,
+    exps_sum_one,
+):
+    """Apply Vertical Recursion Relation (VRR) to build angular momentum on center A.
+
+    This implements Eq. 65 from the algorithm notes:
+    [a+1,0|00]^m = (P-A)_i [a0|00]^m - (rho/zeta)(Q-P)_i [a0|00]^{m+1}
+                   + a_i/(2*zeta) * ([a-1,0|00]^m - (rho/zeta)[a-1,0|00]^{m+1})
+
+    Parameters
+    ----------
+    integrals_m : np.ndarray
+        Array containing [00|00]^m for all m values.
+        Shape: (m_max, K_d, K_b, K_c, K_a)
+    m_max : int
+        Maximum angular momentum order.
+    rel_coord_a : np.ndarray(3, K_d, K_b, K_c, K_a)
+        P - A coordinates for each primitive combination.
+    coord_wac : np.ndarray(3, K_d, K_b, K_c, K_a)
+        Q - P coordinates (weighted average centers difference).
+    harm_mean : np.ndarray(K_d, K_b, K_c, K_a)
+        Harmonic mean: rho = zeta*eta/(zeta+eta).
+    exps_sum_one : np.ndarray(K_d, K_b, K_c, K_a)
+        Sum of exponents: zeta = alpha_a + alpha_b.
+
+    Returns
+    -------
+    integrals_vert : np.ndarray
+        Integrals with angular momentum built on center A.
+        Shape: (m_max, m_max, m_max, m_max, K_d, K_b, K_c, K_a)
+        Axes 1, 2, 3 correspond to a_x, a_y, a_z.
+    """
+    # Precompute coefficients for efficiency (avoid repeated division)
+    rho_over_zeta = harm_mean / exps_sum_one
+    half_over_zeta = 0.5 / exps_sum_one
+
+    # Precompute products (avoids repeated multiplication in loops)
+    roz_wac_x = rho_over_zeta * coord_wac[0]
+    roz_wac_y = rho_over_zeta * coord_wac[1]
+    roz_wac_z = rho_over_zeta * coord_wac[2]
+
+    # Initialize output array with contiguous memory
+    # axis 0: m, axis 1: a_x, axis 2: a_y, axis 3: a_z
+    integrals_vert = np.zeros((m_max, m_max, m_max, m_max, *integrals_m.shape[1:]), order="C")
+
+    # Base case: [00|00]^m
+    integrals_vert[:, 0, 0, 0, ...] = integrals_m
+
+    # VRR for x-component (a_x)
+    if m_max > 1:
+        # First step: a_x = 0 -> a_x = 1
+        integrals_vert[:-1, 1, 0, 0, ...] = (
+            rel_coord_a[0] * integrals_vert[:-1, 0, 0, 0, ...]
+            - roz_wac_x * integrals_vert[1:, 0, 0, 0, ...]
+        )
+        # Higher a_x values (precompute a * half_over_zeta)
+        for a in range(1, m_max - 1):
+            coeff_a = a * half_over_zeta
+            integrals_vert[:-1, a + 1, 0, 0, ...] = (
+                rel_coord_a[0] * integrals_vert[:-1, a, 0, 0, ...]
+                - roz_wac_x * integrals_vert[1:, a, 0, 0, ...]
+                + coeff_a
+                * (
+                    integrals_vert[:-1, a - 1, 0, 0, ...]
+                    - rho_over_zeta * integrals_vert[1:, a - 1, 0, 0, ...]
+                )
+            )
+
+    # VRR for y-component (a_y)
+    if m_max > 1:
+        integrals_vert[:-1, :, 1, 0, ...] = (
+            rel_coord_a[1] * integrals_vert[:-1, :, 0, 0, ...]
+            - roz_wac_y * integrals_vert[1:, :, 0, 0, ...]
+        )
+        for a in range(1, m_max - 1):
+            coeff_a = a * half_over_zeta
+            integrals_vert[:-1, :, a + 1, 0, ...] = (
+                rel_coord_a[1] * integrals_vert[:-1, :, a, 0, ...]
+                - roz_wac_y * integrals_vert[1:, :, a, 0, ...]
+                + coeff_a
+                * (
+                    integrals_vert[:-1, :, a - 1, 0, ...]
+                    - rho_over_zeta * integrals_vert[1:, :, a - 1, 0, ...]
+                )
+            )
+
+    # VRR for z-component (a_z)
+    if m_max > 1:
+        integrals_vert[:-1, :, :, 1, ...] = (
+            rel_coord_a[2] * integrals_vert[:-1, :, :, 0, ...]
+            - roz_wac_z * integrals_vert[1:, :, :, 0, ...]
+        )
+        for a in range(1, m_max - 1):
+            coeff_a = a * half_over_zeta
+            integrals_vert[:-1, :, :, a + 1, ...] = (
+                rel_coord_a[2] * integrals_vert[:-1, :, :, a, ...]
+                - roz_wac_z * integrals_vert[1:, :, :, a, ...]
+                + coeff_a
+                * (
+                    integrals_vert[:-1, :, :, a - 1, ...]
+                    - rho_over_zeta * integrals_vert[1:, :, :, a - 1, ...]
+                )
+            )
+
+    return integrals_vert
+
+
+def _electron_transfer_recursion(
+    integrals_vert,
+    m_max,
+    m_max_c,
+    rel_coord_c,
+    rel_coord_a,
+    exps_sum_one,
+    exps_sum_two,
+):
+    """Apply Electron Transfer Recursion (ETR) to transfer angular momentum to center C.
+
+    This implements Eq. 66 from the algorithm notes:
+    [a0|c+1,0]^0 = (Q-C)_i [a0|c0]^0 + (zeta/eta)(P-A)_i [a0|c0]^0
+                   - (zeta/eta) [a+1,0|c0]^0
+                   + c_i/(2*eta) [a0|c-1,0]^0
+                   + a_i/(2*eta) [a-1,0|c0]^0
+
+    Parameters
+    ----------
+    integrals_vert : np.ndarray
+        Output from VRR with angular momentum on A.
+        Shape: (m_max, a_x_max, a_y_max, a_z_max, K_d, K_b, K_c, K_a)
+    m_max : int
+        Maximum m value (angmom_a + angmom_b + angmom_c + angmom_d + 1).
+    m_max_c : int
+        Maximum c angular momentum (angmom_c + angmom_d + 1).
+    rel_coord_c : np.ndarray(3, K_d, K_b, K_c, K_a)
+        Q - C coordinates.
+    rel_coord_a : np.ndarray(3, K_d, K_b, K_c, K_a)
+        P - A coordinates.
+    exps_sum_one : np.ndarray
+        zeta = alpha_a + alpha_b.
+    exps_sum_two : np.ndarray
+        eta = alpha_c + alpha_d.
+
+    Returns
+    -------
+    integrals_etransf : np.ndarray
+        Integrals with angular momentum on both A and C.
+        Shape: (c_x_max, c_y_max, c_z_max, a_x_max, a_y_max, a_z_max, K_d, K_b, K_c, K_a)
+    """
+    n_primitives = integrals_vert.shape[4:]
+    zeta_over_eta = exps_sum_one / exps_sum_two
+
+    # Precompute coefficients (avoid repeated division in loops)
+    half_over_eta = 0.5 / exps_sum_two
+
+    # Precompute combined coordinate terms for each axis
+    qc_plus_zoe_pa_x = rel_coord_c[0] + zeta_over_eta * rel_coord_a[0]
+    qc_plus_zoe_pa_y = rel_coord_c[1] + zeta_over_eta * rel_coord_a[1]
+    qc_plus_zoe_pa_z = rel_coord_c[2] + zeta_over_eta * rel_coord_a[2]
+
+    # Initialize ETR output with contiguous memory
+    integrals_etransf = np.zeros(
+        (m_max_c, m_max_c, m_max_c, m_max, m_max, m_max, *n_primitives), order="C"
+    )
+
+    # Base case: discard m index (take m=0)
+    integrals_etransf[0, 0, 0, ...] = integrals_vert[0, ...]
+
+    # Precompute a_indices coefficient array once
+    if m_max > 2:
+        a_coeff_x = (
+            np.arange(1, m_max - 1).reshape(-1, 1, 1, *([1] * len(n_primitives))) * half_over_eta
+        )
+        a_coeff_y = (
+            np.arange(1, m_max - 1).reshape(1, 1, 1, 1, -1, 1, *([1] * len(n_primitives)))
+            * half_over_eta
+        )
+        a_coeff_z = (
+            np.arange(1, m_max - 1).reshape(1, 1, 1, 1, 1, -1, *([1] * len(n_primitives)))
+            * half_over_eta
+        )
+
+    # ETR for c_x
+    for c in range(m_max_c - 1):
+        c_coeff = c * half_over_eta  # Precompute c/(2*eta)
+        if c == 0:
+            # First step: c_x = 0 -> c_x = 1
+            # For a_x = 0
+            integrals_etransf[1, 0, 0, 0, ...] = (
+                qc_plus_zoe_pa_x * integrals_etransf[0, 0, 0, 0, ...]
+                - zeta_over_eta * integrals_etransf[0, 0, 0, 1, ...]
+            )
+            # For a_x >= 1
+            if m_max > 2:
+                integrals_etransf[1, 0, 0, 1:-1, ...] = (
+                    qc_plus_zoe_pa_x * integrals_etransf[0, 0, 0, 1:-1, ...]
+                    + a_coeff_x * integrals_etransf[0, 0, 0, :-2, ...]
+                    - zeta_over_eta * integrals_etransf[0, 0, 0, 2:, ...]
+                )
+        else:
+            # General case: c_x -> c_x + 1
+            integrals_etransf[c + 1, 0, 0, 0, ...] = (
+                qc_plus_zoe_pa_x * integrals_etransf[c, 0, 0, 0, ...]
+                + c_coeff * integrals_etransf[c - 1, 0, 0, 0, ...]
+                - zeta_over_eta * integrals_etransf[c, 0, 0, 1, ...]
+            )
+            if m_max > 2:
+                integrals_etransf[c + 1, 0, 0, 1:-1, ...] = (
+                    qc_plus_zoe_pa_x * integrals_etransf[c, 0, 0, 1:-1, ...]
+                    + a_coeff_x * integrals_etransf[c, 0, 0, :-2, ...]
+                    + c_coeff * integrals_etransf[c - 1, 0, 0, 1:-1, ...]
+                    - zeta_over_eta * integrals_etransf[c, 0, 0, 2:, ...]
+                )
+
+    # ETR for c_y (similar structure, using precomputed coefficients)
+    for c in range(m_max_c - 1):
+        c_coeff = c * half_over_eta
+        if c == 0:
+            integrals_etransf[:, 1, 0, :, 0, ...] = (
+                qc_plus_zoe_pa_y * integrals_etransf[:, 0, 0, :, 0, ...]
+                - zeta_over_eta * integrals_etransf[:, 0, 0, :, 1, ...]
+            )
+            if m_max > 2:
+                integrals_etransf[:, 1, 0, :, 1:-1, ...] = (
+                    qc_plus_zoe_pa_y * integrals_etransf[:, 0, 0, :, 1:-1, ...]
+                    + a_coeff_y * integrals_etransf[:, 0, 0, :, :-2, ...]
+                    - zeta_over_eta * integrals_etransf[:, 0, 0, :, 2:, ...]
+                )
+        else:
+            integrals_etransf[:, c + 1, 0, :, 0, ...] = (
+                qc_plus_zoe_pa_y * integrals_etransf[:, c, 0, :, 0, ...]
+                + c_coeff * integrals_etransf[:, c - 1, 0, :, 0, ...]
+                - zeta_over_eta * integrals_etransf[:, c, 0, :, 1, ...]
+            )
+            if m_max > 2:
+                integrals_etransf[:, c + 1, 0, :, 1:-1, ...] = (
+                    qc_plus_zoe_pa_y * integrals_etransf[:, c, 0, :, 1:-1, ...]
+                    + a_coeff_y * integrals_etransf[:, c, 0, :, :-2, ...]
+                    + c_coeff * integrals_etransf[:, c - 1, 0, :, 1:-1, ...]
+                    - zeta_over_eta * integrals_etransf[:, c, 0, :, 2:, ...]
+                )
+
+    # ETR for c_z (similar structure, using precomputed coefficients)
+    for c in range(m_max_c - 1):
+        c_coeff = c * half_over_eta
+        if c == 0:
+            integrals_etransf[:, :, 1, :, :, 0, ...] = (
+                qc_plus_zoe_pa_z * integrals_etransf[:, :, 0, :, :, 0, ...]
+                - zeta_over_eta * integrals_etransf[:, :, 0, :, :, 1, ...]
+            )
+            if m_max > 2:
+                integrals_etransf[:, :, 1, :, :, 1:-1, ...] = (
+                    qc_plus_zoe_pa_z * integrals_etransf[:, :, 0, :, :, 1:-1, ...]
+                    + a_coeff_z * integrals_etransf[:, :, 0, :, :, :-2, ...]
+                    - zeta_over_eta * integrals_etransf[:, :, 0, :, :, 2:, ...]
+                )
+        else:
+            integrals_etransf[:, :, c + 1, :, :, 0, ...] = (
+                qc_plus_zoe_pa_z * integrals_etransf[:, :, c, :, :, 0, ...]
+                + c_coeff * integrals_etransf[:, :, c - 1, :, :, 0, ...]
+                - zeta_over_eta * integrals_etransf[:, :, c, :, :, 1, ...]
+            )
+            if m_max > 2:
+                integrals_etransf[:, :, c + 1, :, :, 1:-1, ...] = (
+                    qc_plus_zoe_pa_z * integrals_etransf[:, :, c, :, :, 1:-1, ...]
+                    + a_coeff_z * integrals_etransf[:, :, c, :, :, :-2, ...]
+                    + c_coeff * integrals_etransf[:, :, c - 1, :, :, 1:-1, ...]
+                    - zeta_over_eta * integrals_etransf[:, :, c, :, :, 2:, ...]
+                )
+
+    return integrals_etransf
+
+
+def _horizontal_recursion_relation(
+    integrals_cont,
+    angmom_a,
+    angmom_b,
+    angmom_c,
+    angmom_d,
+    angmom_components_a,
+    angmom_components_b,
+    angmom_components_c,
+    angmom_components_d,
+    rel_dist_one,
+    rel_dist_two,
+):
+    """Apply Horizontal Recursion Relation (HRR) to distribute angular momentum to B and D.
+
+    This implements Eq. 67 from the algorithm notes (Head-Gordon-Pople scheme):
+    [ab|cd] = [a+1,0|cd] + (A-B)_i * [a,0|cd]
+
+    In the HGP scheme, HRR is applied AFTER contraction, which is more efficient
+    because contracted integrals are smaller than primitive integrals.
+
+    Parameters
+    ----------
+    integrals_cont : np.ndarray
+        Contracted integrals from ETR+contraction step.
+        Shape: (c_x, c_y, c_z, a_x, a_y, a_z, M_a, M_c, M_b, M_d)
+    angmom_a/b/c/d : int
+        Angular momenta for each center.
+    angmom_components_a/b/c/d : np.ndarray(L, 3)
+        Angular momentum components for each center.
+    rel_dist_one : np.ndarray(3,)
+        A - B distance vector.
+    rel_dist_two : np.ndarray(3,)
+        C - D distance vector.
+
+    Returns
+    -------
+    integrals : np.ndarray(L_a, L_b, L_c, L_d, M_a, M_b, M_c, M_d)
+        Final integrals in Chemists' notation.
+    """
+    m_max_a = angmom_a + angmom_b + 1
+    m_max_c = angmom_c + angmom_d + 1
+    n_cont = integrals_cont.shape[6:]  # (M_a, M_c, M_b, M_d)
+
+    # ---- HRR for center D (x and y components) ----
+    integrals_horiz_d = np.zeros(
+        (angmom_d + 1, angmom_d + 1, m_max_c, m_max_c, m_max_c, m_max_a, m_max_a, m_max_a, *n_cont)
+    )
+    integrals_horiz_d[0, 0, :, :, :, :, :, :, ...] = integrals_cont[
+        :, :, :, :m_max_a, :m_max_a, :m_max_a, ...
+    ]
+
+    # HRR x-component of d
+    for d in range(angmom_d):
+        integrals_horiz_d[d + 1, 0, :-1, :, :, :, :, :, ...] = (
+            integrals_horiz_d[d, 0, 1:, :, :, :, :, :, ...]
+            + rel_dist_two[0] * integrals_horiz_d[d, 0, :-1, :, :, :, :, :, ...]
+        )
+    # HRR y-component of d
+    for d in range(angmom_d):
+        integrals_horiz_d[:, d + 1, :, :-1, :, :, :, :, ...] = (
+            integrals_horiz_d[:, d, :, 1:, :, :, :, :, ...]
+            + rel_dist_two[1] * integrals_horiz_d[:, d, :, :-1, :, :, :, :, ...]
+        )
+
+    # Select angular momentum components (x, y) for c and d, then recurse z
+    angmoms_c_x, angmoms_c_y, angmoms_c_z = angmom_components_c.T
+    angmoms_d_x, angmoms_d_y, angmoms_d_z = angmom_components_d.T
+
+    integrals_horiz_d2 = np.zeros(
+        (
+            angmom_d + 1,
+            m_max_c,
+            angmom_components_d.shape[0],
+            angmom_components_c.shape[0],
+            m_max_a,
+            m_max_a,
+            m_max_a,
+            *n_cont,
+        )
+    )
+    integrals_horiz_d2[0] = np.transpose(
+        integrals_horiz_d[
+            angmoms_d_x.reshape(-1, 1),
+            angmoms_d_y.reshape(-1, 1),
+            angmoms_c_x.reshape(1, -1),
+            angmoms_c_y.reshape(1, -1),
+            :,
+            :,
+            :,
+            :,
+            :,
+            :,
+            :,
+            :,
+        ],
+        (2, 0, 1, 3, 4, 5, 6, 7, 8, 9),
+    )
+
+    # HRR z-component of d
+    for d in range(angmom_d):
+        integrals_horiz_d2[d + 1, :-1, :, :, :, :, :, ...] = (
+            integrals_horiz_d2[d, 1:, :, :, :, :, :, ...]
+            + rel_dist_two[2] * integrals_horiz_d2[d, :-1, :, :, :, :, :, ...]
+        )
+
+    # Select z components for c and d
+    integrals_horiz_d2 = integrals_horiz_d2[
+        angmoms_d_z.reshape(-1, 1),
+        angmoms_c_z.reshape(1, -1),
+        np.arange(angmoms_d_z.size).reshape(-1, 1),
+        np.arange(angmoms_c_z.size).reshape(1, -1),
+        :,
+        :,
+        :,
+        :,
+        :,
+        :,
+        :,
+    ]
+
+    # ---- HRR for center B (x and y components) ----
+    angmoms_a_x, angmoms_a_y, angmoms_a_z = angmom_components_a.T
+    angmoms_b_x, angmoms_b_y, angmoms_b_z = angmom_components_b.T
+
+    integrals_horiz_b = np.zeros(
+        (
+            angmom_b + 1,
+            angmom_b + 1,
+            m_max_a,
+            m_max_a,
+            m_max_a,
+            angmom_components_d.shape[0],
+            angmom_components_c.shape[0],
+            *n_cont,
+        )
+    )
+    integrals_horiz_b[0, 0, :, :, :, :, :, ...] = np.transpose(
+        integrals_horiz_d2[:, :, :, :, :, :, :, :, :], (2, 3, 4, 0, 1, 5, 6, 7, 8)
+    )
+
+    # HRR x-component of b
+    for b in range(angmom_b):
+        integrals_horiz_b[b + 1, 0, :-1, :, :, :, :, ...] = (
+            integrals_horiz_b[b, 0, 1:, :, :, :, :, ...]
+            + rel_dist_one[0] * integrals_horiz_b[b, 0, :-1, :, :, :, :, ...]
+        )
+    # HRR y-component of b
+    for b in range(angmom_b):
+        integrals_horiz_b[:, b + 1, :, :-1, :, :, :, ...] = (
+            integrals_horiz_b[:, b, :, 1:, :, :, :, ...]
+            + rel_dist_one[1] * integrals_horiz_b[:, b, :, :-1, :, :, :, ...]
+        )
+
+    # Select angular momentum components (x, y) for a and b, then recurse z
+    integrals_horiz_b2 = np.zeros(
+        (
+            angmom_b + 1,
+            m_max_a,
+            angmom_components_b.shape[0],
+            angmom_components_a.shape[0],
+            angmom_components_d.shape[0],
+            angmom_components_c.shape[0],
+            *n_cont,
+        )
+    )
+    integrals_horiz_b2[0] = np.transpose(
+        integrals_horiz_b[
+            angmoms_b_x.reshape(-1, 1),
+            angmoms_b_y.reshape(-1, 1),
+            angmoms_a_x.reshape(1, -1),
+            angmoms_a_y.reshape(1, -1),
+            :,
+            :,
+            :,
+            :,
+            :,
+            :,
+            :,
+        ],
+        (2, 0, 1, 3, 4, 5, 6, 7, 8),
+    )
+
+    # HRR z-component of b
+    for b in range(angmom_b):
+        integrals_horiz_b2[b + 1, :-1, :, :, :, :, ...] = (
+            integrals_horiz_b2[b, 1:, :, :, :, :, ...]
+            + rel_dist_one[2] * integrals_horiz_b2[b, :-1, :, :, :, :, ...]
+        )
+
+    # Select z components for a and b
+    integrals_horiz_b2 = integrals_horiz_b2[
+        angmoms_b_z.reshape(-1, 1),
+        angmoms_a_z.reshape(1, -1),
+        np.arange(angmoms_b_z.size).reshape(-1, 1),
+        np.arange(angmoms_a_z.size).reshape(1, -1),
+        :,
+        :,
+        :,
+        :,
+        :,
+        :,
+    ]
+
+    # Rearrange to final order: (L_a, L_b, L_c, L_d, M_a, M_b, M_c, M_d)
+    # Current: (L_b, L_a, L_d, L_c, M_a, M_c, M_b, M_d)
+    integrals = np.transpose(integrals_horiz_b2, (1, 0, 3, 2, 4, 6, 5, 7))
+
+    # Apply factorial2 normalization for angular momentum components
+    norm_a = _get_factorial2_norm(angmom_components_a).reshape(-1, 1, 1, 1, 1, 1, 1, 1)
+    norm_b = _get_factorial2_norm(angmom_components_b).reshape(1, -1, 1, 1, 1, 1, 1, 1)
+    norm_c = _get_factorial2_norm(angmom_components_c).reshape(1, 1, -1, 1, 1, 1, 1, 1)
+    norm_d = _get_factorial2_norm(angmom_components_d).reshape(1, 1, 1, -1, 1, 1, 1, 1)
+
+    integrals = integrals * norm_a * norm_b * norm_c * norm_d
+
+    return integrals
+
+
+def compute_two_electron_integrals_os_hgp(
+    boys_func,
+    coord_a,
+    angmom_a,
+    angmom_components_a,
+    exps_a,
+    coeffs_a,
+    coord_b,
+    angmom_b,
+    angmom_components_b,
+    exps_b,
+    coeffs_b,
+    coord_c,
+    angmom_c,
+    angmom_components_c,
+    exps_c,
+    coeffs_c,
+    coord_d,
+    angmom_d,
+    angmom_components_d,
+    exps_d,
+    coeffs_d,
+    primitive_threshold=0.0,
+):
+    r"""Compute two-electron integrals using OS+HGP algorithm.
+
+    This is the main entry point that combines all steps:
+    1. Boys function initialization (base case [00|00]^m)
+    2. VRR: Build angular momentum on center A  (Eq. 65)
+    3. ETR: Transfer angular momentum to center C (Eq. 66)
+    4. Contract primitives (einsum-based)
+    5. HRR: Distribute to centers B and D (Eq. 67, done LAST per HGP)
+
+    Parameters
+    ----------
+    boys_func : callable
+        Boys function with signature boys_func(orders, weighted_dist).
+    coord_a/b/c/d : np.ndarray(3,)
+        Centers of each contraction.
+    angmom_a/b/c/d : int
+        Angular momentum of each contraction.
+    angmom_components_a/b/c/d : np.ndarray(L, 3)
+        Angular momentum components for each contraction.
+    exps_a/b/c/d : np.ndarray(K,)
+        Primitive exponents.
+    coeffs_a/b/c/d : np.ndarray(K, M)
+        Contraction coefficients.
+    primitive_threshold : float, optional
+        Screening threshold for primitive quartets (default: 0.0, no screening).
+        Primitive quartets with |prefactor| < threshold are zeroed out per Eq. 64.
+
+    Returns
+    -------
+    integrals : np.ndarray(L_a, L_b, L_c, L_d, M_a, M_b, M_c, M_d)
+        Two-electron integrals in Chemists' notation.
+    """
+    m_max = angmom_a + angmom_b + angmom_c + angmom_d + 1
+    m_max_c = angmom_c + angmom_d + 1
+
+    # --- Pre-compute primitive quantities ---
+    # Reshape exponents for broadcasting: (K_d, K_b, K_c, K_a)
+    coord_a_4d = coord_a[:, np.newaxis, np.newaxis, np.newaxis, np.newaxis]
+    coord_b_4d = coord_b[:, np.newaxis, np.newaxis, np.newaxis, np.newaxis]
+    coord_c_4d = coord_c[:, np.newaxis, np.newaxis, np.newaxis, np.newaxis]
+    coord_d_4d = coord_d[:, np.newaxis, np.newaxis, np.newaxis, np.newaxis]
+
+    exps_a_4d = exps_a[np.newaxis, np.newaxis, np.newaxis, :]
+    exps_b_4d = exps_b[np.newaxis, :, np.newaxis, np.newaxis]
+    exps_c_4d = exps_c[np.newaxis, np.newaxis, :, np.newaxis]
+    exps_d_4d = exps_d[:, np.newaxis, np.newaxis, np.newaxis]
+
+    # Sum of exponents
+    exps_sum_one = exps_a_4d + exps_b_4d  # zeta = alpha_a + alpha_b
+    exps_sum_two = exps_c_4d + exps_d_4d  # eta  = alpha_c + alpha_d
+    exps_sum = exps_sum_one + exps_sum_two
+
+    # Harmonic means
+    harm_mean_one = (exps_a_4d * exps_b_4d) / exps_sum_one
+    harm_mean_two = (exps_c_4d * exps_d_4d) / exps_sum_two
+    harm_mean = exps_sum_one * exps_sum_two / exps_sum  # rho
+
+    # Weighted average centers
+    coord_wac_one = (exps_a_4d * coord_a_4d + exps_b_4d * coord_b_4d) / exps_sum_one  # P
+    coord_wac_two = (exps_c_4d * coord_c_4d + exps_d_4d * coord_d_4d) / exps_sum_two  # Q
+    coord_wac = coord_wac_one - coord_wac_two  # P - Q
+
+    # Relative coordinates
+    rel_dist_one = coord_a - coord_b  # A - B (for HRR)
+    rel_dist_two = coord_c - coord_d  # C - D (for HRR)
+    rel_coord_a = coord_wac_one - coord_a_4d  # P - A (for VRR)
+    rel_coord_c = coord_wac_two - coord_c_4d  # Q - C (for ETR)
+
+    # --- Step 1: Boys function initialization ---
+    weighted_dist = harm_mean * np.sum(coord_wac**2, axis=0)
+    prefactor = (
+        (2 * np.pi**2.5)
+        / (exps_sum_one * exps_sum_two * exps_sum**0.5)
+        * np.exp(-harm_mean_one * np.sum((coord_a_4d - coord_b_4d) ** 2, axis=0))
+        * np.exp(-harm_mean_two * np.sum((coord_c_4d - coord_d_4d) ** 2, axis=0))
+    )
+
+    # --- Primitive-level screening (Eq. 64) ---
+    if primitive_threshold > 0:
+        prefactor = np.where(np.abs(prefactor) >= primitive_threshold, prefactor, 0.0)
+
+    orders = np.arange(m_max)[:, None, None, None, None]
+    integrals_m = boys_func(orders, weighted_dist[None, :, :, :, :]) * prefactor
+
+    # --- Step 2: VRR ---
+    integrals_vert = _vertical_recursion_relation(
+        integrals_m, m_max, rel_coord_a, coord_wac, harm_mean, exps_sum_one
+    )
+
+    # --- Step 3: ETR ---
+    integrals_etransf = _electron_transfer_recursion(
+        integrals_vert, m_max, m_max_c, rel_coord_c, rel_coord_a, exps_sum_one, exps_sum_two
+    )
+
+    # --- Step 4: Contract primitives ---
+    integrals_cont = _optimized_contraction(
+        integrals_etransf,
+        exps_a,
+        exps_b,
+        exps_c,
+        exps_d,
+        coeffs_a,
+        coeffs_b,
+        coeffs_c,
+        coeffs_d,
+        angmom_a,
+        angmom_b,
+        angmom_c,
+        angmom_d,
+    )
+
+    # --- Step 5: HRR (done LAST per HGP scheme) ---
+    integrals = _horizontal_recursion_relation(
+        integrals_cont,
+        angmom_a,
+        angmom_b,
+        angmom_c,
+        angmom_d,
+        angmom_components_a,
+        angmom_components_b,
+        angmom_components_c,
+        angmom_components_d,
+        rel_dist_one,
+        rel_dist_two,
+    )
+
+    return integrals

--- a/gbasis/integrals/_two_elec_int_improved.py
+++ b/gbasis/integrals/_two_elec_int_improved.py
@@ -49,33 +49,26 @@ def _optimized_contraction(integrals_etransf, exps, coeffs, angmoms):
     ----------
     integrals_etransf : np.ndarray
         ETR output with shape (c_x, c_y, c_z, a_x, a_y, a_z, K_d, K_b, K_c, K_a).
-    exps : tuple of np.ndarray
-        Primitive exponents (exps_a, exps_b, exps_c, exps_d).
-    coeffs : tuple of np.ndarray
-        Contraction coefficients (coeffs_a, coeffs_b, coeffs_c, coeffs_d).
-    angmoms : tuple of int
-        Angular momenta (angmom_a, angmom_b, angmom_c, angmom_d).
+    exps : array-like of shape (4, K)
+        Primitive exponents stacked for all 4 centers (a, b, c, d).
+    coeffs : array-like of shape (4, K, M)
+        Contraction coefficients stacked for all 4 centers (a, b, c, d).
+    angmoms : array-like of shape (4,)
+        Angular momenta for all 4 centers (a, b, c, d).
 
     Returns
     -------
     contracted : np.ndarray
         Contracted integrals with shape (c_x, c_y, c_z, a_x, a_y, a_z, M_a, M_c, M_b, M_d).
     """
-    exps_a, exps_b, exps_c, exps_d = exps
-    coeffs_a, coeffs_b, coeffs_c, coeffs_d = coeffs
-    angmom_a, angmom_b, angmom_c, angmom_d = angmoms
-
-    # Precompute normalization constants (1D arrays)
-    norm_a = (2 * exps_a / np.pi) ** 0.75 * (4 * exps_a) ** (angmom_a / 2)
-    norm_b = (2 * exps_b / np.pi) ** 0.75 * (4 * exps_b) ** (angmom_b / 2)
-    norm_c = (2 * exps_c / np.pi) ** 0.75 * (4 * exps_c) ** (angmom_c / 2)
-    norm_d = (2 * exps_d / np.pi) ** 0.75 * (4 * exps_d) ** (angmom_d / 2)
-
-    # Multiply coefficients by normalization (more efficient than per-element)
-    coeffs_a_norm = coeffs_a * norm_a[:, np.newaxis]
-    coeffs_b_norm = coeffs_b * norm_b[:, np.newaxis]
-    coeffs_c_norm = coeffs_c * norm_c[:, np.newaxis]
-    coeffs_d_norm = coeffs_d * norm_d[:, np.newaxis]
+    # Vectorized norm computation over all 4 centers
+    exps = np.array(exps)  # shape (4, K)
+    angmoms = np.array(angmoms)  # shape (4,)
+    coeffs = np.array(coeffs)  # shape (4, K, M)
+    # shape (4, K)
+    norms = ((2 / np.pi) * exps) ** 0.75 * (4 * exps) ** (angmoms[:, np.newaxis] / 2)
+    coeffs_norm = coeffs * norms[:, :, np.newaxis]  # shape (4, K, M)
+    coeffs_a_norm, coeffs_b_norm, coeffs_c_norm, coeffs_d_norm = coeffs_norm
 
     # Use einsum with optimization for contraction
     # Input: (c_x, c_y, c_z, a_x, a_y, a_z, K_d, K_b, K_c, K_a)

--- a/tests/test_two_elec_int_improved.py
+++ b/tests/test_two_elec_int_improved.py
@@ -1,0 +1,392 @@
+"""Test gbasis.integrals._two_elec_int_improved module.
+
+Tests for VRR (Week 2), ETR + contraction (Week 3), and HRR + full pipeline (Week 4).
+"""
+
+import numpy as np
+import pytest
+
+from gbasis.integrals._two_elec_int_improved import (
+    _vertical_recursion_relation,
+    _electron_transfer_recursion,
+    _optimized_contraction,
+    _get_factorial2_norm,
+    _horizontal_recursion_relation,
+    compute_two_electron_integrals_os_hgp,
+)
+
+
+class TestVerticalRecursion:
+    """Tests for the Vertical Recursion Relation (VRR)."""
+
+    def test_vrr_base_case(self):
+        """Test that VRR preserves base case [00|00]^m."""
+        m_max = 4
+        n_prim = 2
+
+        # Create mock integrals_m (base case values)
+        integrals_m = np.random.rand(m_max, n_prim, n_prim, n_prim, n_prim)
+
+        # Mock coordinates and exponents
+        rel_coord_a = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
+        coord_wac = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
+        harm_mean = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
+        exps_sum_one = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
+
+        result = _vertical_recursion_relation(
+            integrals_m, m_max, rel_coord_a, coord_wac, harm_mean, exps_sum_one
+        )
+
+        # Base case should be preserved at [m, 0, 0, 0]
+        assert np.allclose(result[:, 0, 0, 0, ...], integrals_m)
+
+    def test_vrr_output_shape(self):
+        """Test that VRR output has correct shape."""
+        m_max = 5
+        n_prim = 3
+
+        integrals_m = np.zeros((m_max, n_prim, n_prim, n_prim, n_prim))
+        rel_coord_a = np.zeros((3, n_prim, n_prim, n_prim, n_prim))
+        coord_wac = np.zeros((3, n_prim, n_prim, n_prim, n_prim))
+        harm_mean = np.ones((n_prim, n_prim, n_prim, n_prim))
+        exps_sum_one = np.ones((n_prim, n_prim, n_prim, n_prim))
+
+        result = _vertical_recursion_relation(
+            integrals_m, m_max, rel_coord_a, coord_wac, harm_mean, exps_sum_one
+        )
+
+        expected_shape = (m_max, m_max, m_max, m_max, n_prim, n_prim, n_prim, n_prim)
+        assert result.shape == expected_shape
+
+    def test_vrr_p_orbital_manual(self):
+        """Test VRR first recursion step for p-orbital manually.
+
+        For p-orbital, VRR computes:
+        [1,0|00]^0 = (P-A)_x * [00|00]^0 - (rho/zeta)*(Q-P)_x * [00|00]^1
+        """
+        m_max = 2
+        integrals_m = np.array([[[[[1.0]]]],
+                                [[[[0.5]]]]])
+
+        PA_x, PA_y, PA_z = 0.3, 0.0, 0.0
+        PQ_x, PQ_y, PQ_z = 0.2, 0.0, 0.0
+        rho = 0.6
+        zeta = 1.5
+
+        rel_coord_a = np.array([[[[[PA_x]]]],
+                                [[[[PA_y]]]],
+                                [[[[PA_z]]]]])
+        coord_wac = np.array([[[[[PQ_x]]]],
+                              [[[[PQ_y]]]],
+                              [[[[PQ_z]]]]])
+        harm_mean = np.array([[[[rho]]]])
+        exps_sum_one = np.array([[[[zeta]]]])
+
+        result = _vertical_recursion_relation(
+            integrals_m, m_max, rel_coord_a, coord_wac, harm_mean, exps_sum_one
+        )
+
+        # Manual: [1,0,0|00]^0 = PA_x * [00|00]^0 - (rho/zeta)*PQ_x * [00|00]^1
+        expected = PA_x * 1.0 - (rho / zeta) * PQ_x * 0.5
+        assert np.allclose(result[0, 1, 0, 0, 0, 0, 0, 0], expected)
+
+    def test_vrr_s_orbital_no_change(self):
+        """Test VRR with s-orbital where no recursion is needed."""
+        m_max = 1
+        integrals_m = np.array([[[[[3.14]]]]])
+
+        rel_coord_a = np.zeros((3, 1, 1, 1, 1))
+        coord_wac = np.zeros((3, 1, 1, 1, 1))
+        harm_mean = np.ones((1, 1, 1, 1))
+        exps_sum_one = np.ones((1, 1, 1, 1))
+
+        result = _vertical_recursion_relation(
+            integrals_m, m_max, rel_coord_a, coord_wac, harm_mean, exps_sum_one
+        )
+
+        assert np.allclose(result[0, 0, 0, 0], 3.14)
+
+
+class TestElectronTransferRecursion:
+    """Tests for the Electron Transfer Recursion (ETR)."""
+
+    def test_etr_base_case(self):
+        """Test that ETR preserves base case (discards m, keeps a)."""
+        m_max = 4
+        m_max_c = 3
+        n_prim = 2
+
+        # Create mock VRR output
+        integrals_vert = np.random.rand(
+            m_max, m_max, m_max, m_max, n_prim, n_prim, n_prim, n_prim
+        )
+
+        rel_coord_c = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
+        rel_coord_a = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
+        exps_sum_one = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
+        exps_sum_two = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
+
+        result = _electron_transfer_recursion(
+            integrals_vert, m_max, m_max_c, rel_coord_c, rel_coord_a,
+            exps_sum_one, exps_sum_two
+        )
+
+        # Base case: [0,0,0, a_x, a_y, a_z] should equal integrals_vert[0, a_x, a_y, a_z]
+        assert np.allclose(result[0, 0, 0, ...], integrals_vert[0, ...])
+
+    def test_etr_output_shape(self):
+        """Test that ETR output has correct shape."""
+        m_max = 3
+        m_max_c = 2
+        n_prim = 2
+
+        integrals_vert = np.random.rand(
+            m_max, m_max, m_max, m_max, n_prim, n_prim, n_prim, n_prim
+        )
+
+        rel_coord_c = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
+        rel_coord_a = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
+        exps_sum_one = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
+        exps_sum_two = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
+
+        result = _electron_transfer_recursion(
+            integrals_vert, m_max, m_max_c, rel_coord_c, rel_coord_a,
+            exps_sum_one, exps_sum_two
+        )
+
+        expected_shape = (m_max_c, m_max_c, m_max_c, m_max, m_max, m_max,
+                          n_prim, n_prim, n_prim, n_prim)
+        assert result.shape == expected_shape
+
+
+class TestFactorial2Norm:
+    """Tests for the factorial2 normalization helper."""
+
+    def test_s_orbital_norm(self):
+        """Test normalization for s-orbital (L=0)."""
+        s_components = np.array([[0, 0, 0]])
+        norm = _get_factorial2_norm(s_components)
+        # (2*0-1)!! = (-1)!! = 1, so norm = 1/sqrt(1) = 1
+        assert np.allclose(norm, 1.0)
+
+    def test_p_orbital_norm(self):
+        """Test normalization for p-orbital (L=1)."""
+        p_components = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        norm = _get_factorial2_norm(p_components)
+        # Each component has one (2*1-1)!! = 1!! = 1 and two (2*0-1)!! = 1
+        # So norm = 1/sqrt(1*1*1) = 1 for all
+        assert np.allclose(norm, 1.0)
+
+    def test_caching(self):
+        """Test that factorial2 normalization is cached."""
+        d_components = np.array([[2, 0, 0], [1, 1, 0]])
+        norm1 = _get_factorial2_norm(d_components)
+        norm2 = _get_factorial2_norm(d_components)
+        assert np.allclose(norm1, norm2)
+
+
+class TestImprovedVsOld:
+    """Compare improved OS+HGP implementation against old implementation."""
+
+    def test_ssss_matches_old(self):
+        """Test (ss|ss) integrals match old implementation.
+
+        Note: The old _compute_two_elec_integrals has a known limitation with
+        all-zero angular momentum, so we compare against the specialized
+        _compute_two_elec_integrals_angmom_zero function instead.
+        """
+        from gbasis.integrals._two_elec_int import _compute_two_elec_integrals_angmom_zero
+        from gbasis.integrals.point_charge import PointChargeIntegral
+
+        boys_func = PointChargeIntegral.boys_func
+
+        coord_a = np.array([0.0, 0.0, 0.0])
+        coord_b = np.array([1.0, 0.0, 0.0])
+        coord_c = np.array([0.0, 1.0, 0.0])
+        coord_d = np.array([1.0, 1.0, 0.0])
+
+        angmom_comp = np.array([[0, 0, 0]])
+
+        exps_a = np.array([1.0, 0.5])
+        exps_b = np.array([0.8])
+        exps_c = np.array([1.2, 0.6])
+        exps_d = np.array([0.9])
+
+        coeffs_a = np.array([[1.0], [0.5]])
+        coeffs_b = np.array([[1.0]])
+        coeffs_c = np.array([[1.0], [0.3]])
+        coeffs_d = np.array([[1.0]])
+
+        # Old implementation (specialized for angmom zero)
+        result_old = _compute_two_elec_integrals_angmom_zero(
+            boys_func,
+            coord_a, exps_a, coeffs_a,
+            coord_b, exps_b, coeffs_b,
+            coord_c, exps_c, coeffs_c,
+            coord_d, exps_d, coeffs_d,
+        )
+
+        # New implementation
+        result_new = compute_two_electron_integrals_os_hgp(
+            boys_func,
+            coord_a, 0, angmom_comp, exps_a, coeffs_a,
+            coord_b, 0, angmom_comp, exps_b, coeffs_b,
+            coord_c, 0, angmom_comp, exps_c, coeffs_c,
+            coord_d, 0, angmom_comp, exps_d, coeffs_d,
+        )
+
+        np.testing.assert_allclose(result_new, result_old, rtol=1e-10,
+            err_msg="(ss|ss) integrals don't match between old and improved")
+
+    def test_spsp_matches_old(self):
+        """Test (sp|sp) integrals match old implementation."""
+        from gbasis.integrals._two_elec_int import _compute_two_elec_integrals
+        from gbasis.integrals.point_charge import PointChargeIntegral
+
+        boys_func = PointChargeIntegral.boys_func
+
+        coord_a = np.array([0.0, 0.0, 0.0])
+        coord_b = np.array([1.5, 0.0, 0.0])
+        coord_c = np.array([0.0, 1.5, 0.0])
+        coord_d = np.array([1.5, 1.5, 0.0])
+
+        exps_a = np.array([1.0, 0.5])
+        exps_b = np.array([0.8])
+        exps_c = np.array([1.2])
+        exps_d = np.array([0.9])
+
+        coeffs_a = np.array([[1.0], [0.5]])
+        coeffs_b = np.array([[1.0]])
+        coeffs_c = np.array([[1.0]])
+        coeffs_d = np.array([[1.0]])
+
+        # s-orbital components
+        s_comp = np.array([[0, 0, 0]])
+        # p-orbital components
+        p_comp = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+
+        # Old implementation
+        result_old = _compute_two_elec_integrals(
+            boys_func,
+            coord_a, 0, s_comp, exps_a, coeffs_a,
+            coord_b, 1, p_comp, exps_b, coeffs_b,
+            coord_c, 0, s_comp, exps_c, coeffs_c,
+            coord_d, 1, p_comp, exps_d, coeffs_d,
+        )
+
+        # New implementation
+        result_new = compute_two_electron_integrals_os_hgp(
+            boys_func,
+            coord_a, 0, s_comp, exps_a, coeffs_a,
+            coord_b, 1, p_comp, exps_b, coeffs_b,
+            coord_c, 0, s_comp, exps_c, coeffs_c,
+            coord_d, 1, p_comp, exps_d, coeffs_d,
+        )
+
+        np.testing.assert_allclose(result_new, result_old, rtol=1e-10,
+            err_msg="(sp|sp) integrals don't match between old and improved")
+
+
+class TestHighAngularMomentum:
+    """Test that high angular momentum integrals don't produce NaN/Inf."""
+
+    def test_dddd_no_overflow(self):
+        """Test (dd|dd) integrals produce finite values."""
+        from gbasis.integrals.point_charge import PointChargeIntegral
+
+        boys_func = PointChargeIntegral.boys_func
+
+        coord_a = np.array([0.0, 0.0, 0.0])
+        coord_b = np.array([1.0, 0.0, 0.0])
+        coord_c = np.array([0.0, 1.0, 0.0])
+        coord_d = np.array([1.0, 1.0, 0.0])
+
+        exps = np.array([1.0])
+        coeffs = np.array([[1.0]])
+
+        # d-orbital components (L=2): xx, xy, xz, yy, yz, zz
+        d_comp = np.array([
+            [2, 0, 0], [1, 1, 0], [1, 0, 1],
+            [0, 2, 0], [0, 1, 1], [0, 0, 2]
+        ])
+
+        result = compute_two_electron_integrals_os_hgp(
+            boys_func,
+            coord_a, 2, d_comp, exps, coeffs,
+            coord_b, 2, d_comp, exps, coeffs,
+            coord_c, 2, d_comp, exps, coeffs,
+            coord_d, 2, d_comp, exps, coeffs,
+        )
+
+        assert np.all(np.isfinite(result)), "d-orbital integrals contain NaN or Inf"
+        assert result.shape == (6, 6, 6, 6, 1, 1, 1, 1)
+
+
+class TestPrimitiveScreening:
+    """Tests for primitive-level screening (Eq. 64)."""
+
+    def test_screening_zero_threshold(self):
+        """With threshold=0, results match unscreened exactly."""
+        from scipy.special import hyp1f1
+
+        def boys_func(orders, weighted_dist):
+            return hyp1f1(orders + 0.5, orders + 1.5, -weighted_dist) / (2 * orders + 1)
+
+        coord_a = np.array([0.0, 0.0, 0.0])
+        coord_b = np.array([1.0, 0.0, 0.0])
+        exps = np.array([1.0, 0.5])
+        coeffs = np.array([[1.0], [1.0]])
+        s_comp = np.array([[0, 0, 0]])
+        p_comp = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+
+        result_no_screen = compute_two_electron_integrals_os_hgp(
+            boys_func,
+            coord_a, 0, s_comp, exps, coeffs,
+            coord_b, 1, p_comp, exps, coeffs,
+            coord_a, 0, s_comp, exps, coeffs,
+            coord_b, 1, p_comp, exps, coeffs,
+        )
+
+        result_screened = compute_two_electron_integrals_os_hgp(
+            boys_func,
+            coord_a, 0, s_comp, exps, coeffs,
+            coord_b, 1, p_comp, exps, coeffs,
+            coord_a, 0, s_comp, exps, coeffs,
+            coord_b, 1, p_comp, exps, coeffs,
+            primitive_threshold=0.0,
+        )
+
+        np.testing.assert_array_equal(result_no_screen, result_screened)
+
+    def test_screening_reasonable_threshold(self):
+        """With reasonable threshold, results match within tolerance."""
+        from scipy.special import hyp1f1
+
+        def boys_func(orders, weighted_dist):
+            return hyp1f1(orders + 0.5, orders + 1.5, -weighted_dist) / (2 * orders + 1)
+
+        coord_a = np.array([0.0, 0.0, 0.0])
+        coord_b = np.array([1.0, 0.0, 0.0])
+        exps = np.array([1.0, 0.5, 0.1])
+        coeffs = np.array([[1.0], [1.0], [1.0]])
+        s_comp = np.array([[0, 0, 0]])
+
+        result_no_screen = compute_two_electron_integrals_os_hgp(
+            boys_func,
+            coord_a, 0, s_comp, exps, coeffs,
+            coord_b, 0, s_comp, exps, coeffs,
+            coord_a, 0, s_comp, exps, coeffs,
+            coord_b, 0, s_comp, exps, coeffs,
+        )
+
+        result_screened = compute_two_electron_integrals_os_hgp(
+            boys_func,
+            coord_a, 0, s_comp, exps, coeffs,
+            coord_b, 0, s_comp, exps, coeffs,
+            coord_a, 0, s_comp, exps, coeffs,
+            coord_b, 0, s_comp, exps, coeffs,
+            primitive_threshold=1e-12,
+        )
+
+        np.testing.assert_allclose(result_no_screen, result_screened, atol=1e-10)
+

--- a/tests/test_two_elec_int_improved.py
+++ b/tests/test_two_elec_int_improved.py
@@ -159,22 +159,22 @@ class TestFactorial2Norm:
 
     def test_s_orbital_norm(self):
         """Test normalization for s-orbital (L=0)."""
-        s_components = np.array([[0, 0, 0]])
-        norm = _get_factorial2_norm(s_components)
+        s_key = ((0, 0, 0),)
+        norm = _get_factorial2_norm(s_key)
         # (2*0-1)!! = (-1)!! = 1, so norm = 1/sqrt(1) = 1
         assert np.allclose(norm, 1.0)
 
     def test_p_orbital_norm(self):
         """Test normalization for p-orbital (L=1)."""
-        p_components = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
-        norm = _get_factorial2_norm(p_components)
+        p_key = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+        norm = _get_factorial2_norm(p_key)
         # Each component has one (2*1-1)!! = 1!! = 1 and two (2*0-1)!! = 1
         # So norm = 1/sqrt(1*1*1) = 1 for all
         assert np.allclose(norm, 1.0)
 
     def test_caching(self):
         """Test that factorial2 normalization is cached."""
-        d_components = np.array([[2, 0, 0], [1, 1, 0]])
-        norm1 = _get_factorial2_norm(d_components)
-        norm2 = _get_factorial2_norm(d_components)
+        d_key = ((2, 0, 0), (1, 1, 0))
+        norm1 = _get_factorial2_norm(d_key)
+        norm2 = _get_factorial2_norm(d_key)
         assert np.allclose(norm1, norm2)

--- a/tests/test_two_elec_int_improved.py
+++ b/tests/test_two_elec_int_improved.py
@@ -1,0 +1,183 @@
+"""Test gbasis.integrals._two_elec_int_improved module.
+
+Tests for VRR (Week 2) and ETR + contraction (Week 3).
+"""
+
+import numpy as np
+import pytest
+
+from gbasis.integrals._two_elec_int_improved import (
+    _vertical_recursion_relation,
+    _electron_transfer_recursion,
+    _optimized_contraction,
+    _get_factorial2_norm,
+)
+
+
+class TestVerticalRecursion:
+    """Tests for the Vertical Recursion Relation (VRR)."""
+
+    def test_vrr_base_case(self):
+        """Test that VRR preserves base case [00|00]^m."""
+        m_max = 4
+        n_prim = 2
+
+        # Create mock integrals_m (base case values)
+        integrals_m = np.random.rand(m_max, n_prim, n_prim, n_prim, n_prim)
+
+        # Mock coordinates and exponents
+        rel_coord_a = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
+        coord_wac = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
+        harm_mean = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
+        exps_sum_one = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
+
+        result = _vertical_recursion_relation(
+            integrals_m, m_max, rel_coord_a, coord_wac, harm_mean, exps_sum_one
+        )
+
+        # Base case should be preserved at [m, 0, 0, 0]
+        assert np.allclose(result[:, 0, 0, 0, ...], integrals_m)
+
+    def test_vrr_output_shape(self):
+        """Test that VRR output has correct shape."""
+        m_max = 5
+        n_prim = 3
+
+        integrals_m = np.zeros((m_max, n_prim, n_prim, n_prim, n_prim))
+        rel_coord_a = np.zeros((3, n_prim, n_prim, n_prim, n_prim))
+        coord_wac = np.zeros((3, n_prim, n_prim, n_prim, n_prim))
+        harm_mean = np.ones((n_prim, n_prim, n_prim, n_prim))
+        exps_sum_one = np.ones((n_prim, n_prim, n_prim, n_prim))
+
+        result = _vertical_recursion_relation(
+            integrals_m, m_max, rel_coord_a, coord_wac, harm_mean, exps_sum_one
+        )
+
+        expected_shape = (m_max, m_max, m_max, m_max, n_prim, n_prim, n_prim, n_prim)
+        assert result.shape == expected_shape
+
+    def test_vrr_p_orbital_manual(self):
+        """Test VRR first recursion step for p-orbital manually.
+
+        For p-orbital, VRR computes:
+        [1,0|00]^0 = (P-A)_x * [00|00]^0 - (rho/zeta)*(Q-P)_x * [00|00]^1
+        """
+        m_max = 2
+        integrals_m = np.array([[[[[1.0]]]],
+                                [[[[0.5]]]]])
+
+        PA_x, PA_y, PA_z = 0.3, 0.0, 0.0
+        PQ_x, PQ_y, PQ_z = 0.2, 0.0, 0.0
+        rho = 0.6
+        zeta = 1.5
+
+        rel_coord_a = np.array([[[[[PA_x]]]],
+                                [[[[PA_y]]]],
+                                [[[[PA_z]]]]])
+        coord_wac = np.array([[[[[PQ_x]]]],
+                              [[[[PQ_y]]]],
+                              [[[[PQ_z]]]]])
+        harm_mean = np.array([[[[rho]]]])
+        exps_sum_one = np.array([[[[zeta]]]])
+
+        result = _vertical_recursion_relation(
+            integrals_m, m_max, rel_coord_a, coord_wac, harm_mean, exps_sum_one
+        )
+
+        # Manual: [1,0,0|00]^0 = PA_x * [00|00]^0 - (rho/zeta)*PQ_x * [00|00]^1
+        expected = PA_x * 1.0 - (rho / zeta) * PQ_x * 0.5
+        assert np.allclose(result[0, 1, 0, 0, 0, 0, 0, 0], expected)
+
+    def test_vrr_s_orbital_no_change(self):
+        """Test VRR with s-orbital where no recursion is needed."""
+        m_max = 1
+        integrals_m = np.array([[[[[3.14]]]]])
+
+        rel_coord_a = np.zeros((3, 1, 1, 1, 1))
+        coord_wac = np.zeros((3, 1, 1, 1, 1))
+        harm_mean = np.ones((1, 1, 1, 1))
+        exps_sum_one = np.ones((1, 1, 1, 1))
+
+        result = _vertical_recursion_relation(
+            integrals_m, m_max, rel_coord_a, coord_wac, harm_mean, exps_sum_one
+        )
+
+        assert np.allclose(result[0, 0, 0, 0], 3.14)
+
+
+class TestElectronTransferRecursion:
+    """Tests for the Electron Transfer Recursion (ETR)."""
+
+    def test_etr_base_case(self):
+        """Test that ETR preserves base case (discards m, keeps a)."""
+        m_max = 4
+        m_max_c = 3
+        n_prim = 2
+
+        # Create mock VRR output
+        integrals_vert = np.random.rand(
+            m_max, m_max, m_max, m_max, n_prim, n_prim, n_prim, n_prim
+        )
+
+        rel_coord_c = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
+        rel_coord_a = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
+        exps_sum_one = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
+        exps_sum_two = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
+
+        result = _electron_transfer_recursion(
+            integrals_vert, m_max, m_max_c, rel_coord_c, rel_coord_a,
+            exps_sum_one, exps_sum_two
+        )
+
+        # Base case: [0,0,0, a_x, a_y, a_z] should equal integrals_vert[0, a_x, a_y, a_z]
+        assert np.allclose(result[0, 0, 0, ...], integrals_vert[0, ...])
+
+    def test_etr_output_shape(self):
+        """Test that ETR output has correct shape."""
+        m_max = 3
+        m_max_c = 2
+        n_prim = 2
+
+        integrals_vert = np.random.rand(
+            m_max, m_max, m_max, m_max, n_prim, n_prim, n_prim, n_prim
+        )
+
+        rel_coord_c = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
+        rel_coord_a = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
+        exps_sum_one = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
+        exps_sum_two = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
+
+        result = _electron_transfer_recursion(
+            integrals_vert, m_max, m_max_c, rel_coord_c, rel_coord_a,
+            exps_sum_one, exps_sum_two
+        )
+
+        expected_shape = (m_max_c, m_max_c, m_max_c, m_max, m_max, m_max,
+                          n_prim, n_prim, n_prim, n_prim)
+        assert result.shape == expected_shape
+
+
+class TestFactorial2Norm:
+    """Tests for the factorial2 normalization helper."""
+
+    def test_s_orbital_norm(self):
+        """Test normalization for s-orbital (L=0)."""
+        s_components = np.array([[0, 0, 0]])
+        norm = _get_factorial2_norm(s_components)
+        # (2*0-1)!! = (-1)!! = 1, so norm = 1/sqrt(1) = 1
+        assert np.allclose(norm, 1.0)
+
+    def test_p_orbital_norm(self):
+        """Test normalization for p-orbital (L=1)."""
+        p_components = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        norm = _get_factorial2_norm(p_components)
+        # Each component has one (2*1-1)!! = 1!! = 1 and two (2*0-1)!! = 1
+        # So norm = 1/sqrt(1*1*1) = 1 for all
+        assert np.allclose(norm, 1.0)
+
+    def test_caching(self):
+        """Test that factorial2 normalization is cached."""
+        d_components = np.array([[2, 0, 0], [1, 1, 0]])
+        norm1 = _get_factorial2_norm(d_components)
+        norm2 = _get_factorial2_norm(d_components)
+        assert np.allclose(norm1, norm2)

--- a/tests/test_two_elec_int_improved.py
+++ b/tests/test_two_elec_int_improved.py
@@ -4,16 +4,19 @@ Tests for VRR (Week 2), ETR + contraction (Week 3), and HRR + full pipeline (Wee
 """
 
 import numpy as np
-import pytest
+from scipy.special import hyp1f1
 
+from gbasis.integrals._two_elec_int import (
+    _compute_two_elec_integrals,
+    _compute_two_elec_integrals_angmom_zero,
+)
 from gbasis.integrals._two_elec_int_improved import (
-    _vertical_recursion_relation,
     _electron_transfer_recursion,
-    _optimized_contraction,
     _get_factorial2_norm,
-    _horizontal_recursion_relation,
+    _vertical_recursion_relation,
     compute_two_electron_integrals_os_hgp,
 )
+from gbasis.integrals.point_charge import PointChargeIntegral
 
 
 class TestVerticalRecursion:
@@ -65,20 +68,15 @@ class TestVerticalRecursion:
         [1,0|00]^0 = (P-A)_x * [00|00]^0 - (rho/zeta)*(Q-P)_x * [00|00]^1
         """
         m_max = 2
-        integrals_m = np.array([[[[[1.0]]]],
-                                [[[[0.5]]]]])
+        integrals_m = np.array([[[[[1.0]]]], [[[[0.5]]]]])
 
         PA_x, PA_y, PA_z = 0.3, 0.0, 0.0
         PQ_x, PQ_y, PQ_z = 0.2, 0.0, 0.0
         rho = 0.6
         zeta = 1.5
 
-        rel_coord_a = np.array([[[[[PA_x]]]],
-                                [[[[PA_y]]]],
-                                [[[[PA_z]]]]])
-        coord_wac = np.array([[[[[PQ_x]]]],
-                              [[[[PQ_y]]]],
-                              [[[[PQ_z]]]]])
+        rel_coord_a = np.array([[[[[PA_x]]]], [[[[PA_y]]]], [[[[PA_z]]]]])
+        coord_wac = np.array([[[[[PQ_x]]]], [[[[PQ_y]]]], [[[[PQ_z]]]]])
         harm_mean = np.array([[[[rho]]]])
         exps_sum_one = np.array([[[[zeta]]]])
 
@@ -117,9 +115,7 @@ class TestElectronTransferRecursion:
         n_prim = 2
 
         # Create mock VRR output
-        integrals_vert = np.random.rand(
-            m_max, m_max, m_max, m_max, n_prim, n_prim, n_prim, n_prim
-        )
+        integrals_vert = np.random.rand(m_max, m_max, m_max, m_max, n_prim, n_prim, n_prim, n_prim)
 
         rel_coord_c = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
         rel_coord_a = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
@@ -127,8 +123,7 @@ class TestElectronTransferRecursion:
         exps_sum_two = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
 
         result = _electron_transfer_recursion(
-            integrals_vert, m_max, m_max_c, rel_coord_c, rel_coord_a,
-            exps_sum_one, exps_sum_two
+            integrals_vert, m_max, m_max_c, rel_coord_c, rel_coord_a, exps_sum_one, exps_sum_two
         )
 
         # Base case: [0,0,0, a_x, a_y, a_z] should equal integrals_vert[0, a_x, a_y, a_z]
@@ -140,9 +135,7 @@ class TestElectronTransferRecursion:
         m_max_c = 2
         n_prim = 2
 
-        integrals_vert = np.random.rand(
-            m_max, m_max, m_max, m_max, n_prim, n_prim, n_prim, n_prim
-        )
+        integrals_vert = np.random.rand(m_max, m_max, m_max, m_max, n_prim, n_prim, n_prim, n_prim)
 
         rel_coord_c = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
         rel_coord_a = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
@@ -150,12 +143,21 @@ class TestElectronTransferRecursion:
         exps_sum_two = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
 
         result = _electron_transfer_recursion(
-            integrals_vert, m_max, m_max_c, rel_coord_c, rel_coord_a,
-            exps_sum_one, exps_sum_two
+            integrals_vert, m_max, m_max_c, rel_coord_c, rel_coord_a, exps_sum_one, exps_sum_two
         )
 
-        expected_shape = (m_max_c, m_max_c, m_max_c, m_max, m_max, m_max,
-                          n_prim, n_prim, n_prim, n_prim)
+        expected_shape = (
+            m_max_c,
+            m_max_c,
+            m_max_c,
+            m_max,
+            m_max,
+            m_max,
+            n_prim,
+            n_prim,
+            n_prim,
+            n_prim,
+        )
         assert result.shape == expected_shape
 
 
@@ -195,9 +197,6 @@ class TestImprovedVsOld:
         all-zero angular momentum, so we compare against the specialized
         _compute_two_elec_integrals_angmom_zero function instead.
         """
-        from gbasis.integrals._two_elec_int import _compute_two_elec_integrals_angmom_zero
-        from gbasis.integrals.point_charge import PointChargeIntegral
-
         boys_func = PointChargeIntegral.boys_func
 
         coord_a = np.array([0.0, 0.0, 0.0])
@@ -220,29 +219,54 @@ class TestImprovedVsOld:
         # Old implementation (specialized for angmom zero)
         result_old = _compute_two_elec_integrals_angmom_zero(
             boys_func,
-            coord_a, exps_a, coeffs_a,
-            coord_b, exps_b, coeffs_b,
-            coord_c, exps_c, coeffs_c,
-            coord_d, exps_d, coeffs_d,
+            coord_a,
+            exps_a,
+            coeffs_a,
+            coord_b,
+            exps_b,
+            coeffs_b,
+            coord_c,
+            exps_c,
+            coeffs_c,
+            coord_d,
+            exps_d,
+            coeffs_d,
         )
 
         # New implementation
         result_new = compute_two_electron_integrals_os_hgp(
             boys_func,
-            coord_a, 0, angmom_comp, exps_a, coeffs_a,
-            coord_b, 0, angmom_comp, exps_b, coeffs_b,
-            coord_c, 0, angmom_comp, exps_c, coeffs_c,
-            coord_d, 0, angmom_comp, exps_d, coeffs_d,
+            coord_a,
+            0,
+            angmom_comp,
+            exps_a,
+            coeffs_a,
+            coord_b,
+            0,
+            angmom_comp,
+            exps_b,
+            coeffs_b,
+            coord_c,
+            0,
+            angmom_comp,
+            exps_c,
+            coeffs_c,
+            coord_d,
+            0,
+            angmom_comp,
+            exps_d,
+            coeffs_d,
         )
 
-        np.testing.assert_allclose(result_new, result_old, rtol=1e-10,
-            err_msg="(ss|ss) integrals don't match between old and improved")
+        np.testing.assert_allclose(
+            result_new,
+            result_old,
+            rtol=1e-10,
+            err_msg="(ss|ss) integrals don't match between old and improved",
+        )
 
     def test_spsp_matches_old(self):
         """Test (sp|sp) integrals match old implementation."""
-        from gbasis.integrals._two_elec_int import _compute_two_elec_integrals
-        from gbasis.integrals.point_charge import PointChargeIntegral
-
         boys_func = PointChargeIntegral.boys_func
 
         coord_a = np.array([0.0, 0.0, 0.0])
@@ -268,23 +292,59 @@ class TestImprovedVsOld:
         # Old implementation
         result_old = _compute_two_elec_integrals(
             boys_func,
-            coord_a, 0, s_comp, exps_a, coeffs_a,
-            coord_b, 1, p_comp, exps_b, coeffs_b,
-            coord_c, 0, s_comp, exps_c, coeffs_c,
-            coord_d, 1, p_comp, exps_d, coeffs_d,
+            coord_a,
+            0,
+            s_comp,
+            exps_a,
+            coeffs_a,
+            coord_b,
+            1,
+            p_comp,
+            exps_b,
+            coeffs_b,
+            coord_c,
+            0,
+            s_comp,
+            exps_c,
+            coeffs_c,
+            coord_d,
+            1,
+            p_comp,
+            exps_d,
+            coeffs_d,
         )
 
         # New implementation
         result_new = compute_two_electron_integrals_os_hgp(
             boys_func,
-            coord_a, 0, s_comp, exps_a, coeffs_a,
-            coord_b, 1, p_comp, exps_b, coeffs_b,
-            coord_c, 0, s_comp, exps_c, coeffs_c,
-            coord_d, 1, p_comp, exps_d, coeffs_d,
+            coord_a,
+            0,
+            s_comp,
+            exps_a,
+            coeffs_a,
+            coord_b,
+            1,
+            p_comp,
+            exps_b,
+            coeffs_b,
+            coord_c,
+            0,
+            s_comp,
+            exps_c,
+            coeffs_c,
+            coord_d,
+            1,
+            p_comp,
+            exps_d,
+            coeffs_d,
         )
 
-        np.testing.assert_allclose(result_new, result_old, rtol=1e-10,
-            err_msg="(sp|sp) integrals don't match between old and improved")
+        np.testing.assert_allclose(
+            result_new,
+            result_old,
+            rtol=1e-10,
+            err_msg="(sp|sp) integrals don't match between old and improved",
+        )
 
 
 class TestHighAngularMomentum:
@@ -292,8 +352,6 @@ class TestHighAngularMomentum:
 
     def test_dddd_no_overflow(self):
         """Test (dd|dd) integrals produce finite values."""
-        from gbasis.integrals.point_charge import PointChargeIntegral
-
         boys_func = PointChargeIntegral.boys_func
 
         coord_a = np.array([0.0, 0.0, 0.0])
@@ -305,17 +363,30 @@ class TestHighAngularMomentum:
         coeffs = np.array([[1.0]])
 
         # d-orbital components (L=2): xx, xy, xz, yy, yz, zz
-        d_comp = np.array([
-            [2, 0, 0], [1, 1, 0], [1, 0, 1],
-            [0, 2, 0], [0, 1, 1], [0, 0, 2]
-        ])
+        d_comp = np.array([[2, 0, 0], [1, 1, 0], [1, 0, 1], [0, 2, 0], [0, 1, 1], [0, 0, 2]])
 
         result = compute_two_electron_integrals_os_hgp(
             boys_func,
-            coord_a, 2, d_comp, exps, coeffs,
-            coord_b, 2, d_comp, exps, coeffs,
-            coord_c, 2, d_comp, exps, coeffs,
-            coord_d, 2, d_comp, exps, coeffs,
+            coord_a,
+            2,
+            d_comp,
+            exps,
+            coeffs,
+            coord_b,
+            2,
+            d_comp,
+            exps,
+            coeffs,
+            coord_c,
+            2,
+            d_comp,
+            exps,
+            coeffs,
+            coord_d,
+            2,
+            d_comp,
+            exps,
+            coeffs,
         )
 
         assert np.all(np.isfinite(result)), "d-orbital integrals contain NaN or Inf"
@@ -327,7 +398,6 @@ class TestPrimitiveScreening:
 
     def test_screening_zero_threshold(self):
         """With threshold=0, results match unscreened exactly."""
-        from scipy.special import hyp1f1
 
         def boys_func(orders, weighted_dist):
             return hyp1f1(orders + 0.5, orders + 1.5, -weighted_dist) / (2 * orders + 1)
@@ -341,18 +411,50 @@ class TestPrimitiveScreening:
 
         result_no_screen = compute_two_electron_integrals_os_hgp(
             boys_func,
-            coord_a, 0, s_comp, exps, coeffs,
-            coord_b, 1, p_comp, exps, coeffs,
-            coord_a, 0, s_comp, exps, coeffs,
-            coord_b, 1, p_comp, exps, coeffs,
+            coord_a,
+            0,
+            s_comp,
+            exps,
+            coeffs,
+            coord_b,
+            1,
+            p_comp,
+            exps,
+            coeffs,
+            coord_a,
+            0,
+            s_comp,
+            exps,
+            coeffs,
+            coord_b,
+            1,
+            p_comp,
+            exps,
+            coeffs,
         )
 
         result_screened = compute_two_electron_integrals_os_hgp(
             boys_func,
-            coord_a, 0, s_comp, exps, coeffs,
-            coord_b, 1, p_comp, exps, coeffs,
-            coord_a, 0, s_comp, exps, coeffs,
-            coord_b, 1, p_comp, exps, coeffs,
+            coord_a,
+            0,
+            s_comp,
+            exps,
+            coeffs,
+            coord_b,
+            1,
+            p_comp,
+            exps,
+            coeffs,
+            coord_a,
+            0,
+            s_comp,
+            exps,
+            coeffs,
+            coord_b,
+            1,
+            p_comp,
+            exps,
+            coeffs,
             primitive_threshold=0.0,
         )
 
@@ -360,7 +462,6 @@ class TestPrimitiveScreening:
 
     def test_screening_reasonable_threshold(self):
         """With reasonable threshold, results match within tolerance."""
-        from scipy.special import hyp1f1
 
         def boys_func(orders, weighted_dist):
             return hyp1f1(orders + 0.5, orders + 1.5, -weighted_dist) / (2 * orders + 1)
@@ -373,20 +474,51 @@ class TestPrimitiveScreening:
 
         result_no_screen = compute_two_electron_integrals_os_hgp(
             boys_func,
-            coord_a, 0, s_comp, exps, coeffs,
-            coord_b, 0, s_comp, exps, coeffs,
-            coord_a, 0, s_comp, exps, coeffs,
-            coord_b, 0, s_comp, exps, coeffs,
+            coord_a,
+            0,
+            s_comp,
+            exps,
+            coeffs,
+            coord_b,
+            0,
+            s_comp,
+            exps,
+            coeffs,
+            coord_a,
+            0,
+            s_comp,
+            exps,
+            coeffs,
+            coord_b,
+            0,
+            s_comp,
+            exps,
+            coeffs,
         )
 
         result_screened = compute_two_electron_integrals_os_hgp(
             boys_func,
-            coord_a, 0, s_comp, exps, coeffs,
-            coord_b, 0, s_comp, exps, coeffs,
-            coord_a, 0, s_comp, exps, coeffs,
-            coord_b, 0, s_comp, exps, coeffs,
+            coord_a,
+            0,
+            s_comp,
+            exps,
+            coeffs,
+            coord_b,
+            0,
+            s_comp,
+            exps,
+            coeffs,
+            coord_a,
+            0,
+            s_comp,
+            exps,
+            coeffs,
+            coord_b,
+            0,
+            s_comp,
+            exps,
+            coeffs,
             primitive_threshold=1e-12,
         )
 
         np.testing.assert_allclose(result_no_screen, result_screened, atol=1e-10)
-

--- a/tests/test_two_elec_int_improved.py
+++ b/tests/test_two_elec_int_improved.py
@@ -8,6 +8,7 @@ import numpy as np
 from gbasis.integrals._two_elec_int_improved import (
     _electron_transfer_recursion,
     _get_factorial2_norm,
+    _optimized_contraction,
     _vertical_recursion_relation,
 )
 
@@ -151,6 +152,36 @@ class TestElectronTransferRecursion:
             n_prim,
             n_prim,
         )
+        assert result.shape == expected_shape
+
+
+class TestOptimizedContraction:
+    """Tests for the optimized primitive contraction."""
+
+    def test_output_shape(self):
+        """Test that contraction output has correct shape."""
+        K, M = 2, 3
+        integrals_etransf = np.random.rand(1, 1, 1, 1, 1, 1, K, K, K, K)
+        exps = np.random.rand(4, K) + 0.1
+        coeffs = np.random.rand(4, K, M)
+        angmoms = np.array([0, 0, 0, 0])
+
+        result = _optimized_contraction(integrals_etransf, exps, coeffs, angmoms)
+
+        expected_shape = (1, 1, 1, 1, 1, 1, M, M, M, M)
+        assert result.shape == expected_shape
+
+    def test_accepts_tuples(self):
+        """Test that contraction accepts tuples as well as arrays."""
+        K, M = 2, 2
+        integrals_etransf = np.random.rand(1, 1, 1, 1, 1, 1, K, K, K, K)
+        exps = tuple(np.random.rand(K) + 0.1 for _ in range(4))
+        coeffs = tuple(np.random.rand(K, M) for _ in range(4))
+        angmoms = (0, 0, 0, 0)
+
+        result = _optimized_contraction(integrals_etransf, exps, coeffs, angmoms)
+
+        expected_shape = (1, 1, 1, 1, 1, 1, M, M, M, M)
         assert result.shape == expected_shape
 
 

--- a/tests/test_two_elec_int_improved.py
+++ b/tests/test_two_elec_int_improved.py
@@ -4,13 +4,11 @@ Tests for VRR (Week 2) and ETR + contraction (Week 3).
 """
 
 import numpy as np
-import pytest
 
 from gbasis.integrals._two_elec_int_improved import (
-    _vertical_recursion_relation,
     _electron_transfer_recursion,
-    _optimized_contraction,
     _get_factorial2_norm,
+    _vertical_recursion_relation,
 )
 
 
@@ -63,20 +61,15 @@ class TestVerticalRecursion:
         [1,0|00]^0 = (P-A)_x * [00|00]^0 - (rho/zeta)*(Q-P)_x * [00|00]^1
         """
         m_max = 2
-        integrals_m = np.array([[[[[1.0]]]],
-                                [[[[0.5]]]]])
+        integrals_m = np.array([[[[[1.0]]]], [[[[0.5]]]]])
 
         PA_x, PA_y, PA_z = 0.3, 0.0, 0.0
         PQ_x, PQ_y, PQ_z = 0.2, 0.0, 0.0
         rho = 0.6
         zeta = 1.5
 
-        rel_coord_a = np.array([[[[[PA_x]]]],
-                                [[[[PA_y]]]],
-                                [[[[PA_z]]]]])
-        coord_wac = np.array([[[[[PQ_x]]]],
-                              [[[[PQ_y]]]],
-                              [[[[PQ_z]]]]])
+        rel_coord_a = np.array([[[[[PA_x]]]], [[[[PA_y]]]], [[[[PA_z]]]]])
+        coord_wac = np.array([[[[[PQ_x]]]], [[[[PQ_y]]]], [[[[PQ_z]]]]])
         harm_mean = np.array([[[[rho]]]])
         exps_sum_one = np.array([[[[zeta]]]])
 
@@ -115,9 +108,7 @@ class TestElectronTransferRecursion:
         n_prim = 2
 
         # Create mock VRR output
-        integrals_vert = np.random.rand(
-            m_max, m_max, m_max, m_max, n_prim, n_prim, n_prim, n_prim
-        )
+        integrals_vert = np.random.rand(m_max, m_max, m_max, m_max, n_prim, n_prim, n_prim, n_prim)
 
         rel_coord_c = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
         rel_coord_a = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
@@ -125,8 +116,7 @@ class TestElectronTransferRecursion:
         exps_sum_two = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
 
         result = _electron_transfer_recursion(
-            integrals_vert, m_max, m_max_c, rel_coord_c, rel_coord_a,
-            exps_sum_one, exps_sum_two
+            integrals_vert, m_max, m_max_c, rel_coord_c, rel_coord_a, exps_sum_one, exps_sum_two
         )
 
         # Base case: [0,0,0, a_x, a_y, a_z] should equal integrals_vert[0, a_x, a_y, a_z]
@@ -138,9 +128,7 @@ class TestElectronTransferRecursion:
         m_max_c = 2
         n_prim = 2
 
-        integrals_vert = np.random.rand(
-            m_max, m_max, m_max, m_max, n_prim, n_prim, n_prim, n_prim
-        )
+        integrals_vert = np.random.rand(m_max, m_max, m_max, m_max, n_prim, n_prim, n_prim, n_prim)
 
         rel_coord_c = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
         rel_coord_a = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
@@ -148,12 +136,21 @@ class TestElectronTransferRecursion:
         exps_sum_two = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
 
         result = _electron_transfer_recursion(
-            integrals_vert, m_max, m_max_c, rel_coord_c, rel_coord_a,
-            exps_sum_one, exps_sum_two
+            integrals_vert, m_max, m_max_c, rel_coord_c, rel_coord_a, exps_sum_one, exps_sum_two
         )
 
-        expected_shape = (m_max_c, m_max_c, m_max_c, m_max, m_max, m_max,
-                          n_prim, n_prim, n_prim, n_prim)
+        expected_shape = (
+            m_max_c,
+            m_max_c,
+            m_max_c,
+            m_max,
+            m_max,
+            m_max,
+            n_prim,
+            n_prim,
+            n_prim,
+            n_prim,
+        )
         assert result.shape == expected_shape
 
 


### PR DESCRIPTION

## Summary
- Implemented `_horizontal_recursion_relation()` — HRR (Eq. 67), transfers angular momentum to center B and D
- Implemented `compute_two_electron_integrals_os_hgp()` — complete OS+HGP pipeline entry point
- Full pipeline: Boys → VRR → ETR → Contract → HRR
- Part of Issue #221 (Week 4),
-  builds on PR #234 (VRR) and,
-  ETR PR #237

## What Changed

| File | Lines | What |
|------|-------|------|
| `gbasis/integrals/_two_elec_int_improved.py` | +200 | HRR + complete pipeline implementation |
| `tests/test_two_elec_int_improved.py` | +200 | 14 tests (VRR + ETR + HRR + pipeline) |

## Mathematical Reference

The Horizontal Recursion Relation (Eq. 67) is:

$$[a, b+1_i | c, d] = [a+1_i, b | c, d] + (A-B)_i [a, b | c, d]$$

where angular momentum is transferred from center A to center B (and similarly C to D).

## How To Test

```bash
# Run tests
pytest tests/test_two_elec_int_improved.py -v

# Check coverage
python -m pytest tests/test_two_elec_int_improved.py --cov=gbasis.integrals._two_elec_int_improved --cov-report=term-missing

# Check formatting & linting
black --check gbasis/integrals/_two_elec_int_improved.py tests/test_two_elec_int_improved.py
ruff check gbasis/integrals/_two_elec_int_improved.py tests/test_two_elec_int_improved.py

# Verify existing tests not broken
pytest tests/ --timeout=120
```


## Proof That It Works

### Tests (16 passed)

<img width="1852" height="632" alt="image" src="https://github.com/user-attachments/assets/72144a00-0492-41fa-9008-4d58eb1604a4" />


## Check coverage
<img width="1851" height="835" alt="image" src="https://github.com/user-attachments/assets/b8eace62-0016-47bd-a4b5-b88a5526fecf" />


### Black: Clean & Ruff: Clean
<img width="1835" height="260" alt="image" src="https://github.com/user-attachments/assets/a1ac5a2c-75d3-4790-84d8-36c9ed755a99" />



### Existing tests: Not broken
307 passed, 279 skipped, 1 xfailed, 4 warnings in 67.52s (0:01:07)

## First Checklist
- [x] Tests added for each new function
- [x] All 9 tests pass
- [x] Black formatted
- [x] Ruff linting clean
- [x] Existing tests not broken
- [x] Docstrings in numpydoc format
- [x] No new dependencies added (uses existing numpy)
- [x] Pure Python only (no C/Fortran)


## Scope of this PR
- This PR completes the full OS+HGP pipeline for two-electron integrals (VRR → ETR → Contract → HRR)
- Adds `_vertical_recursion_relation` (VRR)
- Adds `_electron_transfer_recursion` (ETR)
- Adds `_optimized_contraction` with per-center vectorized norm computation
- Adds `_horizontal_recursion_relation` (HRR)
- Adds `compute_two_electron_integrals_os_hgp` (full pipeline)
- Does NOT modify any existing code
- Does NOT change any existing tests


## Second Checklist
- [x] Write a good description of what the PR does.
- [x] Add tests for each unit of code added (e.g. function, class)
- [ ] Update documentation
- [ ] Squash commits that can be grouped together
- [x] Rebase onto master



## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
|   | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |



