### PR TITLE
[PR-6] feat: implement Schwarz screening for two-electron integral optimization

### DIFF
--- a/gbasis/integrals/_schwarz_screening.py
+++ b/gbasis/integrals/_schwarz_screening.py
@@ -1,0 +1,218 @@
+"""Integral screening utilities for efficient 2-electron integral computation.
+
+This module implements Schwarz screening and shell-pair screening to skip
+negligible integrals, providing speedup for spatially extended systems.
+
+References:
+- Häser, M. & Ahlrichs, R. J. Comput. Chem. 1989, 10, 104.
+- Gill, P. M. W.; Johnson, B. G.; Pople, J. A. Int. J. Quantum Chem. 1991, 40, 745.
+"""
+
+import numpy as np
+
+
+def compute_schwarz_bound_shell_pair(boys_func, cont_one, cont_two, compute_integral_func):
+    """Compute Schwarz bound for a shell pair: sqrt((ab|ab)).
+
+    Parameters
+    ----------
+    boys_func : callable
+        Boys function for integral evaluation.
+    cont_one : GeneralizedContractionShell
+        First contracted shell.
+    cont_two : GeneralizedContractionShell
+        Second contracted shell.
+    compute_integral_func : callable
+        Function to compute (ab|cd) integrals.
+
+    Returns
+    -------
+    bound : float
+        Schwarz bound sqrt(max|(ab|ab)|) for this shell pair.
+    """
+    # Compute (ab|ab) integral
+    integral = compute_integral_func(
+        boys_func,
+        cont_one.coord,
+        cont_one.angmom,
+        cont_one.angmom_components_cart,
+        cont_one.exps,
+        cont_one.coeffs,
+        cont_two.coord,
+        cont_two.angmom,
+        cont_two.angmom_components_cart,
+        cont_two.exps,
+        cont_two.coeffs,
+        cont_one.coord,
+        cont_one.angmom,
+        cont_one.angmom_components_cart,
+        cont_one.exps,
+        cont_one.coeffs,
+        cont_two.coord,
+        cont_two.angmom,
+        cont_two.angmom_components_cart,
+        cont_two.exps,
+        cont_two.coeffs,
+    )
+
+    # Return sqrt of maximum absolute value
+    return np.sqrt(np.max(np.abs(integral)))
+
+
+def compute_schwarz_bounds(contractions, boys_func, compute_integral_func):
+    """Precompute Schwarz bounds for all shell pairs.
+
+    Parameters
+    ----------
+    contractions : list of GeneralizedContractionShell
+        List of all contracted shells.
+    boys_func : callable
+        Boys function for integral evaluation.
+    compute_integral_func : callable
+        Function to compute (ab|cd) integrals.
+
+    Returns
+    -------
+    bounds : np.ndarray(n_shells, n_shells)
+        Schwarz bounds sqrt((ab|ab)) for each shell pair.
+    """
+    n_shells = len(contractions)
+    bounds = np.zeros((n_shells, n_shells))
+
+    for i, cont_i in enumerate(contractions):
+        for j in range(i, n_shells):
+            cont_j = contractions[j]
+            bounds[i, j] = compute_schwarz_bound_shell_pair(
+                boys_func, cont_i, cont_j, compute_integral_func
+            )
+            bounds[j, i] = bounds[i, j]  # Symmetry: (ab|ab) = (ba|ba)
+
+    return bounds
+
+
+def shell_pair_significant(cont_one, cont_two, threshold=1e-12):
+    """Check if a shell pair is significant using primitive screening.
+
+    Uses the Gaussian product theorem: exp(-a*b/(a+b) * |A-B|^2) factor.
+    If this factor is below threshold for all primitive pairs, skip.
+
+    Parameters
+    ----------
+    cont_one : GeneralizedContractionShell
+        First contracted shell.
+    cont_two : GeneralizedContractionShell
+        Second contracted shell.
+    threshold : float
+        Screening threshold.
+
+    Returns
+    -------
+    significant : bool
+        True if shell pair might contribute significantly.
+    """
+    # Distance between shell centers
+    r_ab_sq = np.sum((cont_one.coord - cont_two.coord) ** 2)
+
+    if r_ab_sq < 1e-10:
+        # Same center, always significant
+        return True
+
+    # Check if any primitive pair survives screening
+    for exp_a in cont_one.exps:
+        for exp_b in cont_two.exps:
+            # Gaussian decay factor
+            decay = np.exp(-exp_a * exp_b / (exp_a + exp_b) * r_ab_sq)
+            if decay > threshold:
+                return True
+
+    return False
+
+
+class SchwarzScreener:
+    """Class for Schwarz integral screening.
+
+    Precomputes Schwarz bounds and provides efficient screening.
+
+    Attributes
+    ----------
+    bounds : np.ndarray
+        Schwarz bounds for all shell pairs.
+    threshold : float
+        Screening threshold.
+    n_screened : int
+        Counter for number of screened shell quartets.
+    n_computed : int
+        Counter for number of computed shell quartets.
+    """
+
+    def __init__(self, contractions, boys_func, compute_integral_func, threshold=1e-12):
+        """Initialize Schwarz screener.
+
+        Parameters
+        ----------
+        contractions : list of GeneralizedContractionShell
+            List of all contracted shells.
+        boys_func : callable
+            Boys function for integral evaluation.
+        compute_integral_func : callable
+            Function to compute (ab|cd) integrals.
+        threshold : float
+            Screening threshold (default: 1e-12).
+        """
+        self.threshold = threshold
+        self.n_screened = 0
+        self.n_computed = 0
+
+        # Precompute Schwarz bounds
+        self.bounds = compute_schwarz_bounds(contractions, boys_func, compute_integral_func)
+
+    def is_significant(self, i, j, k, l_shell):
+        """Check if shell quartet (ij|kl) is significant.
+
+        Uses Schwarz inequality: |(ij|kl)| <= sqrt((ij|ij)) * sqrt((kl|kl))
+
+        Parameters
+        ----------
+        i, j, k, l_shell : int
+            Shell indices.
+
+        Returns
+        -------
+        significant : bool
+            True if integral might be significant, False if can be skipped.
+        """
+        bound = self.bounds[i, j] * self.bounds[k, l_shell]
+
+        if bound < self.threshold:
+            self.n_screened += 1
+            return False
+        else:
+            self.n_computed += 1
+            return True
+
+    def get_statistics(self):
+        """Get screening statistics.
+
+        Returns
+        -------
+        stats : dict
+            Dictionary with screening statistics.
+        """
+        total = self.n_screened + self.n_computed
+        if total == 0:
+            percent_screened = 0.0
+        else:
+            percent_screened = 100.0 * self.n_screened / total
+
+        return {
+            "n_screened": self.n_screened,
+            "n_computed": self.n_computed,
+            "total": total,
+            "percent_screened": percent_screened,
+            "speedup_factor": total / max(self.n_computed, 1),
+        }
+
+    def reset_counters(self):
+        """Reset screening counters."""
+        self.n_screened = 0
+        self.n_computed = 0

--- a/gbasis/integrals/_two_elec_int_improved.py
+++ b/gbasis/integrals/_two_elec_int_improved.py
@@ -1,0 +1,386 @@
+"""Improved two-electron integrals using Obara-Saika + Head-Gordon-Pople recursions.
+
+This module implements VRR, ETR, and primitive contraction steps of the
+OS+HGP algorithm for two-electron integrals.
+
+Algorithm overview (full pipeline):
+1. Start with Boys function F_m(T) for m = 0 to angmom_total
+2. VRR: Build [a0|00]^m from [00|00]^m (Eq. 65)        <-- Done (PR 2)
+3. ETR: Build [a0|c0]^0 from [a0|00]^m (Eq. 66)        <-- THIS PR
+4. Contract primitives                                    <-- THIS PR
+5. HRR: Build [ab|cd] from [a0|c0] (Eq. 67)             <-- Future
+
+References:
+- Obara, S. & Saika, A. J. Chem. Phys. 1986, 84, 3963.
+- Head-Gordon, M. & Pople, J. A. J. Chem. Phys. 1988, 89, 5777.
+- Ahlrichs, R. Phys. Chem. Chem. Phys. 2006, 8, 3072.
+"""
+
+import numpy as np
+
+from gbasis.utils import factorial2
+
+# Cache for factorial2 values to avoid repeated computation
+_FACTORIAL2_CACHE = {}
+
+
+def _get_factorial2_norm(angmom_components):
+    """Get cached factorial2 normalization for angular momentum components.
+
+    Parameters
+    ----------
+    angmom_components : np.ndarray(n, 3)
+        Angular momentum components.
+
+    Returns
+    -------
+    norm : np.ndarray(n,)
+        Normalization factors 1/sqrt(prod((2*l-1)!!)).
+    """
+    key = tuple(map(tuple, angmom_components))
+    if key not in _FACTORIAL2_CACHE:
+        _FACTORIAL2_CACHE[key] = 1.0 / np.sqrt(
+            np.prod(factorial2(2 * angmom_components - 1), axis=1)
+        )
+    return _FACTORIAL2_CACHE[key]
+
+
+def _optimized_contraction(
+    integrals_etransf,
+    exps_a,
+    exps_b,
+    exps_c,
+    exps_d,
+    coeffs_a,
+    coeffs_b,
+    coeffs_c,
+    coeffs_d,
+    angmom_a,
+    angmom_b,
+    angmom_c,
+    angmom_d,
+):
+    """Optimized primitive contraction using einsum.
+
+    Parameters
+    ----------
+    integrals_etransf : np.ndarray
+        ETR output with shape (c_x, c_y, c_z, a_x, a_y, a_z, K_d, K_b, K_c, K_a).
+    exps_a/b/c/d : np.ndarray
+        Primitive exponents.
+    coeffs_a/b/c/d : np.ndarray
+        Contraction coefficients.
+    angmom_a/b/c/d : int
+        Angular momenta.
+
+    Returns
+    -------
+    contracted : np.ndarray
+        Contracted integrals with shape (c_x, c_y, c_z, a_x, a_y, a_z, M_a, M_c, M_b, M_d).
+    """
+    # Precompute normalization constants (1D arrays)
+    norm_a = (2 * exps_a / np.pi) ** 0.75 * (4 * exps_a) ** (angmom_a / 2)
+    norm_b = (2 * exps_b / np.pi) ** 0.75 * (4 * exps_b) ** (angmom_b / 2)
+    norm_c = (2 * exps_c / np.pi) ** 0.75 * (4 * exps_c) ** (angmom_c / 2)
+    norm_d = (2 * exps_d / np.pi) ** 0.75 * (4 * exps_d) ** (angmom_d / 2)
+
+    # Multiply coefficients by normalization (more efficient than per-element)
+    coeffs_a_norm = coeffs_a * norm_a[:, np.newaxis]
+    coeffs_b_norm = coeffs_b * norm_b[:, np.newaxis]
+    coeffs_c_norm = coeffs_c * norm_c[:, np.newaxis]
+    coeffs_d_norm = coeffs_d * norm_d[:, np.newaxis]
+
+    # Use einsum with optimization for contraction
+    # Input: (c_x, c_y, c_z, a_x, a_y, a_z, K_d, K_b, K_c, K_a)
+    # Contract one primitive at a time for memory efficiency
+    # K_a contraction
+    contracted = np.einsum("...a,aA->...A", integrals_etransf, coeffs_a_norm, optimize=True)
+    # K_c contraction (now axis -2 is K_c)
+    contracted = np.einsum("...cA,cC->...CA", contracted, coeffs_c_norm, optimize=True)
+    # K_b contraction (now axis -3 is K_b)
+    contracted = np.einsum("...bCA,bB->...CBA", contracted, coeffs_b_norm, optimize=True)
+    # K_d contraction (now axis -4 is K_d)
+    contracted = np.einsum("...dCBA,dD->...CBAD", contracted, coeffs_d_norm, optimize=True)
+
+    # Reorder to (c_x, c_y, c_z, a_x, a_y, a_z, M_a, M_c, M_b, M_d)
+    # Current: (..., M_c, M_b, M_a, M_d) -> need (..., M_a, M_c, M_b, M_d)
+    contracted = np.moveaxis(contracted, -2, -4)
+
+    return contracted
+
+
+def _vertical_recursion_relation(
+    integrals_m,
+    m_max,
+    rel_coord_a,
+    coord_wac,
+    harm_mean,
+    exps_sum_one,
+):
+    """Apply Vertical Recursion Relation (VRR) to build angular momentum on center A.
+
+    This implements Eq. 65 from the algorithm notes:
+    [a+1,0|00]^m = (P-A)_i [a0|00]^m - (rho/zeta)(Q-P)_i [a0|00]^{m+1}
+                   + a_i/(2*zeta) * ([a-1,0|00]^m - (rho/zeta)[a-1,0|00]^{m+1})
+
+    Parameters
+    ----------
+    integrals_m : np.ndarray
+        Array containing [00|00]^m for all m values.
+        Shape: (m_max, K_d, K_b, K_c, K_a)
+    m_max : int
+        Maximum angular momentum order.
+    rel_coord_a : np.ndarray(3, K_d, K_b, K_c, K_a)
+        P - A coordinates for each primitive combination.
+    coord_wac : np.ndarray(3, K_d, K_b, K_c, K_a)
+        Q - P coordinates (weighted average centers difference).
+    harm_mean : np.ndarray(K_d, K_b, K_c, K_a)
+        Harmonic mean: rho = zeta*eta/(zeta+eta).
+    exps_sum_one : np.ndarray(K_d, K_b, K_c, K_a)
+        Sum of exponents: zeta = alpha_a + alpha_b.
+
+    Returns
+    -------
+    integrals_vert : np.ndarray
+        Integrals with angular momentum built on center A.
+        Shape: (m_max, m_max, m_max, m_max, K_d, K_b, K_c, K_a)
+        Axes 1, 2, 3 correspond to a_x, a_y, a_z.
+    """
+    # Precompute coefficients for efficiency (avoid repeated division)
+    rho_over_zeta = harm_mean / exps_sum_one
+    half_over_zeta = 0.5 / exps_sum_one
+
+    # Precompute products (avoids repeated multiplication in loops)
+    roz_wac_x = rho_over_zeta * coord_wac[0]
+    roz_wac_y = rho_over_zeta * coord_wac[1]
+    roz_wac_z = rho_over_zeta * coord_wac[2]
+
+    # Initialize output array with contiguous memory
+    # axis 0: m, axis 1: a_x, axis 2: a_y, axis 3: a_z
+    integrals_vert = np.zeros((m_max, m_max, m_max, m_max, *integrals_m.shape[1:]), order="C")
+
+    # Base case: [00|00]^m
+    integrals_vert[:, 0, 0, 0, ...] = integrals_m
+
+    # VRR for x-component (a_x)
+    if m_max > 1:
+        # First step: a_x = 0 -> a_x = 1
+        integrals_vert[:-1, 1, 0, 0, ...] = (
+            rel_coord_a[0] * integrals_vert[:-1, 0, 0, 0, ...]
+            - roz_wac_x * integrals_vert[1:, 0, 0, 0, ...]
+        )
+        # Higher a_x values (precompute a * half_over_zeta)
+        for a in range(1, m_max - 1):
+            coeff_a = a * half_over_zeta
+            integrals_vert[:-1, a + 1, 0, 0, ...] = (
+                rel_coord_a[0] * integrals_vert[:-1, a, 0, 0, ...]
+                - roz_wac_x * integrals_vert[1:, a, 0, 0, ...]
+                + coeff_a
+                * (
+                    integrals_vert[:-1, a - 1, 0, 0, ...]
+                    - rho_over_zeta * integrals_vert[1:, a - 1, 0, 0, ...]
+                )
+            )
+
+    # VRR for y-component (a_y)
+    if m_max > 1:
+        integrals_vert[:-1, :, 1, 0, ...] = (
+            rel_coord_a[1] * integrals_vert[:-1, :, 0, 0, ...]
+            - roz_wac_y * integrals_vert[1:, :, 0, 0, ...]
+        )
+        for a in range(1, m_max - 1):
+            coeff_a = a * half_over_zeta
+            integrals_vert[:-1, :, a + 1, 0, ...] = (
+                rel_coord_a[1] * integrals_vert[:-1, :, a, 0, ...]
+                - roz_wac_y * integrals_vert[1:, :, a, 0, ...]
+                + coeff_a
+                * (
+                    integrals_vert[:-1, :, a - 1, 0, ...]
+                    - rho_over_zeta * integrals_vert[1:, :, a - 1, 0, ...]
+                )
+            )
+
+    # VRR for z-component (a_z)
+    if m_max > 1:
+        integrals_vert[:-1, :, :, 1, ...] = (
+            rel_coord_a[2] * integrals_vert[:-1, :, :, 0, ...]
+            - roz_wac_z * integrals_vert[1:, :, :, 0, ...]
+        )
+        for a in range(1, m_max - 1):
+            coeff_a = a * half_over_zeta
+            integrals_vert[:-1, :, :, a + 1, ...] = (
+                rel_coord_a[2] * integrals_vert[:-1, :, :, a, ...]
+                - roz_wac_z * integrals_vert[1:, :, :, a, ...]
+                + coeff_a
+                * (
+                    integrals_vert[:-1, :, :, a - 1, ...]
+                    - rho_over_zeta * integrals_vert[1:, :, :, a - 1, ...]
+                )
+            )
+
+    return integrals_vert
+
+
+def _electron_transfer_recursion(
+    integrals_vert,
+    m_max,
+    m_max_c,
+    rel_coord_c,
+    rel_coord_a,
+    exps_sum_one,
+    exps_sum_two,
+):
+    """Apply Electron Transfer Recursion (ETR) to transfer angular momentum to center C.
+
+    This implements Eq. 66 from the algorithm notes:
+    [a0|c+1,0]^0 = (Q-C)_i [a0|c0]^0 + (zeta/eta)(P-A)_i [a0|c0]^0
+                   - (zeta/eta) [a+1,0|c0]^0
+                   + c_i/(2*eta) [a0|c-1,0]^0
+                   + a_i/(2*eta) [a-1,0|c0]^0
+
+    Parameters
+    ----------
+    integrals_vert : np.ndarray
+        Output from VRR with angular momentum on A.
+        Shape: (m_max, a_x_max, a_y_max, a_z_max, K_d, K_b, K_c, K_a)
+    m_max : int
+        Maximum m value (angmom_a + angmom_b + angmom_c + angmom_d + 1).
+    m_max_c : int
+        Maximum c angular momentum (angmom_c + angmom_d + 1).
+    rel_coord_c : np.ndarray(3, K_d, K_b, K_c, K_a)
+        Q - C coordinates.
+    rel_coord_a : np.ndarray(3, K_d, K_b, K_c, K_a)
+        P - A coordinates.
+    exps_sum_one : np.ndarray
+        zeta = alpha_a + alpha_b.
+    exps_sum_two : np.ndarray
+        eta = alpha_c + alpha_d.
+
+    Returns
+    -------
+    integrals_etransf : np.ndarray
+        Integrals with angular momentum on both A and C.
+        Shape: (c_x_max, c_y_max, c_z_max, a_x_max, a_y_max, a_z_max, K_d, K_b, K_c, K_a)
+    """
+    n_primitives = integrals_vert.shape[4:]
+    zeta_over_eta = exps_sum_one / exps_sum_two
+
+    # Precompute coefficients (avoid repeated division in loops)
+    half_over_eta = 0.5 / exps_sum_two
+
+    # Precompute combined coordinate terms for each axis
+    qc_plus_zoe_pa_x = rel_coord_c[0] + zeta_over_eta * rel_coord_a[0]
+    qc_plus_zoe_pa_y = rel_coord_c[1] + zeta_over_eta * rel_coord_a[1]
+    qc_plus_zoe_pa_z = rel_coord_c[2] + zeta_over_eta * rel_coord_a[2]
+
+    # Initialize ETR output with contiguous memory
+    integrals_etransf = np.zeros(
+        (m_max_c, m_max_c, m_max_c, m_max, m_max, m_max, *n_primitives), order="C"
+    )
+
+    # Base case: discard m index (take m=0)
+    integrals_etransf[0, 0, 0, ...] = integrals_vert[0, ...]
+
+    # Precompute a_indices coefficient array once
+    if m_max > 2:
+        a_coeff_x = (
+            np.arange(1, m_max - 1).reshape(-1, 1, 1, *([1] * len(n_primitives))) * half_over_eta
+        )
+        a_coeff_y = (
+            np.arange(1, m_max - 1).reshape(1, 1, 1, 1, -1, 1, *([1] * len(n_primitives)))
+            * half_over_eta
+        )
+        a_coeff_z = (
+            np.arange(1, m_max - 1).reshape(1, 1, 1, 1, 1, -1, *([1] * len(n_primitives)))
+            * half_over_eta
+        )
+
+    # ETR for c_x
+    for c in range(m_max_c - 1):
+        c_coeff = c * half_over_eta  # Precompute c/(2*eta)
+        if c == 0:
+            # First step: c_x = 0 -> c_x = 1
+            # For a_x = 0
+            integrals_etransf[1, 0, 0, 0, ...] = (
+                qc_plus_zoe_pa_x * integrals_etransf[0, 0, 0, 0, ...]
+                - zeta_over_eta * integrals_etransf[0, 0, 0, 1, ...]
+            )
+            # For a_x >= 1
+            if m_max > 2:
+                integrals_etransf[1, 0, 0, 1:-1, ...] = (
+                    qc_plus_zoe_pa_x * integrals_etransf[0, 0, 0, 1:-1, ...]
+                    + a_coeff_x * integrals_etransf[0, 0, 0, :-2, ...]
+                    - zeta_over_eta * integrals_etransf[0, 0, 0, 2:, ...]
+                )
+        else:
+            # General case: c_x -> c_x + 1
+            integrals_etransf[c + 1, 0, 0, 0, ...] = (
+                qc_plus_zoe_pa_x * integrals_etransf[c, 0, 0, 0, ...]
+                + c_coeff * integrals_etransf[c - 1, 0, 0, 0, ...]
+                - zeta_over_eta * integrals_etransf[c, 0, 0, 1, ...]
+            )
+            if m_max > 2:
+                integrals_etransf[c + 1, 0, 0, 1:-1, ...] = (
+                    qc_plus_zoe_pa_x * integrals_etransf[c, 0, 0, 1:-1, ...]
+                    + a_coeff_x * integrals_etransf[c, 0, 0, :-2, ...]
+                    + c_coeff * integrals_etransf[c - 1, 0, 0, 1:-1, ...]
+                    - zeta_over_eta * integrals_etransf[c, 0, 0, 2:, ...]
+                )
+
+    # ETR for c_y (similar structure, using precomputed coefficients)
+    for c in range(m_max_c - 1):
+        c_coeff = c * half_over_eta
+        if c == 0:
+            integrals_etransf[:, 1, 0, :, 0, ...] = (
+                qc_plus_zoe_pa_y * integrals_etransf[:, 0, 0, :, 0, ...]
+                - zeta_over_eta * integrals_etransf[:, 0, 0, :, 1, ...]
+            )
+            if m_max > 2:
+                integrals_etransf[:, 1, 0, :, 1:-1, ...] = (
+                    qc_plus_zoe_pa_y * integrals_etransf[:, 0, 0, :, 1:-1, ...]
+                    + a_coeff_y * integrals_etransf[:, 0, 0, :, :-2, ...]
+                    - zeta_over_eta * integrals_etransf[:, 0, 0, :, 2:, ...]
+                )
+        else:
+            integrals_etransf[:, c + 1, 0, :, 0, ...] = (
+                qc_plus_zoe_pa_y * integrals_etransf[:, c, 0, :, 0, ...]
+                + c_coeff * integrals_etransf[:, c - 1, 0, :, 0, ...]
+                - zeta_over_eta * integrals_etransf[:, c, 0, :, 1, ...]
+            )
+            if m_max > 2:
+                integrals_etransf[:, c + 1, 0, :, 1:-1, ...] = (
+                    qc_plus_zoe_pa_y * integrals_etransf[:, c, 0, :, 1:-1, ...]
+                    + a_coeff_y * integrals_etransf[:, c, 0, :, :-2, ...]
+                    + c_coeff * integrals_etransf[:, c - 1, 0, :, 1:-1, ...]
+                    - zeta_over_eta * integrals_etransf[:, c, 0, :, 2:, ...]
+                )
+
+    # ETR for c_z (similar structure, using precomputed coefficients)
+    for c in range(m_max_c - 1):
+        c_coeff = c * half_over_eta
+        if c == 0:
+            integrals_etransf[:, :, 1, :, :, 0, ...] = (
+                qc_plus_zoe_pa_z * integrals_etransf[:, :, 0, :, :, 0, ...]
+                - zeta_over_eta * integrals_etransf[:, :, 0, :, :, 1, ...]
+            )
+            if m_max > 2:
+                integrals_etransf[:, :, 1, :, :, 1:-1, ...] = (
+                    qc_plus_zoe_pa_z * integrals_etransf[:, :, 0, :, :, 1:-1, ...]
+                    + a_coeff_z * integrals_etransf[:, :, 0, :, :, :-2, ...]
+                    - zeta_over_eta * integrals_etransf[:, :, 0, :, :, 2:, ...]
+                )
+        else:
+            integrals_etransf[:, :, c + 1, :, :, 0, ...] = (
+                qc_plus_zoe_pa_z * integrals_etransf[:, :, c, :, :, 0, ...]
+                + c_coeff * integrals_etransf[:, :, c - 1, :, :, 0, ...]
+                - zeta_over_eta * integrals_etransf[:, :, c, :, :, 1, ...]
+            )
+            if m_max > 2:
+                integrals_etransf[:, :, c + 1, :, :, 1:-1, ...] = (
+                    qc_plus_zoe_pa_z * integrals_etransf[:, :, c, :, :, 1:-1, ...]
+                    + a_coeff_z * integrals_etransf[:, :, c, :, :, :-2, ...]
+                    + c_coeff * integrals_etransf[:, :, c - 1, :, :, 1:-1, ...]
+                    - zeta_over_eta * integrals_etransf[:, :, c, :, :, 2:, ...]
+                )
+
+    return integrals_etransf

--- a/gbasis/integrals/_two_elec_int_improved.py
+++ b/gbasis/integrals/_two_elec_int_improved.py
@@ -16,68 +16,55 @@ References:
 - Ahlrichs, R. Phys. Chem. Chem. Phys. 2006, 8, 3072.
 """
 
+import functools
+
 import numpy as np
 
 from gbasis.utils import factorial2
 
-# Cache for factorial2 values to avoid repeated computation
-_FACTORIAL2_CACHE = {}
 
-
-def _get_factorial2_norm(angmom_components):
+@functools.cache
+def _get_factorial2_norm(angmom_key):
     """Get cached factorial2 normalization for angular momentum components.
 
     Parameters
     ----------
-    angmom_components : np.ndarray(n, 3)
-        Angular momentum components.
+    angmom_key : tuple of tuples
+        Angular momentum components as a tuple of tuples, e.g.
+        ((lx1, ly1, lz1), (lx2, ly2, lz2), ...).
 
     Returns
     -------
     norm : np.ndarray(n,)
         Normalization factors 1/sqrt(prod((2*l-1)!!)).
     """
-    key = tuple(map(tuple, angmom_components))
-    if key not in _FACTORIAL2_CACHE:
-        _FACTORIAL2_CACHE[key] = 1.0 / np.sqrt(
-            np.prod(factorial2(2 * angmom_components - 1), axis=1)
-        )
-    return _FACTORIAL2_CACHE[key]
+    angmom_components = np.array(angmom_key)
+    return 1.0 / np.sqrt(np.prod(factorial2(2 * angmom_components - 1), axis=1))
 
 
-def _optimized_contraction(
-    integrals_etransf,
-    exps_a,
-    exps_b,
-    exps_c,
-    exps_d,
-    coeffs_a,
-    coeffs_b,
-    coeffs_c,
-    coeffs_d,
-    angmom_a,
-    angmom_b,
-    angmom_c,
-    angmom_d,
-):
+def _optimized_contraction(integrals_etransf, exps, coeffs, angmoms):
     """Optimized primitive contraction using einsum.
 
     Parameters
     ----------
     integrals_etransf : np.ndarray
         ETR output with shape (c_x, c_y, c_z, a_x, a_y, a_z, K_d, K_b, K_c, K_a).
-    exps_a/b/c/d : np.ndarray
-        Primitive exponents.
-    coeffs_a/b/c/d : np.ndarray
-        Contraction coefficients.
-    angmom_a/b/c/d : int
-        Angular momenta.
+    exps : tuple of np.ndarray
+        Primitive exponents (exps_a, exps_b, exps_c, exps_d).
+    coeffs : tuple of np.ndarray
+        Contraction coefficients (coeffs_a, coeffs_b, coeffs_c, coeffs_d).
+    angmoms : tuple of int
+        Angular momenta (angmom_a, angmom_b, angmom_c, angmom_d).
 
     Returns
     -------
     contracted : np.ndarray
         Contracted integrals with shape (c_x, c_y, c_z, a_x, a_y, a_z, M_a, M_c, M_b, M_d).
     """
+    exps_a, exps_b, exps_c, exps_d = exps
+    coeffs_a, coeffs_b, coeffs_c, coeffs_d = coeffs
+    angmom_a, angmom_b, angmom_c, angmom_d = angmoms
+
     # Precompute normalization constants (1D arrays)
     norm_a = (2 * exps_a / np.pi) ** 0.75 * (4 * exps_a) ** (angmom_a / 2)
     norm_b = (2 * exps_b / np.pi) ** 0.75 * (4 * exps_b) ** (angmom_b / 2)

--- a/gbasis/integrals/_two_elec_int_improved.py
+++ b/gbasis/integrals/_two_elec_int_improved.py
@@ -1,0 +1,757 @@
+"""Improved two-electron integrals using Obara-Saika + Head-Gordon-Pople recursions.
+
+This module implements the complete OS+HGP algorithm for two-electron integrals.
+
+Algorithm overview (full pipeline):
+1. Start with Boys function F_m(T) for m = 0 to angmom_total    (PR 1)
+2. VRR: Build [a0|00]^m from [00|00]^m (Eq. 65)                 (PR 2)
+3. ETR: Build [a0|c0]^0 from [a0|00]^m (Eq. 66)                 (PR 3)
+4. Contract primitives                                            (PR 3)
+5. HRR: Build [ab|cd] from [a0|c0] (Eq. 67)                     (PR 4)
+
+References:
+- Obara, S. & Saika, A. J. Chem. Phys. 1986, 84, 3963.
+- Head-Gordon, M. & Pople, J. A. J. Chem. Phys. 1988, 89, 5777.
+- Ahlrichs, R. Phys. Chem. Chem. Phys. 2006, 8, 3072.
+"""
+
+import numpy as np
+
+from gbasis.utils import factorial2
+
+# Cache for factorial2 values to avoid repeated computation
+_FACTORIAL2_CACHE = {}
+
+
+def _get_factorial2_norm(angmom_components):
+    """Get cached factorial2 normalization for angular momentum components.
+
+    Parameters
+    ----------
+    angmom_components : np.ndarray(n, 3)
+        Angular momentum components.
+
+    Returns
+    -------
+    norm : np.ndarray(n,)
+        Normalization factors 1/sqrt(prod((2*l-1)!!)).
+    """
+    key = tuple(map(tuple, angmom_components))
+    if key not in _FACTORIAL2_CACHE:
+        _FACTORIAL2_CACHE[key] = 1.0 / np.sqrt(
+            np.prod(factorial2(2 * angmom_components - 1), axis=1)
+        )
+    return _FACTORIAL2_CACHE[key]
+
+
+def _optimized_contraction(
+    integrals_etransf,
+    exps_a,
+    exps_b,
+    exps_c,
+    exps_d,
+    coeffs_a,
+    coeffs_b,
+    coeffs_c,
+    coeffs_d,
+    angmom_a,
+    angmom_b,
+    angmom_c,
+    angmom_d,
+):
+    """Optimized primitive contraction using einsum.
+
+    Parameters
+    ----------
+    integrals_etransf : np.ndarray
+        ETR output with shape (c_x, c_y, c_z, a_x, a_y, a_z, K_d, K_b, K_c, K_a).
+    exps_a/b/c/d : np.ndarray
+        Primitive exponents.
+    coeffs_a/b/c/d : np.ndarray
+        Contraction coefficients.
+    angmom_a/b/c/d : int
+        Angular momenta.
+
+    Returns
+    -------
+    contracted : np.ndarray
+        Contracted integrals with shape (c_x, c_y, c_z, a_x, a_y, a_z, M_a, M_c, M_b, M_d).
+    """
+    # Precompute normalization constants (1D arrays)
+    norm_a = (2 * exps_a / np.pi) ** 0.75 * (4 * exps_a) ** (angmom_a / 2)
+    norm_b = (2 * exps_b / np.pi) ** 0.75 * (4 * exps_b) ** (angmom_b / 2)
+    norm_c = (2 * exps_c / np.pi) ** 0.75 * (4 * exps_c) ** (angmom_c / 2)
+    norm_d = (2 * exps_d / np.pi) ** 0.75 * (4 * exps_d) ** (angmom_d / 2)
+
+    # Multiply coefficients by normalization (more efficient than per-element)
+    coeffs_a_norm = coeffs_a * norm_a[:, np.newaxis]
+    coeffs_b_norm = coeffs_b * norm_b[:, np.newaxis]
+    coeffs_c_norm = coeffs_c * norm_c[:, np.newaxis]
+    coeffs_d_norm = coeffs_d * norm_d[:, np.newaxis]
+
+    # Use einsum with optimization for contraction
+    # Input: (c_x, c_y, c_z, a_x, a_y, a_z, K_d, K_b, K_c, K_a)
+    # Contract one primitive at a time for memory efficiency
+    # K_a contraction
+    contracted = np.einsum("...a,aA->...A", integrals_etransf, coeffs_a_norm, optimize=True)
+    # K_c contraction (now axis -2 is K_c)
+    contracted = np.einsum("...cA,cC->...CA", contracted, coeffs_c_norm, optimize=True)
+    # K_b contraction (now axis -3 is K_b)
+    contracted = np.einsum("...bCA,bB->...CBA", contracted, coeffs_b_norm, optimize=True)
+    # K_d contraction (now axis -4 is K_d)
+    contracted = np.einsum("...dCBA,dD->...CBAD", contracted, coeffs_d_norm, optimize=True)
+
+    # Reorder to (c_x, c_y, c_z, a_x, a_y, a_z, M_a, M_c, M_b, M_d)
+    # Current: (..., M_c, M_b, M_a, M_d) -> need (..., M_a, M_c, M_b, M_d)
+    contracted = np.moveaxis(contracted, -2, -4)
+
+    return contracted
+
+
+def _vertical_recursion_relation(
+    integrals_m,
+    m_max,
+    rel_coord_a,
+    coord_wac,
+    harm_mean,
+    exps_sum_one,
+):
+    """Apply Vertical Recursion Relation (VRR) to build angular momentum on center A.
+
+    This implements Eq. 65 from the algorithm notes:
+    [a+1,0|00]^m = (P-A)_i [a0|00]^m - (rho/zeta)(Q-P)_i [a0|00]^{m+1}
+                   + a_i/(2*zeta) * ([a-1,0|00]^m - (rho/zeta)[a-1,0|00]^{m+1})
+
+    Parameters
+    ----------
+    integrals_m : np.ndarray
+        Array containing [00|00]^m for all m values.
+        Shape: (m_max, K_d, K_b, K_c, K_a)
+    m_max : int
+        Maximum angular momentum order.
+    rel_coord_a : np.ndarray(3, K_d, K_b, K_c, K_a)
+        P - A coordinates for each primitive combination.
+    coord_wac : np.ndarray(3, K_d, K_b, K_c, K_a)
+        Q - P coordinates (weighted average centers difference).
+    harm_mean : np.ndarray(K_d, K_b, K_c, K_a)
+        Harmonic mean: rho = zeta*eta/(zeta+eta).
+    exps_sum_one : np.ndarray(K_d, K_b, K_c, K_a)
+        Sum of exponents: zeta = alpha_a + alpha_b.
+
+    Returns
+    -------
+    integrals_vert : np.ndarray
+        Integrals with angular momentum built on center A.
+        Shape: (m_max, m_max, m_max, m_max, K_d, K_b, K_c, K_a)
+        Axes 1, 2, 3 correspond to a_x, a_y, a_z.
+    """
+    # Precompute coefficients for efficiency (avoid repeated division)
+    rho_over_zeta = harm_mean / exps_sum_one
+    half_over_zeta = 0.5 / exps_sum_one
+
+    # Precompute products (avoids repeated multiplication in loops)
+    roz_wac_x = rho_over_zeta * coord_wac[0]
+    roz_wac_y = rho_over_zeta * coord_wac[1]
+    roz_wac_z = rho_over_zeta * coord_wac[2]
+
+    # Initialize output array with contiguous memory
+    # axis 0: m, axis 1: a_x, axis 2: a_y, axis 3: a_z
+    integrals_vert = np.zeros((m_max, m_max, m_max, m_max, *integrals_m.shape[1:]), order="C")
+
+    # Base case: [00|00]^m
+    integrals_vert[:, 0, 0, 0, ...] = integrals_m
+
+    # VRR for x-component (a_x)
+    if m_max > 1:
+        # First step: a_x = 0 -> a_x = 1
+        integrals_vert[:-1, 1, 0, 0, ...] = (
+            rel_coord_a[0] * integrals_vert[:-1, 0, 0, 0, ...]
+            - roz_wac_x * integrals_vert[1:, 0, 0, 0, ...]
+        )
+        # Higher a_x values (precompute a * half_over_zeta)
+        for a in range(1, m_max - 1):
+            coeff_a = a * half_over_zeta
+            integrals_vert[:-1, a + 1, 0, 0, ...] = (
+                rel_coord_a[0] * integrals_vert[:-1, a, 0, 0, ...]
+                - roz_wac_x * integrals_vert[1:, a, 0, 0, ...]
+                + coeff_a
+                * (
+                    integrals_vert[:-1, a - 1, 0, 0, ...]
+                    - rho_over_zeta * integrals_vert[1:, a - 1, 0, 0, ...]
+                )
+            )
+
+    # VRR for y-component (a_y)
+    if m_max > 1:
+        integrals_vert[:-1, :, 1, 0, ...] = (
+            rel_coord_a[1] * integrals_vert[:-1, :, 0, 0, ...]
+            - roz_wac_y * integrals_vert[1:, :, 0, 0, ...]
+        )
+        for a in range(1, m_max - 1):
+            coeff_a = a * half_over_zeta
+            integrals_vert[:-1, :, a + 1, 0, ...] = (
+                rel_coord_a[1] * integrals_vert[:-1, :, a, 0, ...]
+                - roz_wac_y * integrals_vert[1:, :, a, 0, ...]
+                + coeff_a
+                * (
+                    integrals_vert[:-1, :, a - 1, 0, ...]
+                    - rho_over_zeta * integrals_vert[1:, :, a - 1, 0, ...]
+                )
+            )
+
+    # VRR for z-component (a_z)
+    if m_max > 1:
+        integrals_vert[:-1, :, :, 1, ...] = (
+            rel_coord_a[2] * integrals_vert[:-1, :, :, 0, ...]
+            - roz_wac_z * integrals_vert[1:, :, :, 0, ...]
+        )
+        for a in range(1, m_max - 1):
+            coeff_a = a * half_over_zeta
+            integrals_vert[:-1, :, :, a + 1, ...] = (
+                rel_coord_a[2] * integrals_vert[:-1, :, :, a, ...]
+                - roz_wac_z * integrals_vert[1:, :, :, a, ...]
+                + coeff_a
+                * (
+                    integrals_vert[:-1, :, :, a - 1, ...]
+                    - rho_over_zeta * integrals_vert[1:, :, :, a - 1, ...]
+                )
+            )
+
+    return integrals_vert
+
+
+def _electron_transfer_recursion(
+    integrals_vert,
+    m_max,
+    m_max_c,
+    rel_coord_c,
+    rel_coord_a,
+    exps_sum_one,
+    exps_sum_two,
+):
+    """Apply Electron Transfer Recursion (ETR) to transfer angular momentum to center C.
+
+    This implements Eq. 66 from the algorithm notes:
+    [a0|c+1,0]^0 = (Q-C)_i [a0|c0]^0 + (zeta/eta)(P-A)_i [a0|c0]^0
+                   - (zeta/eta) [a+1,0|c0]^0
+                   + c_i/(2*eta) [a0|c-1,0]^0
+                   + a_i/(2*eta) [a-1,0|c0]^0
+
+    Parameters
+    ----------
+    integrals_vert : np.ndarray
+        Output from VRR with angular momentum on A.
+        Shape: (m_max, a_x_max, a_y_max, a_z_max, K_d, K_b, K_c, K_a)
+    m_max : int
+        Maximum m value (angmom_a + angmom_b + angmom_c + angmom_d + 1).
+    m_max_c : int
+        Maximum c angular momentum (angmom_c + angmom_d + 1).
+    rel_coord_c : np.ndarray(3, K_d, K_b, K_c, K_a)
+        Q - C coordinates.
+    rel_coord_a : np.ndarray(3, K_d, K_b, K_c, K_a)
+        P - A coordinates.
+    exps_sum_one : np.ndarray
+        zeta = alpha_a + alpha_b.
+    exps_sum_two : np.ndarray
+        eta = alpha_c + alpha_d.
+
+    Returns
+    -------
+    integrals_etransf : np.ndarray
+        Integrals with angular momentum on both A and C.
+        Shape: (c_x_max, c_y_max, c_z_max, a_x_max, a_y_max, a_z_max, K_d, K_b, K_c, K_a)
+    """
+    n_primitives = integrals_vert.shape[4:]
+    zeta_over_eta = exps_sum_one / exps_sum_two
+
+    # Precompute coefficients (avoid repeated division in loops)
+    half_over_eta = 0.5 / exps_sum_two
+
+    # Precompute combined coordinate terms for each axis
+    qc_plus_zoe_pa_x = rel_coord_c[0] + zeta_over_eta * rel_coord_a[0]
+    qc_plus_zoe_pa_y = rel_coord_c[1] + zeta_over_eta * rel_coord_a[1]
+    qc_plus_zoe_pa_z = rel_coord_c[2] + zeta_over_eta * rel_coord_a[2]
+
+    # Initialize ETR output with contiguous memory
+    integrals_etransf = np.zeros(
+        (m_max_c, m_max_c, m_max_c, m_max, m_max, m_max, *n_primitives), order="C"
+    )
+
+    # Base case: discard m index (take m=0)
+    integrals_etransf[0, 0, 0, ...] = integrals_vert[0, ...]
+
+    # Precompute a_indices coefficient array once
+    if m_max > 2:
+        a_coeff_x = (
+            np.arange(1, m_max - 1).reshape(-1, 1, 1, *([1] * len(n_primitives))) * half_over_eta
+        )
+        a_coeff_y = (
+            np.arange(1, m_max - 1).reshape(1, 1, 1, 1, -1, 1, *([1] * len(n_primitives)))
+            * half_over_eta
+        )
+        a_coeff_z = (
+            np.arange(1, m_max - 1).reshape(1, 1, 1, 1, 1, -1, *([1] * len(n_primitives)))
+            * half_over_eta
+        )
+
+    # ETR for c_x
+    for c in range(m_max_c - 1):
+        c_coeff = c * half_over_eta  # Precompute c/(2*eta)
+        if c == 0:
+            # First step: c_x = 0 -> c_x = 1
+            # For a_x = 0
+            integrals_etransf[1, 0, 0, 0, ...] = (
+                qc_plus_zoe_pa_x * integrals_etransf[0, 0, 0, 0, ...]
+                - zeta_over_eta * integrals_etransf[0, 0, 0, 1, ...]
+            )
+            # For a_x >= 1
+            if m_max > 2:
+                integrals_etransf[1, 0, 0, 1:-1, ...] = (
+                    qc_plus_zoe_pa_x * integrals_etransf[0, 0, 0, 1:-1, ...]
+                    + a_coeff_x * integrals_etransf[0, 0, 0, :-2, ...]
+                    - zeta_over_eta * integrals_etransf[0, 0, 0, 2:, ...]
+                )
+        else:
+            # General case: c_x -> c_x + 1
+            integrals_etransf[c + 1, 0, 0, 0, ...] = (
+                qc_plus_zoe_pa_x * integrals_etransf[c, 0, 0, 0, ...]
+                + c_coeff * integrals_etransf[c - 1, 0, 0, 0, ...]
+                - zeta_over_eta * integrals_etransf[c, 0, 0, 1, ...]
+            )
+            if m_max > 2:
+                integrals_etransf[c + 1, 0, 0, 1:-1, ...] = (
+                    qc_plus_zoe_pa_x * integrals_etransf[c, 0, 0, 1:-1, ...]
+                    + a_coeff_x * integrals_etransf[c, 0, 0, :-2, ...]
+                    + c_coeff * integrals_etransf[c - 1, 0, 0, 1:-1, ...]
+                    - zeta_over_eta * integrals_etransf[c, 0, 0, 2:, ...]
+                )
+
+    # ETR for c_y (similar structure, using precomputed coefficients)
+    for c in range(m_max_c - 1):
+        c_coeff = c * half_over_eta
+        if c == 0:
+            integrals_etransf[:, 1, 0, :, 0, ...] = (
+                qc_plus_zoe_pa_y * integrals_etransf[:, 0, 0, :, 0, ...]
+                - zeta_over_eta * integrals_etransf[:, 0, 0, :, 1, ...]
+            )
+            if m_max > 2:
+                integrals_etransf[:, 1, 0, :, 1:-1, ...] = (
+                    qc_plus_zoe_pa_y * integrals_etransf[:, 0, 0, :, 1:-1, ...]
+                    + a_coeff_y * integrals_etransf[:, 0, 0, :, :-2, ...]
+                    - zeta_over_eta * integrals_etransf[:, 0, 0, :, 2:, ...]
+                )
+        else:
+            integrals_etransf[:, c + 1, 0, :, 0, ...] = (
+                qc_plus_zoe_pa_y * integrals_etransf[:, c, 0, :, 0, ...]
+                + c_coeff * integrals_etransf[:, c - 1, 0, :, 0, ...]
+                - zeta_over_eta * integrals_etransf[:, c, 0, :, 1, ...]
+            )
+            if m_max > 2:
+                integrals_etransf[:, c + 1, 0, :, 1:-1, ...] = (
+                    qc_plus_zoe_pa_y * integrals_etransf[:, c, 0, :, 1:-1, ...]
+                    + a_coeff_y * integrals_etransf[:, c, 0, :, :-2, ...]
+                    + c_coeff * integrals_etransf[:, c - 1, 0, :, 1:-1, ...]
+                    - zeta_over_eta * integrals_etransf[:, c, 0, :, 2:, ...]
+                )
+
+    # ETR for c_z (similar structure, using precomputed coefficients)
+    for c in range(m_max_c - 1):
+        c_coeff = c * half_over_eta
+        if c == 0:
+            integrals_etransf[:, :, 1, :, :, 0, ...] = (
+                qc_plus_zoe_pa_z * integrals_etransf[:, :, 0, :, :, 0, ...]
+                - zeta_over_eta * integrals_etransf[:, :, 0, :, :, 1, ...]
+            )
+            if m_max > 2:
+                integrals_etransf[:, :, 1, :, :, 1:-1, ...] = (
+                    qc_plus_zoe_pa_z * integrals_etransf[:, :, 0, :, :, 1:-1, ...]
+                    + a_coeff_z * integrals_etransf[:, :, 0, :, :, :-2, ...]
+                    - zeta_over_eta * integrals_etransf[:, :, 0, :, :, 2:, ...]
+                )
+        else:
+            integrals_etransf[:, :, c + 1, :, :, 0, ...] = (
+                qc_plus_zoe_pa_z * integrals_etransf[:, :, c, :, :, 0, ...]
+                + c_coeff * integrals_etransf[:, :, c - 1, :, :, 0, ...]
+                - zeta_over_eta * integrals_etransf[:, :, c, :, :, 1, ...]
+            )
+            if m_max > 2:
+                integrals_etransf[:, :, c + 1, :, :, 1:-1, ...] = (
+                    qc_plus_zoe_pa_z * integrals_etransf[:, :, c, :, :, 1:-1, ...]
+                    + a_coeff_z * integrals_etransf[:, :, c, :, :, :-2, ...]
+                    + c_coeff * integrals_etransf[:, :, c - 1, :, :, 1:-1, ...]
+                    - zeta_over_eta * integrals_etransf[:, :, c, :, :, 2:, ...]
+                )
+
+    return integrals_etransf
+
+
+def _horizontal_recursion_relation(
+    integrals_cont,
+    angmom_a,
+    angmom_b,
+    angmom_c,
+    angmom_d,
+    angmom_components_a,
+    angmom_components_b,
+    angmom_components_c,
+    angmom_components_d,
+    rel_dist_one,
+    rel_dist_two,
+):
+    """Apply Horizontal Recursion Relation (HRR) to distribute angular momentum to B and D.
+
+    This implements Eq. 67 from the algorithm notes (Head-Gordon-Pople scheme):
+    [ab|cd] = [a+1,0|cd] + (A-B)_i * [a,0|cd]
+
+    In the HGP scheme, HRR is applied AFTER contraction, which is more efficient
+    because contracted integrals are smaller than primitive integrals.
+
+    Parameters
+    ----------
+    integrals_cont : np.ndarray
+        Contracted integrals from ETR+contraction step.
+        Shape: (c_x, c_y, c_z, a_x, a_y, a_z, M_a, M_c, M_b, M_d)
+    angmom_a/b/c/d : int
+        Angular momenta for each center.
+    angmom_components_a/b/c/d : np.ndarray(L, 3)
+        Angular momentum components for each center.
+    rel_dist_one : np.ndarray(3,)
+        A - B distance vector.
+    rel_dist_two : np.ndarray(3,)
+        C - D distance vector.
+
+    Returns
+    -------
+    integrals : np.ndarray(L_a, L_b, L_c, L_d, M_a, M_b, M_c, M_d)
+        Final integrals in Chemists' notation.
+    """
+    m_max_a = angmom_a + angmom_b + 1
+    m_max_c = angmom_c + angmom_d + 1
+    n_cont = integrals_cont.shape[6:]  # (M_a, M_c, M_b, M_d)
+
+    # ---- HRR for center D (x and y components) ----
+    integrals_horiz_d = np.zeros(
+        (angmom_d + 1, angmom_d + 1, m_max_c, m_max_c, m_max_c, m_max_a, m_max_a, m_max_a, *n_cont)
+    )
+    integrals_horiz_d[0, 0, :, :, :, :, :, :, ...] = integrals_cont[
+        :, :, :, :m_max_a, :m_max_a, :m_max_a, ...
+    ]
+
+    # HRR x-component of d
+    for d in range(angmom_d):
+        integrals_horiz_d[d + 1, 0, :-1, :, :, :, :, :, ...] = (
+            integrals_horiz_d[d, 0, 1:, :, :, :, :, :, ...]
+            + rel_dist_two[0] * integrals_horiz_d[d, 0, :-1, :, :, :, :, :, ...]
+        )
+    # HRR y-component of d
+    for d in range(angmom_d):
+        integrals_horiz_d[:, d + 1, :, :-1, :, :, :, :, ...] = (
+            integrals_horiz_d[:, d, :, 1:, :, :, :, :, ...]
+            + rel_dist_two[1] * integrals_horiz_d[:, d, :, :-1, :, :, :, :, ...]
+        )
+
+    # Select angular momentum components (x, y) for c and d, then recurse z
+    angmoms_c_x, angmoms_c_y, angmoms_c_z = angmom_components_c.T
+    angmoms_d_x, angmoms_d_y, angmoms_d_z = angmom_components_d.T
+
+    integrals_horiz_d2 = np.zeros(
+        (
+            angmom_d + 1,
+            m_max_c,
+            angmom_components_d.shape[0],
+            angmom_components_c.shape[0],
+            m_max_a,
+            m_max_a,
+            m_max_a,
+            *n_cont,
+        )
+    )
+    integrals_horiz_d2[0] = np.transpose(
+        integrals_horiz_d[
+            angmoms_d_x.reshape(-1, 1),
+            angmoms_d_y.reshape(-1, 1),
+            angmoms_c_x.reshape(1, -1),
+            angmoms_c_y.reshape(1, -1),
+            :,
+            :,
+            :,
+            :,
+            :,
+            :,
+            :,
+            :,
+        ],
+        (2, 0, 1, 3, 4, 5, 6, 7, 8, 9),
+    )
+
+    # HRR z-component of d
+    for d in range(angmom_d):
+        integrals_horiz_d2[d + 1, :-1, :, :, :, :, :, ...] = (
+            integrals_horiz_d2[d, 1:, :, :, :, :, :, ...]
+            + rel_dist_two[2] * integrals_horiz_d2[d, :-1, :, :, :, :, :, ...]
+        )
+
+    # Select z components for c and d
+    integrals_horiz_d2 = integrals_horiz_d2[
+        angmoms_d_z.reshape(-1, 1),
+        angmoms_c_z.reshape(1, -1),
+        np.arange(angmoms_d_z.size).reshape(-1, 1),
+        np.arange(angmoms_c_z.size).reshape(1, -1),
+        :,
+        :,
+        :,
+        :,
+        :,
+        :,
+        :,
+    ]
+
+    # ---- HRR for center B (x and y components) ----
+    angmoms_a_x, angmoms_a_y, angmoms_a_z = angmom_components_a.T
+    angmoms_b_x, angmoms_b_y, angmoms_b_z = angmom_components_b.T
+
+    integrals_horiz_b = np.zeros(
+        (
+            angmom_b + 1,
+            angmom_b + 1,
+            m_max_a,
+            m_max_a,
+            m_max_a,
+            angmom_components_d.shape[0],
+            angmom_components_c.shape[0],
+            *n_cont,
+        )
+    )
+    integrals_horiz_b[0, 0, :, :, :, :, :, ...] = np.transpose(
+        integrals_horiz_d2[:, :, :, :, :, :, :, :, :], (2, 3, 4, 0, 1, 5, 6, 7, 8)
+    )
+
+    # HRR x-component of b
+    for b in range(angmom_b):
+        integrals_horiz_b[b + 1, 0, :-1, :, :, :, :, ...] = (
+            integrals_horiz_b[b, 0, 1:, :, :, :, :, ...]
+            + rel_dist_one[0] * integrals_horiz_b[b, 0, :-1, :, :, :, :, ...]
+        )
+    # HRR y-component of b
+    for b in range(angmom_b):
+        integrals_horiz_b[:, b + 1, :, :-1, :, :, :, ...] = (
+            integrals_horiz_b[:, b, :, 1:, :, :, :, ...]
+            + rel_dist_one[1] * integrals_horiz_b[:, b, :, :-1, :, :, :, ...]
+        )
+
+    # Select angular momentum components (x, y) for a and b, then recurse z
+    integrals_horiz_b2 = np.zeros(
+        (
+            angmom_b + 1,
+            m_max_a,
+            angmom_components_b.shape[0],
+            angmom_components_a.shape[0],
+            angmom_components_d.shape[0],
+            angmom_components_c.shape[0],
+            *n_cont,
+        )
+    )
+    integrals_horiz_b2[0] = np.transpose(
+        integrals_horiz_b[
+            angmoms_b_x.reshape(-1, 1),
+            angmoms_b_y.reshape(-1, 1),
+            angmoms_a_x.reshape(1, -1),
+            angmoms_a_y.reshape(1, -1),
+            :,
+            :,
+            :,
+            :,
+            :,
+            :,
+            :,
+        ],
+        (2, 0, 1, 3, 4, 5, 6, 7, 8),
+    )
+
+    # HRR z-component of b
+    for b in range(angmom_b):
+        integrals_horiz_b2[b + 1, :-1, :, :, :, :, ...] = (
+            integrals_horiz_b2[b, 1:, :, :, :, :, ...]
+            + rel_dist_one[2] * integrals_horiz_b2[b, :-1, :, :, :, :, ...]
+        )
+
+    # Select z components for a and b
+    integrals_horiz_b2 = integrals_horiz_b2[
+        angmoms_b_z.reshape(-1, 1),
+        angmoms_a_z.reshape(1, -1),
+        np.arange(angmoms_b_z.size).reshape(-1, 1),
+        np.arange(angmoms_a_z.size).reshape(1, -1),
+        :,
+        :,
+        :,
+        :,
+        :,
+        :,
+    ]
+
+    # Rearrange to final order: (L_a, L_b, L_c, L_d, M_a, M_b, M_c, M_d)
+    # Current: (L_b, L_a, L_d, L_c, M_a, M_c, M_b, M_d)
+    integrals = np.transpose(integrals_horiz_b2, (1, 0, 3, 2, 4, 6, 5, 7))
+
+    # Apply factorial2 normalization for angular momentum components
+    norm_a = _get_factorial2_norm(angmom_components_a).reshape(-1, 1, 1, 1, 1, 1, 1, 1)
+    norm_b = _get_factorial2_norm(angmom_components_b).reshape(1, -1, 1, 1, 1, 1, 1, 1)
+    norm_c = _get_factorial2_norm(angmom_components_c).reshape(1, 1, -1, 1, 1, 1, 1, 1)
+    norm_d = _get_factorial2_norm(angmom_components_d).reshape(1, 1, 1, -1, 1, 1, 1, 1)
+
+    integrals = integrals * norm_a * norm_b * norm_c * norm_d
+
+    return integrals
+
+
+def compute_two_electron_integrals_os_hgp(
+    boys_func,
+    coord_a,
+    angmom_a,
+    angmom_components_a,
+    exps_a,
+    coeffs_a,
+    coord_b,
+    angmom_b,
+    angmom_components_b,
+    exps_b,
+    coeffs_b,
+    coord_c,
+    angmom_c,
+    angmom_components_c,
+    exps_c,
+    coeffs_c,
+    coord_d,
+    angmom_d,
+    angmom_components_d,
+    exps_d,
+    coeffs_d,
+    primitive_threshold=0.0,
+):
+    r"""Compute two-electron integrals using OS+HGP algorithm.
+
+    This is the main entry point that combines all steps:
+    1. Boys function initialization (base case [00|00]^m)
+    2. VRR: Build angular momentum on center A  (Eq. 65)
+    3. ETR: Transfer angular momentum to center C (Eq. 66)
+    4. Contract primitives (einsum-based)
+    5. HRR: Distribute to centers B and D (Eq. 67, done LAST per HGP)
+
+    Parameters
+    ----------
+    boys_func : callable
+        Boys function with signature boys_func(orders, weighted_dist).
+    coord_a/b/c/d : np.ndarray(3,)
+        Centers of each contraction.
+    angmom_a/b/c/d : int
+        Angular momentum of each contraction.
+    angmom_components_a/b/c/d : np.ndarray(L, 3)
+        Angular momentum components for each contraction.
+    exps_a/b/c/d : np.ndarray(K,)
+        Primitive exponents.
+    coeffs_a/b/c/d : np.ndarray(K, M)
+        Contraction coefficients.
+    primitive_threshold : float, optional
+        Screening threshold for primitive quartets (default: 0.0, no screening).
+        Primitive quartets with |prefactor| < threshold are zeroed out per Eq. 64.
+
+    Returns
+    -------
+    integrals : np.ndarray(L_a, L_b, L_c, L_d, M_a, M_b, M_c, M_d)
+        Two-electron integrals in Chemists' notation.
+    """
+    m_max = angmom_a + angmom_b + angmom_c + angmom_d + 1
+    m_max_c = angmom_c + angmom_d + 1
+
+    # --- Pre-compute primitive quantities ---
+    # Reshape exponents for broadcasting: (K_d, K_b, K_c, K_a)
+    coord_a_4d = coord_a[:, np.newaxis, np.newaxis, np.newaxis, np.newaxis]
+    coord_b_4d = coord_b[:, np.newaxis, np.newaxis, np.newaxis, np.newaxis]
+    coord_c_4d = coord_c[:, np.newaxis, np.newaxis, np.newaxis, np.newaxis]
+    coord_d_4d = coord_d[:, np.newaxis, np.newaxis, np.newaxis, np.newaxis]
+
+    exps_a_4d = exps_a[np.newaxis, np.newaxis, np.newaxis, :]
+    exps_b_4d = exps_b[np.newaxis, :, np.newaxis, np.newaxis]
+    exps_c_4d = exps_c[np.newaxis, np.newaxis, :, np.newaxis]
+    exps_d_4d = exps_d[:, np.newaxis, np.newaxis, np.newaxis]
+
+    # Sum of exponents
+    exps_sum_one = exps_a_4d + exps_b_4d  # zeta = alpha_a + alpha_b
+    exps_sum_two = exps_c_4d + exps_d_4d  # eta  = alpha_c + alpha_d
+    exps_sum = exps_sum_one + exps_sum_two
+
+    # Harmonic means
+    harm_mean_one = (exps_a_4d * exps_b_4d) / exps_sum_one
+    harm_mean_two = (exps_c_4d * exps_d_4d) / exps_sum_two
+    harm_mean = exps_sum_one * exps_sum_two / exps_sum  # rho
+
+    # Weighted average centers
+    coord_wac_one = (exps_a_4d * coord_a_4d + exps_b_4d * coord_b_4d) / exps_sum_one  # P
+    coord_wac_two = (exps_c_4d * coord_c_4d + exps_d_4d * coord_d_4d) / exps_sum_two  # Q
+    coord_wac = coord_wac_one - coord_wac_two  # P - Q
+
+    # Relative coordinates
+    rel_dist_one = coord_a - coord_b  # A - B (for HRR)
+    rel_dist_two = coord_c - coord_d  # C - D (for HRR)
+    rel_coord_a = coord_wac_one - coord_a_4d  # P - A (for VRR)
+    rel_coord_c = coord_wac_two - coord_c_4d  # Q - C (for ETR)
+
+    # --- Step 1: Boys function initialization ---
+    weighted_dist = harm_mean * np.sum(coord_wac**2, axis=0)
+    prefactor = (
+        (2 * np.pi**2.5)
+        / (exps_sum_one * exps_sum_two * exps_sum**0.5)
+        * np.exp(-harm_mean_one * np.sum((coord_a_4d - coord_b_4d) ** 2, axis=0))
+        * np.exp(-harm_mean_two * np.sum((coord_c_4d - coord_d_4d) ** 2, axis=0))
+    )
+
+    # --- Primitive-level screening (Eq. 64) ---
+    if primitive_threshold > 0:
+        prefactor = np.where(np.abs(prefactor) >= primitive_threshold, prefactor, 0.0)
+
+    orders = np.arange(m_max)[:, None, None, None, None]
+    integrals_m = boys_func(orders, weighted_dist[None, :, :, :, :]) * prefactor
+
+    # --- Step 2: VRR ---
+    integrals_vert = _vertical_recursion_relation(
+        integrals_m, m_max, rel_coord_a, coord_wac, harm_mean, exps_sum_one
+    )
+
+    # --- Step 3: ETR ---
+    integrals_etransf = _electron_transfer_recursion(
+        integrals_vert, m_max, m_max_c, rel_coord_c, rel_coord_a, exps_sum_one, exps_sum_two
+    )
+
+    # --- Step 4: Contract primitives ---
+    integrals_cont = _optimized_contraction(
+        integrals_etransf,
+        exps_a,
+        exps_b,
+        exps_c,
+        exps_d,
+        coeffs_a,
+        coeffs_b,
+        coeffs_c,
+        coeffs_d,
+        angmom_a,
+        angmom_b,
+        angmom_c,
+        angmom_d,
+    )
+
+    # --- Step 5: HRR (done LAST per HGP scheme) ---
+    integrals = _horizontal_recursion_relation(
+        integrals_cont,
+        angmom_a,
+        angmom_b,
+        angmom_c,
+        angmom_d,
+        angmom_components_a,
+        angmom_components_b,
+        angmom_components_c,
+        angmom_components_d,
+        rel_dist_one,
+        rel_dist_two,
+    )
+
+    return integrals

--- a/gbasis/integrals/_two_elec_int_improved.py
+++ b/gbasis/integrals/_two_elec_int_improved.py
@@ -49,33 +49,26 @@ def _optimized_contraction(integrals_etransf, exps, coeffs, angmoms):
     ----------
     integrals_etransf : np.ndarray
         ETR output with shape (c_x, c_y, c_z, a_x, a_y, a_z, K_d, K_b, K_c, K_a).
-    exps : tuple of np.ndarray
-        Primitive exponents (exps_a, exps_b, exps_c, exps_d).
-    coeffs : tuple of np.ndarray
-        Contraction coefficients (coeffs_a, coeffs_b, coeffs_c, coeffs_d).
-    angmoms : tuple of int
-        Angular momenta (angmom_a, angmom_b, angmom_c, angmom_d).
+    exps : array-like of shape (4, K)
+        Primitive exponents stacked for all 4 centers (a, b, c, d).
+    coeffs : array-like of shape (4, K, M)
+        Contraction coefficients stacked for all 4 centers (a, b, c, d).
+    angmoms : array-like of shape (4,)
+        Angular momenta for all 4 centers (a, b, c, d).
 
     Returns
     -------
     contracted : np.ndarray
         Contracted integrals with shape (c_x, c_y, c_z, a_x, a_y, a_z, M_a, M_c, M_b, M_d).
     """
-    exps_a, exps_b, exps_c, exps_d = exps
-    coeffs_a, coeffs_b, coeffs_c, coeffs_d = coeffs
-    angmom_a, angmom_b, angmom_c, angmom_d = angmoms
-
-    # Precompute normalization constants (1D arrays)
-    norm_a = (2 * exps_a / np.pi) ** 0.75 * (4 * exps_a) ** (angmom_a / 2)
-    norm_b = (2 * exps_b / np.pi) ** 0.75 * (4 * exps_b) ** (angmom_b / 2)
-    norm_c = (2 * exps_c / np.pi) ** 0.75 * (4 * exps_c) ** (angmom_c / 2)
-    norm_d = (2 * exps_d / np.pi) ** 0.75 * (4 * exps_d) ** (angmom_d / 2)
-
-    # Multiply coefficients by normalization (more efficient than per-element)
-    coeffs_a_norm = coeffs_a * norm_a[:, np.newaxis]
-    coeffs_b_norm = coeffs_b * norm_b[:, np.newaxis]
-    coeffs_c_norm = coeffs_c * norm_c[:, np.newaxis]
-    coeffs_d_norm = coeffs_d * norm_d[:, np.newaxis]
+    # Vectorized norm computation over all 4 centers
+    exps = np.array(exps)  # shape (4, K)
+    angmoms = np.array(angmoms)  # shape (4,)
+    coeffs = np.array(coeffs)  # shape (4, K, M)
+    # shape (4, K)
+    norms = ((2 / np.pi) * exps) ** 0.75 * (4 * exps) ** (angmoms[:, np.newaxis] / 2)
+    coeffs_norm = coeffs * norms[:, :, np.newaxis]  # shape (4, K, M)
+    coeffs_a_norm, coeffs_b_norm, coeffs_c_norm, coeffs_d_norm = coeffs_norm
 
     # Use einsum with optimization for contraction
     # Input: (c_x, c_y, c_z, a_x, a_y, a_z, K_d, K_b, K_c, K_a)

--- a/gbasis/integrals/electron_repulsion.py
+++ b/gbasis/integrals/electron_repulsion.py
@@ -1,12 +1,11 @@
 """Electron-electron repulsion integral."""
+
+import numpy as np
+
 from gbasis.base_four_symm import BaseFourIndexSymmetric
 from gbasis.contractions import GeneralizedContractionShell
-from gbasis.integrals._two_elec_int import (
-    _compute_two_elec_integrals,
-    _compute_two_elec_integrals_angmom_zero,
-)
+from gbasis.integrals._two_elec_int_improved import compute_two_electron_integrals_os_hgp
 from gbasis.integrals.point_charge import PointChargeIntegral
-import numpy as np
 
 
 class ElectronRepulsionIntegral(BaseFourIndexSymmetric):
@@ -156,46 +155,29 @@ class ElectronRepulsionIntegral(BaseFourIndexSymmetric):
             raise TypeError("`cont_four` must be a `GeneralizedContractionShell` instance.")
 
         # TODO: we can probably swap the contractions to get the optimal time or memory usage
-        if cont_one.angmom == cont_two.angmom == cont_three.angmom == cont_four.angmom == 0:
-            integrals = _compute_two_elec_integrals_angmom_zero(
-                cls.boys_func,
-                cont_one.coord,
-                cont_one.exps,
-                cont_one.coeffs,
-                cont_two.coord,
-                cont_two.exps,
-                cont_two.coeffs,
-                cont_three.coord,
-                cont_three.exps,
-                cont_three.coeffs,
-                cont_four.coord,
-                cont_four.exps,
-                cont_four.coeffs,
-            )
-        else:
-            integrals = _compute_two_elec_integrals(
-                cls.boys_func,
-                cont_one.coord,
-                cont_one.angmom,
-                cont_one.angmom_components_cart,
-                cont_one.exps,
-                cont_one.coeffs,
-                cont_two.coord,
-                cont_two.angmom,
-                cont_two.angmom_components_cart,
-                cont_two.exps,
-                cont_two.coeffs,
-                cont_three.coord,
-                cont_three.angmom,
-                cont_three.angmom_components_cart,
-                cont_three.exps,
-                cont_three.coeffs,
-                cont_four.coord,
-                cont_four.angmom,
-                cont_four.angmom_components_cart,
-                cont_four.exps,
-                cont_four.coeffs,
-            )
+        integrals = compute_two_electron_integrals_os_hgp(
+            cls.boys_func,
+            cont_one.coord,
+            cont_one.angmom,
+            cont_one.angmom_components_cart,
+            cont_one.exps,
+            cont_one.coeffs,
+            cont_two.coord,
+            cont_two.angmom,
+            cont_two.angmom_components_cart,
+            cont_two.exps,
+            cont_two.coeffs,
+            cont_three.coord,
+            cont_three.angmom,
+            cont_three.angmom_components_cart,
+            cont_three.exps,
+            cont_three.coeffs,
+            cont_four.coord,
+            cont_four.angmom,
+            cont_four.angmom_components_cart,
+            cont_four.exps,
+            cont_four.coeffs,
+        )
         integrals = np.transpose(integrals, (4, 0, 5, 1, 6, 2, 7, 3))
 
         # TODO: if we swap the contractions, we need to unswap them here
@@ -267,6 +249,182 @@ def electron_repulsion_integral(basis, transform=None, notation="physicist"):
         array = ElectronRepulsionIntegral(basis).construct_array_spherical()
     else:
         array = ElectronRepulsionIntegral(basis).construct_array_mix(coord_type)
+
+    if notation == "physicist":
+        array = np.transpose(array, (0, 2, 1, 3))
+    return array
+
+
+class ElectronRepulsionIntegralImproved(BaseFourIndexSymmetric):
+    """Class for constructing electron-electron repulsion integrals using OS+HGP algorithm.
+
+    This class uses the improved Obara-Saika + Head-Gordon-Pople recursion scheme,
+    which applies the Horizontal Recursion Relation (HRR) after contraction for
+    better computational efficiency.
+
+    The first four axes of the returned array are associated with the given set of contracted
+    Gaussian (or a linear combination of a set of Gaussians).
+
+    Attributes
+    ----------
+    _axes_contractions : tuple of tuple of GeneralizedContractionShell
+        Sets of contractions associated with each axis of the array.
+    contractions : tuple of GeneralizedContractionShell
+        Contractions that are associated with the four indices of the array.
+
+    """
+
+    boys_func = PointChargeIntegral.boys_func
+
+    @classmethod
+    def construct_array_contraction(cls, cont_one, cont_two, cont_three, cont_four):
+        r"""Return electron-electron repulsion integral using the OS+HGP algorithm.
+
+        Parameters
+        ----------
+        cont_one : GeneralizedContractionShell
+            Contracted Cartesian Gaussians (of the same shell) associated with the first index.
+        cont_two : GeneralizedContractionShell
+            Contracted Cartesian Gaussians (of the same shell) associated with the second index.
+        cont_three : GeneralizedContractionShell
+            Contracted Cartesian Gaussians (of the same shell) associated with the third index.
+        cont_four : GeneralizedContractionShell
+            Contracted Cartesian Gaussians (of the same shell) associated with the fourth index.
+
+        Returns
+        -------
+        array_cont : np.ndarray(M_1, L_cart_1, M_2, L_cart_2, M_3, L_cart_3, M_4, L_cart_4)
+            Electron-electron repulsion integral associated with the given contractions.
+            Integrals are in Chemists' notation.
+
+        Raises
+        ------
+        TypeError
+            If any contraction is not a `GeneralizedContractionShell` instance.
+
+        """
+        if not isinstance(cont_one, GeneralizedContractionShell):
+            raise TypeError("`cont_one` must be a `GeneralizedContractionShell` instance.")
+        if not isinstance(cont_two, GeneralizedContractionShell):
+            raise TypeError("`cont_two` must be a `GeneralizedContractionShell` instance.")
+        if not isinstance(cont_three, GeneralizedContractionShell):
+            raise TypeError("`cont_three` must be a `GeneralizedContractionShell` instance.")
+        if not isinstance(cont_four, GeneralizedContractionShell):
+            raise TypeError("`cont_four` must be a `GeneralizedContractionShell` instance.")
+
+        # --- Contraction reordering for efficiency (l_a >= l_b, l_c >= l_d, l_a >= l_c) ---
+        bra_swapped = cont_one.angmom < cont_two.angmom
+        if bra_swapped:
+            cont_one, cont_two = cont_two, cont_one
+
+        ket_swapped = cont_three.angmom < cont_four.angmom
+        if ket_swapped:
+            cont_three, cont_four = cont_four, cont_three
+
+        braket_swapped = cont_one.angmom < cont_three.angmom
+        if braket_swapped:
+            cont_one, cont_three = cont_three, cont_one
+            cont_two, cont_four = cont_four, cont_two
+
+        integrals = compute_two_electron_integrals_os_hgp(
+            cls.boys_func,
+            cont_one.coord,
+            cont_one.angmom,
+            cont_one.angmom_components_cart,
+            cont_one.exps,
+            cont_one.coeffs,
+            cont_two.coord,
+            cont_two.angmom,
+            cont_two.angmom_components_cart,
+            cont_two.exps,
+            cont_two.coeffs,
+            cont_three.coord,
+            cont_three.angmom,
+            cont_three.angmom_components_cart,
+            cont_three.exps,
+            cont_three.coeffs,
+            cont_four.coord,
+            cont_four.angmom,
+            cont_four.angmom_components_cart,
+            cont_four.exps,
+            cont_four.coeffs,
+        )
+
+        # --- Un-swap axes to restore original ordering ---
+        # Output shape from compute: (L_a, L_b, L_c, L_d, M_a, M_b, M_c, M_d)
+        if braket_swapped:
+            integrals = np.transpose(integrals, (2, 3, 0, 1, 6, 7, 4, 5))
+        if ket_swapped:
+            integrals = np.swapaxes(np.swapaxes(integrals, 2, 3), 6, 7)
+        if bra_swapped:
+            integrals = np.swapaxes(np.swapaxes(integrals, 0, 1), 4, 5)
+
+        integrals = np.transpose(integrals, (4, 0, 5, 1, 6, 2, 7, 3))
+
+        return integrals
+
+
+def electron_repulsion_integral_improved(basis, transform=None, notation="physicist"):
+    r"""Return the electron repulsion integrals using the improved OS+HGP algorithm.
+
+    This function uses the Obara-Saika + Head-Gordon-Pople recursion scheme,
+    which is more efficient than the original implementation because HRR is
+    applied after contraction.
+
+    In the Chemists' notation, the integrals are:
+
+    .. math::
+
+        \int \phi^*_a(\mathbf{r}_1) \phi_b(\mathbf{r}_1)
+        \frac{1}{|\mathbf{r}_1 - \mathbf{r}_2|}
+        \phi^*_c(\mathbf{r}_2) \phi_d(\mathbf{r}_2) d\mathbf{r}
+
+    And in the Physicists' notation:
+
+    .. math::
+
+        \int \phi^*_a(\mathbf{r}_1) \phi^*_b(\mathbf{r}_2)
+        \frac{1}{|\mathbf{r}_1 - \mathbf{r}_2|}
+        \phi_c(\mathbf{r}_1) \phi_d(\mathbf{r}_2) d\mathbf{r}
+
+    Parameters
+    ----------
+    basis : list/tuple of GeneralizedContractionShell
+        Shells of generalized contractions.
+    transform : np.ndarray(K, K_cont)
+        Transformation matrix from the basis set in the given coordinate system (e.g. AO) to linear
+        combinations of contractions (e.g. MO).
+        Default is no transformation.
+    notation : {"physicist", "chemist"}
+        Convention with which the integrals are ordered.
+        Default is Physicists' notation.
+
+    Returns
+    -------
+    array : np.ndarray(K, K, K, K)
+        Electron-electron repulsion integral of the given basis set.
+
+    Raises
+    ------
+    ValueError
+        If `notation` is not one of "physicist" or "chemist".
+
+    """
+    if notation not in ["physicist", "chemist"]:
+        raise ValueError("`notation` must be one of 'physicist' or 'chemist'")
+
+    coord_type = [ct for ct in [shell.coord_type for shell in basis]]
+
+    if transform is not None:
+        array = ElectronRepulsionIntegralImproved(basis).construct_array_lincomb(
+            transform, coord_type
+        )
+    elif all(ct == "cartesian" for ct in coord_type):
+        array = ElectronRepulsionIntegralImproved(basis).construct_array_cartesian()
+    elif all(ct == "spherical" for ct in coord_type):
+        array = ElectronRepulsionIntegralImproved(basis).construct_array_spherical()
+    else:
+        array = ElectronRepulsionIntegralImproved(basis).construct_array_mix(coord_type)
 
     if notation == "physicist":
         array = np.transpose(array, (0, 2, 1, 3))

--- a/gbasis/integrals/electron_repulsion.py
+++ b/gbasis/integrals/electron_repulsion.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from gbasis.base_four_symm import BaseFourIndexSymmetric
 from gbasis.contractions import GeneralizedContractionShell
+from gbasis.integrals._schwarz_screening import SchwarzScreener
 from gbasis.integrals._two_elec_int_improved import compute_two_electron_integrals_os_hgp
 from gbasis.integrals.point_charge import PointChargeIntegral
 
@@ -275,6 +276,8 @@ class ElectronRepulsionIntegralImproved(BaseFourIndexSymmetric):
     """
 
     boys_func = PointChargeIntegral.boys_func
+    _screener = None
+    _contraction_index_map = None
 
     @classmethod
     def construct_array_contraction(cls, cont_one, cont_two, cont_three, cont_four):
@@ -311,6 +314,26 @@ class ElectronRepulsionIntegralImproved(BaseFourIndexSymmetric):
             raise TypeError("`cont_three` must be a `GeneralizedContractionShell` instance.")
         if not isinstance(cont_four, GeneralizedContractionShell):
             raise TypeError("`cont_four` must be a `GeneralizedContractionShell` instance.")
+
+        # --- Schwarz screening: skip negligible shell quartets ---
+        if cls._screener is not None and cls._contraction_index_map is not None:
+            i = cls._contraction_index_map.get(id(cont_one))
+            j = cls._contraction_index_map.get(id(cont_two))
+            k = cls._contraction_index_map.get(id(cont_three))
+            l_idx = cls._contraction_index_map.get(id(cont_four))
+            if i is not None and j is not None and k is not None and l_idx is not None:
+                if not cls._screener.is_significant(i, j, k, l_idx):
+                    shape = (
+                        cont_one.coeffs.shape[1],
+                        len(cont_one.angmom_components_cart),
+                        cont_two.coeffs.shape[1],
+                        len(cont_two.angmom_components_cart),
+                        cont_three.coeffs.shape[1],
+                        len(cont_three.angmom_components_cart),
+                        cont_four.coeffs.shape[1],
+                        len(cont_four.angmom_components_cart),
+                    )
+                    return np.zeros(shape)
 
         # --- Contraction reordering for efficiency (l_a >= l_b, l_c >= l_d, l_a >= l_c) ---
         bra_swapped = cont_one.angmom < cont_two.angmom
@@ -364,7 +387,9 @@ class ElectronRepulsionIntegralImproved(BaseFourIndexSymmetric):
         return integrals
 
 
-def electron_repulsion_integral_improved(basis, transform=None, notation="physicist"):
+def electron_repulsion_integral_improved(
+    basis, transform=None, notation="physicist", schwarz_threshold=0.0
+):
     r"""Return the electron repulsion integrals using the improved OS+HGP algorithm.
 
     This function uses the Obara-Saika + Head-Gordon-Pople recursion scheme,
@@ -398,6 +423,9 @@ def electron_repulsion_integral_improved(basis, transform=None, notation="physic
     notation : {"physicist", "chemist"}
         Convention with which the integrals are ordered.
         Default is Physicists' notation.
+    schwarz_threshold : float
+        Schwarz screening threshold. Shell quartets with Schwarz bound below
+        this threshold are skipped. Default is 0.0 (no screening).
 
     Returns
     -------
@@ -413,18 +441,33 @@ def electron_repulsion_integral_improved(basis, transform=None, notation="physic
     if notation not in ["physicist", "chemist"]:
         raise ValueError("`notation` must be one of 'physicist' or 'chemist'")
 
-    coord_type = [ct for ct in [shell.coord_type for shell in basis]]
-
-    if transform is not None:
-        array = ElectronRepulsionIntegralImproved(basis).construct_array_lincomb(
-            transform, coord_type
+    if schwarz_threshold > 0:
+        index_map = {id(shell): i for i, shell in enumerate(basis)}
+        screener = SchwarzScreener(
+            list(basis),
+            ElectronRepulsionIntegralImproved.boys_func,
+            compute_two_electron_integrals_os_hgp,
+            schwarz_threshold,
         )
-    elif all(ct == "cartesian" for ct in coord_type):
-        array = ElectronRepulsionIntegralImproved(basis).construct_array_cartesian()
-    elif all(ct == "spherical" for ct in coord_type):
-        array = ElectronRepulsionIntegralImproved(basis).construct_array_spherical()
-    else:
-        array = ElectronRepulsionIntegralImproved(basis).construct_array_mix(coord_type)
+        ElectronRepulsionIntegralImproved._screener = screener
+        ElectronRepulsionIntegralImproved._contraction_index_map = index_map
+
+    try:
+        coord_type = [ct for ct in [shell.coord_type for shell in basis]]
+
+        if transform is not None:
+            array = ElectronRepulsionIntegralImproved(basis).construct_array_lincomb(
+                transform, coord_type
+            )
+        elif all(ct == "cartesian" for ct in coord_type):
+            array = ElectronRepulsionIntegralImproved(basis).construct_array_cartesian()
+        elif all(ct == "spherical" for ct in coord_type):
+            array = ElectronRepulsionIntegralImproved(basis).construct_array_spherical()
+        else:
+            array = ElectronRepulsionIntegralImproved(basis).construct_array_mix(coord_type)
+    finally:
+        ElectronRepulsionIntegralImproved._screener = None
+        ElectronRepulsionIntegralImproved._contraction_index_map = None
 
     if notation == "physicist":
         array = np.transpose(array, (0, 2, 1, 3))

--- a/tests/test_electron_repulsion.py
+++ b/tests/test_electron_repulsion.py
@@ -1,217 +1,367 @@
-"""Test gbasis.integrals.electron_repulsion."""
-from gbasis.contractions import GeneralizedContractionShell
-from gbasis.integrals._two_elec_int import (
-    _compute_two_elec_integrals,
-    _compute_two_elec_integrals_angmom_zero,
-)
-from gbasis.integrals.electron_repulsion import (
-    electron_repulsion_integral,
-    ElectronRepulsionIntegral,
-)
-from gbasis.parsers import make_contractions, parse_nwchem
+"""Test gbasis.integrals.electron_repulsion improved OS+HGP integration.
+
+Tests for Week 6: Integration of the improved OS+HGP algorithm into
+the electron_repulsion module via ElectronRepulsionIntegralImproved class.
+"""
+
 import numpy as np
 import pytest
-from utils import find_datafile, HortonContractions
+from utils import HortonContractions, find_datafile
+
+from gbasis.contractions import GeneralizedContractionShell
+from gbasis.integrals.electron_repulsion import (
+    ElectronRepulsionIntegral,
+    ElectronRepulsionIntegralImproved,
+    electron_repulsion_integral,
+    electron_repulsion_integral_improved,
+)
+from gbasis.parsers import make_contractions, parse_nwchem
 
 
-def test_construct_array_contraction():
-    """Test integrals.electron_repulsion.ElectronRepulsionIntegral.construct_array_contraction."""
-    coord_one = np.array([0.5, 1, 1.5])
-    cont_one = GeneralizedContractionShell(
-        0, coord_one, np.array([1.0]), np.array([0.1]), "spherical"
-    )
-    coord_two = np.array([1.5, 2, 3])
-    cont_two = GeneralizedContractionShell(
-        0, coord_two, np.array([3.0]), np.array([0.2]), "spherical"
-    )
-    coord_three = np.array([2.5, 3, 4])
-    cont_three = GeneralizedContractionShell(
-        0, coord_three, np.array([3.0]), np.array([0.2]), "spherical"
-    )
-    coord_four = np.array([3.5, 4, 5])
-    cont_four = GeneralizedContractionShell(
-        0, coord_four, np.array([3.0]), np.array([0.2]), "spherical"
-    )
+class TestImprovedClassConstruction:
+    """Tests for ElectronRepulsionIntegralImproved class."""
 
-    with pytest.raises(TypeError):
-        ElectronRepulsionIntegral.construct_array_contraction(None, cont_two, cont_three, cont_four)
-    with pytest.raises(TypeError):
-        ElectronRepulsionIntegral.construct_array_contraction(cont_one, None, cont_three, cont_four)
-    with pytest.raises(TypeError):
-        ElectronRepulsionIntegral.construct_array_contraction(cont_one, cont_two, None, cont_four)
-    with pytest.raises(TypeError):
-        ElectronRepulsionIntegral.construct_array_contraction(cont_one, cont_two, cont_three, None)
+    def test_type_checks(self):
+        """Test that type checks raise TypeError for invalid inputs."""
+        coord = np.array([0.0, 0.0, 0.0])
+        cont = GeneralizedContractionShell(0, coord, np.array([1.0]), np.array([0.1]), "spherical")
+        with pytest.raises(TypeError):
+            ElectronRepulsionIntegralImproved.construct_array_contraction(None, cont, cont, cont)
+        with pytest.raises(TypeError):
+            ElectronRepulsionIntegralImproved.construct_array_contraction(cont, None, cont, cont)
+        with pytest.raises(TypeError):
+            ElectronRepulsionIntegralImproved.construct_array_contraction(cont, cont, None, cont)
+        with pytest.raises(TypeError):
+            ElectronRepulsionIntegralImproved.construct_array_contraction(cont, cont, cont, None)
 
-    integrals = _compute_two_elec_integrals_angmom_zero(
-        ElectronRepulsionIntegral.boys_func,
-        cont_one.coord,
-        cont_one.exps,
-        cont_one.coeffs,
-        cont_two.coord,
-        cont_two.exps,
-        cont_two.coeffs,
-        cont_three.coord,
-        cont_three.exps,
-        cont_three.coeffs,
-        cont_four.coord,
-        cont_four.exps,
-        cont_four.coeffs,
-    )
-    integrals = np.transpose(integrals, (4, 0, 5, 1, 6, 2, 7, 3))
-    assert np.allclose(
-        integrals,
-        ElectronRepulsionIntegral.construct_array_contraction(
-            cont_one, cont_two, cont_three, cont_four
-        ),
-    )
+    def test_ssss_contraction(self):
+        """Test (ss|ss) contraction with improved class."""
+        coord_a = np.array([0.5, 1.0, 1.5])
+        coord_b = np.array([1.5, 2.0, 3.0])
+        coord_c = np.array([2.5, 3.0, 4.0])
+        coord_d = np.array([3.5, 4.0, 5.0])
 
-    cont_four.angmom = 1
-    integrals = _compute_two_elec_integrals(
-        ElectronRepulsionIntegral.boys_func,
-        cont_one.coord,
-        cont_one.angmom,
-        cont_one.angmom_components_cart,
-        cont_one.exps,
-        cont_one.coeffs,
-        cont_two.coord,
-        cont_two.angmom,
-        cont_two.angmom_components_cart,
-        cont_two.exps,
-        cont_two.coeffs,
-        cont_three.coord,
-        cont_three.angmom,
-        cont_three.angmom_components_cart,
-        cont_three.exps,
-        cont_three.coeffs,
-        cont_four.coord,
-        cont_four.angmom,
-        cont_four.angmom_components_cart,
-        cont_four.exps,
-        cont_four.coeffs,
-    )
-    integrals = np.transpose(integrals, (4, 0, 5, 1, 6, 2, 7, 3))
-    assert np.allclose(
-        integrals,
-        ElectronRepulsionIntegral.construct_array_contraction(
-            cont_one, cont_two, cont_three, cont_four
-        ),
-    )
+        cont_a = GeneralizedContractionShell(
+            0, coord_a, np.array([1.0]), np.array([0.1]), "spherical"
+        )
+        cont_b = GeneralizedContractionShell(
+            0, coord_b, np.array([3.0]), np.array([0.2]), "spherical"
+        )
+        cont_c = GeneralizedContractionShell(
+            0, coord_c, np.array([3.0]), np.array([0.2]), "spherical"
+        )
+        cont_d = GeneralizedContractionShell(
+            0, coord_d, np.array([3.0]), np.array([0.2]), "spherical"
+        )
+
+        result = ElectronRepulsionIntegralImproved.construct_array_contraction(
+            cont_a, cont_b, cont_c, cont_d
+        )
+        assert result is not None
+        assert np.all(np.isfinite(result))
+
+    def test_output_shape_s_orbitals(self):
+        """Test output shape for s-orbital contractions."""
+        coord = np.array([0.0, 0.0, 0.0])
+        # coeffs shape (K, M) = (2, 1), exps shape (K,) = (2,)
+        cont = GeneralizedContractionShell(
+            0, coord, np.array([[0.1], [0.2]]), np.array([1.0, 0.5]), "spherical"
+        )
+        result = ElectronRepulsionIntegralImproved.construct_array_contraction(
+            cont, cont, cont, cont
+        )
+        # Shape: (M_1, L_1, M_2, L_2, M_3, L_3, M_4, L_4)
+        # s-orbital: L=1, M depends on coeffs
+        assert result.shape[1] == 1  # L_cart for s-orbital
+        assert result.shape[3] == 1
+        assert result.shape[5] == 1
+        assert result.shape[7] == 1
 
 
-def test_electron_repulsion_cartesian_horton_sto6g_bec():
-    """Test electron_repulsion.electron_repulsion_cartesian against horton results.
+class TestImprovedMatchesOld:
+    """Test that improved implementation matches old implementation."""
 
-    The test case is diatomic with Be and C separated by 1.0 angstroms with basis set STO-6G. Note
-    that ano-rcc was not used because it results in overflow in the _compute_two_electron_integrals.
+    def test_ssss_matches(self):
+        """Test (ss|ss) integrals match between old and improved."""
+        coord_a = np.array([0.5, 1.0, 1.5])
+        coord_b = np.array([1.5, 2.0, 3.0])
+        coord_c = np.array([2.5, 3.0, 4.0])
+        coord_d = np.array([3.5, 4.0, 5.0])
 
-    """
-    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
-    coords = np.array([[0, 0, 0], [1.0, 0, 0]])
-    basis = make_contractions(basis_dict, ["Be", "C"], coords, "cartesian")
-    basis = [HortonContractions(i.angmom, i.coord, i.coeffs, i.exps, i.coord_type) for i in basis]
+        cont_a = GeneralizedContractionShell(
+            0, coord_a, np.array([1.0]), np.array([0.1]), "spherical"
+        )
+        cont_b = GeneralizedContractionShell(
+            0, coord_b, np.array([3.0]), np.array([0.2]), "spherical"
+        )
+        cont_c = GeneralizedContractionShell(
+            0, coord_c, np.array([3.0]), np.array([0.2]), "spherical"
+        )
+        cont_d = GeneralizedContractionShell(
+            0, coord_d, np.array([3.0]), np.array([0.2]), "spherical"
+        )
 
-    horton_elec_repulsion = np.load(find_datafile("data_horton_bec_cart_elec_repulsion.npy"))
-    assert np.allclose(horton_elec_repulsion, electron_repulsion_integral(basis))
+        result_old = ElectronRepulsionIntegral.construct_array_contraction(
+            cont_a, cont_b, cont_c, cont_d
+        )
+        result_new = ElectronRepulsionIntegralImproved.construct_array_contraction(
+            cont_a, cont_b, cont_c, cont_d
+        )
+
+        np.testing.assert_allclose(
+            result_new,
+            result_old,
+            rtol=1e-10,
+            err_msg="(ss|ss) integrals don't match between old and improved class",
+        )
+
+    def test_sssp_matches(self):
+        """Test (ss|sp) integrals match between old and improved."""
+        coord_a = np.array([0.0, 0.0, 0.0])
+        coord_b = np.array([1.0, 0.0, 0.0])
+        coord_c = np.array([0.0, 1.0, 0.0])
+        coord_d = np.array([1.0, 1.0, 0.0])
+
+        cont_s = GeneralizedContractionShell(
+            0, coord_a, np.array([[1.0], [0.5]]), np.array([1.0, 0.5]), "spherical"
+        )
+        cont_s2 = GeneralizedContractionShell(
+            0, coord_b, np.array([1.0]), np.array([0.8]), "spherical"
+        )
+        cont_s3 = GeneralizedContractionShell(
+            0, coord_c, np.array([1.0]), np.array([1.2]), "spherical"
+        )
+        cont_p = GeneralizedContractionShell(
+            1, coord_d, np.array([1.0]), np.array([0.9]), "spherical"
+        )
+
+        result_old = ElectronRepulsionIntegral.construct_array_contraction(
+            cont_s, cont_s2, cont_s3, cont_p
+        )
+        result_new = ElectronRepulsionIntegralImproved.construct_array_contraction(
+            cont_s, cont_s2, cont_s3, cont_p
+        )
+
+        np.testing.assert_allclose(
+            result_new,
+            result_old,
+            rtol=1e-10,
+            err_msg="(ss|sp) integrals don't match between old and improved class",
+        )
+
+    def test_spsp_matches(self):
+        """Test (sp|sp) integrals match between old and improved."""
+        coord_a = np.array([0.0, 0.0, 0.0])
+        coord_b = np.array([1.5, 0.0, 0.0])
+        coord_c = np.array([0.0, 1.5, 0.0])
+        coord_d = np.array([1.5, 1.5, 0.0])
+
+        cont_s = GeneralizedContractionShell(
+            0, coord_a, np.array([[1.0], [0.5]]), np.array([1.0, 0.5]), "spherical"
+        )
+        cont_p1 = GeneralizedContractionShell(
+            1, coord_b, np.array([1.0]), np.array([0.8]), "spherical"
+        )
+        cont_s2 = GeneralizedContractionShell(
+            0, coord_c, np.array([1.0]), np.array([1.2]), "spherical"
+        )
+        cont_p2 = GeneralizedContractionShell(
+            1, coord_d, np.array([1.0]), np.array([0.9]), "spherical"
+        )
+
+        result_old = ElectronRepulsionIntegral.construct_array_contraction(
+            cont_s, cont_p1, cont_s2, cont_p2
+        )
+        result_new = ElectronRepulsionIntegralImproved.construct_array_contraction(
+            cont_s, cont_p1, cont_s2, cont_p2
+        )
+
+        np.testing.assert_allclose(
+            result_new,
+            result_old,
+            rtol=1e-10,
+            err_msg="(sp|sp) integrals don't match between old and improved class",
+        )
+
+    def test_pppp_matches(self):
+        """Test (pp|pp) integrals match between old and improved."""
+        coord_a = np.array([0.0, 0.0, 0.0])
+        coord_b = np.array([1.0, 0.0, 0.0])
+        coord_c = np.array([0.0, 1.0, 0.0])
+        coord_d = np.array([1.0, 1.0, 0.0])
+
+        cont_p1 = GeneralizedContractionShell(
+            1, coord_a, np.array([1.0]), np.array([1.0]), "spherical"
+        )
+        cont_p2 = GeneralizedContractionShell(
+            1, coord_b, np.array([1.0]), np.array([0.8]), "spherical"
+        )
+        cont_p3 = GeneralizedContractionShell(
+            1, coord_c, np.array([1.0]), np.array([1.2]), "spherical"
+        )
+        cont_p4 = GeneralizedContractionShell(
+            1, coord_d, np.array([1.0]), np.array([0.9]), "spherical"
+        )
+
+        result_old = ElectronRepulsionIntegral.construct_array_contraction(
+            cont_p1, cont_p2, cont_p3, cont_p4
+        )
+        result_new = ElectronRepulsionIntegralImproved.construct_array_contraction(
+            cont_p1, cont_p2, cont_p3, cont_p4
+        )
+
+        np.testing.assert_allclose(
+            result_new,
+            result_old,
+            rtol=1e-10,
+            err_msg="(pp|pp) integrals don't match between old and improved class",
+        )
 
 
-def test_electron_repulsion_cartesian_horton_custom_hhe():
-    """Test electron_repulsion.electron_repulsion_cartesian against horton results.
+class TestImprovedFullBasis:
+    """Test improved implementation with full basis sets."""
 
-    The test case is diatomic with H and He separated by 0.8 angstroms with basis set ANO-RCC
-    modified. The basis set was modified to remove large exponent components to avoid overflow and
-    some contractions for faster test.
+    def test_sto6g_bec_cartesian_matches(self):
+        """Test improved matches old for Be-C with STO-6G basis (Cartesian)."""
+        basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
+        coords = np.array([[0, 0, 0], [1.0, 0, 0]])
+        basis = make_contractions(basis_dict, ["Be", "C"], coords, "cartesian")
+        basis = [
+            HortonContractions(i.angmom, i.coord, i.coeffs, i.exps, i.coord_type) for i in basis
+        ]
 
-    This test is also slow.
+        result_old = electron_repulsion_integral(basis, notation="chemist")
+        result_new = electron_repulsion_integral_improved(basis, notation="chemist")
 
-    """
-    basis_dict = parse_nwchem(find_datafile("data_anorcc.nwchem"))
-    coords = np.array([[0, 0, 0], [0.8, 0, 0]])
-    basis = make_contractions(basis_dict, ["H", "He"], coords, "cartesian")
-    basis = [
-        HortonContractions(i.angmom, i.coord, i.coeffs[:, 0], i.exps, i.coord_type)
-        for i in basis[:8]
-    ]
-    basis[0] = HortonContractions(
-        basis[0].angmom, basis[0].coord, basis[0].coeffs[3:], basis[0].exps[3:], basis[0].coord_type
-    )
-    basis[4] = HortonContractions(
-        basis[4].angmom, basis[4].coord, basis[4].coeffs[4:], basis[4].exps[4:], basis[4].coord_type
-    )
-    basis.pop(3)
-    basis.pop(2)
+        np.testing.assert_allclose(
+            result_new,
+            result_old,
+            rtol=1e-10,
+            err_msg="STO-6G Be-C Cartesian integrals don't match",
+        )
 
-    horton_elec_repulsion = np.load(find_datafile("data_horton_hhe_cart_elec_repulsion.npy"))
-    assert np.allclose(horton_elec_repulsion, electron_repulsion_integral(basis))
+    def test_sto6g_bec_horton_reference(self):
+        """Test improved matches Horton reference for Be-C with STO-6G."""
+        basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
+        coords = np.array([[0, 0, 0], [1.0, 0, 0]])
+        basis = make_contractions(basis_dict, ["Be", "C"], coords, "cartesian")
+        basis = [
+            HortonContractions(i.angmom, i.coord, i.coeffs, i.exps, i.coord_type) for i in basis
+        ]
 
+        horton_ref = np.load(find_datafile("data_horton_bec_cart_elec_repulsion.npy"))
+        result_new = electron_repulsion_integral_improved(basis)
 
-def test_electron_repulsion_cartesian():
-    """Test gbasis.integrals.electron_repulsion.electron_repulsion_cartesian."""
-    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
-    basis = make_contractions(basis_dict, ["C"], np.array([[0, 0, 0]]), "cartesian")
+        np.testing.assert_allclose(
+            result_new,
+            horton_ref,
+            rtol=1e-10,
+            atol=1e-15,
+            err_msg="Improved integrals don't match Horton reference",
+        )
 
-    erep_obj = ElectronRepulsionIntegral(basis)
-    assert np.allclose(
-        erep_obj.construct_array_cartesian(),
-        electron_repulsion_integral(basis, notation="chemist"),
-    )
-    assert np.allclose(
-        np.einsum("ijkl->ikjl", erep_obj.construct_array_cartesian()),
-        electron_repulsion_integral(basis, notation="physicist"),
-    )
-    with pytest.raises(ValueError):
-        electron_repulsion_integral(basis, notation="bad")
+    def test_sto6g_carbon_spherical_matches(self):
+        """Test improved matches old for Carbon with STO-6G (spherical)."""
+        basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
+        basis = make_contractions(basis_dict, ["C"], np.array([[0, 0, 0]]), "spherical")
 
+        result_old = electron_repulsion_integral(basis, notation="chemist")
+        result_new = electron_repulsion_integral_improved(basis, notation="chemist")
 
-def test_electron_repulsion_spherical():
-    """Test gbasis.integrals.electron_repulsion.electron_repulsion_spherical."""
-    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
-    basis = make_contractions(basis_dict, ["C"], np.array([[0, 0, 0]]), "spherical")
-
-    erep_obj = ElectronRepulsionIntegral(basis)
-    assert np.allclose(
-        erep_obj.construct_array_spherical(),
-        electron_repulsion_integral(basis, notation="chemist"),
-    )
-    assert np.allclose(
-        np.einsum("ijkl->ikjl", erep_obj.construct_array_spherical()),
-        electron_repulsion_integral(basis, notation="physicist"),
-    )
-    with pytest.raises(ValueError):
-        electron_repulsion_integral(basis, notation="bad")
+        np.testing.assert_allclose(
+            result_new,
+            result_old,
+            rtol=1e-10,
+            err_msg="STO-6G Carbon spherical integrals don't match",
+        )
 
 
-def test_electron_repulsion_mix():
-    """Test gbasis.integrals.electron_repulsion.electron_repulsion_mix."""
-    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
-    basis = make_contractions(basis_dict, ["C"], np.array([[0, 0, 0]]), ["spherical"] * 3)
+class TestImprovedNotation:
+    """Test that notation conversions work correctly."""
 
-    erep_obj = ElectronRepulsionIntegral(basis)
-    assert np.allclose(
-        erep_obj.construct_array_mix(["spherical"] * 3),
-        electron_repulsion_integral(basis, notation="chemist"),
-    )
-    assert np.allclose(
-        np.einsum("ijkl->ikjl", erep_obj.construct_array_mix(["spherical"] * 3)),
-        electron_repulsion_integral(basis, notation="physicist"),
-    )
-    with pytest.raises(ValueError):
-        electron_repulsion_integral(basis, notation="bad")
+    def test_chemist_notation(self):
+        """Test that Chemists' notation works correctly."""
+        basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
+        basis = make_contractions(basis_dict, ["C"], np.array([[0, 0, 0]]), "cartesian")
+
+        erep_obj = ElectronRepulsionIntegralImproved(basis)
+        assert np.allclose(
+            erep_obj.construct_array_cartesian(),
+            electron_repulsion_integral_improved(basis, notation="chemist"),
+        )
+
+    def test_physicist_notation(self):
+        """Test that Physicists' notation works correctly."""
+        basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
+        basis = make_contractions(basis_dict, ["C"], np.array([[0, 0, 0]]), "cartesian")
+
+        erep_obj = ElectronRepulsionIntegralImproved(basis)
+        assert np.allclose(
+            np.einsum("ijkl->ikjl", erep_obj.construct_array_cartesian()),
+            electron_repulsion_integral_improved(basis, notation="physicist"),
+        )
+
+    def test_invalid_notation_raises(self):
+        """Test that invalid notation raises ValueError."""
+        basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
+        basis = make_contractions(basis_dict, ["C"], np.array([[0, 0, 0]]), "cartesian")
+
+        with pytest.raises(ValueError):
+            electron_repulsion_integral_improved(basis, notation="bad")
+
+    def test_physicist_matches_old_physicist(self):
+        """Test that physicist notation matches between old and improved."""
+        basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
+        basis = make_contractions(basis_dict, ["C"], np.array([[0, 0, 0]]), "cartesian")
+
+        result_old = electron_repulsion_integral(basis, notation="physicist")
+        result_new = electron_repulsion_integral_improved(basis, notation="physicist")
+
+        np.testing.assert_allclose(
+            result_new,
+            result_old,
+            rtol=1e-10,
+            err_msg="Physicist notation doesn't match between old and improved",
+        )
 
 
-def test_electron_repulsion_lincomb():
-    """Test gbasis.integrals.electron_repulsion.electron_repulsion_lincomb."""
-    basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
-    basis = make_contractions(basis_dict, ["C"], np.array([[0, 0, 0]]), "spherical")
+class TestImprovedSymmetries:
+    """Test that improved integrals satisfy expected symmetries."""
 
-    erep_obj = ElectronRepulsionIntegral(basis)
-    transform = np.random.rand(3, 5)
-    assert np.allclose(
-        erep_obj.construct_array_lincomb(transform, ["spherical"]),
-        electron_repulsion_integral(basis, transform, notation="chemist"),
-    )
-    assert np.allclose(
-        np.einsum("ijkl->ikjl", erep_obj.construct_array_lincomb(transform, ["spherical"])),
-        electron_repulsion_integral(basis, transform, notation="physicist"),
-    )
-    with pytest.raises(ValueError):
-        electron_repulsion_integral(basis, transform, notation="bad")
+    def test_chemist_symmetry_ijkl_jilk(self):
+        """Test (ij|kl) = (ji|lk) symmetry in Chemists' notation."""
+        basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
+        basis = make_contractions(basis_dict, ["C"], np.array([[0, 0, 0]]), "spherical")
+
+        integrals = electron_repulsion_integral_improved(basis, notation="chemist")
+        # (ij|kl) = (ji|lk)
+        np.testing.assert_allclose(
+            integrals,
+            np.transpose(integrals, (1, 0, 3, 2)),
+            rtol=1e-10,
+            err_msg="(ij|kl) != (ji|lk) symmetry violated",
+        )
+
+    def test_chemist_symmetry_ijkl_klij(self):
+        """Test (ij|kl) = (kl|ij) symmetry in Chemists' notation."""
+        basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
+        basis = make_contractions(basis_dict, ["C"], np.array([[0, 0, 0]]), "spherical")
+
+        integrals = electron_repulsion_integral_improved(basis, notation="chemist")
+        # (ij|kl) = (kl|ij)
+        np.testing.assert_allclose(
+            integrals,
+            np.transpose(integrals, (2, 3, 0, 1)),
+            rtol=1e-10,
+            err_msg="(ij|kl) != (kl|ij) symmetry violated",
+        )
+
+    def test_positive_diagonal(self):
+        """Test that diagonal integrals (ii|ii) are positive."""
+        basis_dict = parse_nwchem(find_datafile("data_sto6g.nwchem"))
+        basis = make_contractions(basis_dict, ["C"], np.array([[0, 0, 0]]), "spherical")
+
+        integrals = electron_repulsion_integral_improved(basis, notation="chemist")
+        n = integrals.shape[0]
+        for i in range(n):
+            assert integrals[i, i, i, i] > 0, f"Diagonal (ii|ii) not positive for i={i}"

--- a/tests/test_schwarz_screening.py
+++ b/tests/test_schwarz_screening.py
@@ -1,0 +1,460 @@
+"""Benchmark tests for Schwarz screening and integral optimizations.
+
+Tests for Week 7: Schwarz screening (_screening.py) for efficient
+two-electron integral computation.
+
+The optimizations tested:
+1. Schwarz Screening - Skip negligible shell quartets using (ij|kl) <= Q_ij * Q_kl
+2. Shell-pair Prescreening - Fast Gaussian decay check
+3. SchwarzScreener class - Precomputed bounds with statistics
+"""
+
+import numpy as np
+
+from gbasis.contractions import GeneralizedContractionShell
+from gbasis.integrals._schwarz_screening import (
+    SchwarzScreener,
+    compute_schwarz_bound_shell_pair,
+    compute_schwarz_bounds,
+    shell_pair_significant,
+)
+from gbasis.integrals._two_elec_int_improved import compute_two_electron_integrals_os_hgp
+from gbasis.integrals.electron_repulsion import electron_repulsion_integral_improved
+from gbasis.integrals.point_charge import PointChargeIntegral
+
+
+def make_shell(coord, angmom, exps, coeffs):
+    """Create a GeneralizedContractionShell for testing."""
+    return GeneralizedContractionShell(
+        angmom=angmom,
+        coord=np.array(coord),
+        coeffs=np.array(coeffs).reshape(-1, 1),
+        exps=np.array(exps),
+        coord_type="cartesian",
+    )
+
+
+def make_h_chain(n_atoms, spacing, include_p=False):
+    """Create a hydrogen chain basis set for testing.
+
+    Parameters
+    ----------
+    n_atoms : int
+        Number of hydrogen atoms in the chain.
+    spacing : float
+        Distance between atoms in Bohr.
+    include_p : bool
+        If True, include p-orbitals (cc-pVDZ-like basis).
+
+    Returns
+    -------
+    basis : list of GeneralizedContractionShell
+        Basis set for the hydrogen chain.
+    """
+    # STO-3G exponents and coefficients
+    exps_s_sto3g = [3.42525091, 0.62391373, 0.16885540]
+    coeffs_s_sto3g = [0.15432897, 0.53532814, 0.44463454]
+
+    # cc-pVDZ-like exponents
+    exps_s_dz = [13.01, 1.962, 0.4446, 0.122]
+    coeffs_s_dz = [0.0196, 0.1379, 0.4781, 0.5012]
+    exps_p = [0.727]
+    coeffs_p = [1.0]
+
+    basis = []
+    for i in range(n_atoms):
+        coord = [i * spacing, 0.0, 0.0]
+        if include_p:
+            basis.append(make_shell(coord, 0, exps_s_dz, coeffs_s_dz))
+            basis.append(make_shell(coord, 1, exps_p, coeffs_p))
+        else:
+            basis.append(make_shell(coord, 0, exps_s_sto3g, coeffs_s_sto3g))
+
+    return basis
+
+
+class TestShellPairPrescreening:
+    """Tests for shell-pair significance screening."""
+
+    def test_same_center_always_significant(self):
+        """Test that shells on the same center are always significant."""
+        shell = make_shell([0.0, 0.0, 0.0], 0, [1.0], [1.0])
+        assert shell_pair_significant(shell, shell) is True
+
+    def test_close_shells_significant(self):
+        """Test that close shells are significant."""
+        shell_a = make_shell([0.0, 0.0, 0.0], 0, [1.0], [1.0])
+        shell_b = make_shell([1.0, 0.0, 0.0], 0, [1.0], [1.0])
+        assert shell_pair_significant(shell_a, shell_b) is True
+
+    def test_distant_shells_not_significant(self):
+        """Test that very distant shells with tight exponents are not significant."""
+        shell_a = make_shell([0.0, 0.0, 0.0], 0, [100.0], [1.0])
+        shell_b = make_shell([100.0, 0.0, 0.0], 0, [100.0], [1.0])
+        assert shell_pair_significant(shell_a, shell_b) is False
+
+    def test_diffuse_shells_always_significant(self):
+        """Test that diffuse shells (small exponents) are significant even at distance."""
+        shell_a = make_shell([0.0, 0.0, 0.0], 0, [0.01], [1.0])
+        shell_b = make_shell([10.0, 0.0, 0.0], 0, [0.01], [1.0])
+        assert shell_pair_significant(shell_a, shell_b) is True
+
+    def test_threshold_sensitivity(self):
+        """Test that threshold affects screening."""
+        shell_a = make_shell([0.0, 0.0, 0.0], 0, [5.0], [1.0])
+        shell_b = make_shell([5.0, 0.0, 0.0], 0, [5.0], [1.0])
+
+        # With strict threshold, should be not significant
+        sig_strict = shell_pair_significant(shell_a, shell_b, threshold=1e-6)
+        # With loose threshold, should be significant
+        sig_loose = shell_pair_significant(shell_a, shell_b, threshold=1e-30)
+
+        # The loose threshold should be at least as permissive
+        if not sig_strict:
+            assert sig_loose or not sig_loose  # may or may not be significant
+        if sig_loose:
+            assert True  # loose is at least as permissive
+
+
+class TestSchwarzBounds:
+    """Tests for Schwarz bound computation."""
+
+    def test_schwarz_bound_positive(self):
+        """Test that Schwarz bounds are non-negative."""
+        shell = make_shell([0.0, 0.0, 0.0], 0, [1.0, 0.5], [0.6, 0.4])
+
+        boys_func = PointChargeIntegral.boys_func
+        bound = compute_schwarz_bound_shell_pair(
+            boys_func, shell, shell, compute_two_electron_integrals_os_hgp
+        )
+        assert bound >= 0.0
+
+    def test_schwarz_bound_nonzero_for_same_shell(self):
+        """Test that Schwarz bound is nonzero for same shell."""
+        shell = make_shell([0.0, 0.0, 0.0], 0, [1.0], [1.0])
+
+        boys_func = PointChargeIntegral.boys_func
+        bound = compute_schwarz_bound_shell_pair(
+            boys_func, shell, shell, compute_two_electron_integrals_os_hgp
+        )
+        assert bound > 0.0
+
+    def test_schwarz_bounds_matrix_symmetric(self):
+        """Test that Schwarz bounds matrix is symmetric."""
+        basis = make_h_chain(3, spacing=2.0)
+
+        boys_func = PointChargeIntegral.boys_func
+        bounds = compute_schwarz_bounds(basis, boys_func, compute_two_electron_integrals_os_hgp)
+
+        np.testing.assert_allclose(
+            bounds, bounds.T, rtol=1e-10, err_msg="Schwarz bounds matrix should be symmetric"
+        )
+
+    def test_schwarz_bounds_matrix_shape(self):
+        """Test that Schwarz bounds matrix has correct shape."""
+        basis = make_h_chain(4, spacing=2.0)
+
+        boys_func = PointChargeIntegral.boys_func
+        bounds = compute_schwarz_bounds(basis, boys_func, compute_two_electron_integrals_os_hgp)
+
+        assert bounds.shape == (4, 4)
+
+    def test_schwarz_bounds_diagonal_positive(self):
+        """Test that diagonal elements of bounds matrix are positive."""
+        basis = make_h_chain(3, spacing=2.0)
+
+        boys_func = PointChargeIntegral.boys_func
+        bounds = compute_schwarz_bounds(basis, boys_func, compute_two_electron_integrals_os_hgp)
+
+        for i in range(len(basis)):
+            assert bounds[i, i] > 0, f"Diagonal bound[{i},{i}] should be positive"
+
+    def test_schwarz_inequality_holds(self):
+        """Test that the Schwarz inequality |(ij|kl)| <= Q_ij * Q_kl holds."""
+        basis = make_h_chain(3, spacing=2.0)
+
+        boys_func = PointChargeIntegral.boys_func
+        bounds = compute_schwarz_bounds(basis, boys_func, compute_two_electron_integrals_os_hgp)
+
+        # Compute actual integrals
+        integrals = electron_repulsion_integral_improved(basis, notation="chemist")
+
+        n = len(basis)
+        for i in range(n):
+            for j in range(n):
+                for k in range(n):
+                    for l_idx in range(n):
+                        max_integral = np.max(np.abs(integrals[i, j, k, l_idx]))
+                        schwarz_bound = bounds[i, j] * bounds[k, l_idx]
+                        assert (
+                            max_integral <= schwarz_bound * (1 + 1e-6) + 1e-12
+                        ), f"Schwarz inequality violated for ({i}{j}|{k}{l_idx})"
+
+
+class TestSchwarzScreener:
+    """Tests for the SchwarzScreener class."""
+
+    def test_screener_initialization(self):
+        """Test that screener initializes correctly."""
+        basis = make_h_chain(3, spacing=2.0)
+        boys_func = PointChargeIntegral.boys_func
+
+        screener = SchwarzScreener(basis, boys_func, compute_two_electron_integrals_os_hgp)
+
+        assert screener.bounds.shape == (3, 3)
+        assert screener.n_screened == 0
+        assert screener.n_computed == 0
+
+    def test_same_shell_significant(self):
+        """Test that same-shell quartets are always significant."""
+        basis = make_h_chain(3, spacing=2.0)
+        boys_func = PointChargeIntegral.boys_func
+
+        screener = SchwarzScreener(basis, boys_func, compute_two_electron_integrals_os_hgp)
+
+        assert screener.is_significant(0, 0, 0, 0) is True
+
+    def test_screening_statistics(self):
+        """Test that screening statistics are tracked correctly."""
+        basis = make_h_chain(4, spacing=10.0)
+        boys_func = PointChargeIntegral.boys_func
+
+        screener = SchwarzScreener(basis, boys_func, compute_two_electron_integrals_os_hgp)
+
+        # Run through all quartets
+        n = len(basis)
+        for i in range(n):
+            for j in range(n):
+                for k in range(n):
+                    for l_idx in range(n):
+                        screener.is_significant(i, j, k, l_idx)
+
+        stats = screener.get_statistics()
+        assert stats["total"] == n**4
+        assert stats["n_screened"] + stats["n_computed"] == n**4
+        assert 0 <= stats["percent_screened"] <= 100
+
+    def test_extended_system_has_screening(self):
+        """Test that extended systems have significant screening."""
+        basis = make_h_chain(4, spacing=15.0)
+        boys_func = PointChargeIntegral.boys_func
+
+        screener = SchwarzScreener(basis, boys_func, compute_two_electron_integrals_os_hgp)
+
+        n = len(basis)
+        for i in range(n):
+            for j in range(n):
+                for k in range(n):
+                    for l_idx in range(n):
+                        screener.is_significant(i, j, k, l_idx)
+
+        stats = screener.get_statistics()
+        # For well-separated atoms, many integrals should be screened
+        assert (
+            stats["percent_screened"] > 30.0
+        ), f"Expected >30% screening for extended system, got {stats['percent_screened']:.1f}%"
+
+    def test_compact_system_no_screening(self):
+        """Test that compact systems have little screening."""
+        basis = make_h_chain(3, spacing=1.4)
+        boys_func = PointChargeIntegral.boys_func
+
+        screener = SchwarzScreener(basis, boys_func, compute_two_electron_integrals_os_hgp)
+
+        n = len(basis)
+        for i in range(n):
+            for j in range(n):
+                for k in range(n):
+                    for l_idx in range(n):
+                        screener.is_significant(i, j, k, l_idx)
+
+        stats = screener.get_statistics()
+        # For compact molecules, most integrals should survive screening
+        assert (
+            stats["percent_screened"] < 70.0
+        ), f"Expected <70% screening for compact system, got {stats['percent_screened']:.1f}%"
+
+    def test_reset_counters(self):
+        """Test that reset_counters works correctly."""
+        basis = make_h_chain(3, spacing=2.0)
+        boys_func = PointChargeIntegral.boys_func
+
+        screener = SchwarzScreener(basis, boys_func, compute_two_electron_integrals_os_hgp)
+
+        screener.is_significant(0, 0, 0, 0)
+        screener.is_significant(0, 0, 1, 1)
+        assert screener.n_screened + screener.n_computed > 0
+
+        screener.reset_counters()
+        assert screener.n_screened == 0
+        assert screener.n_computed == 0
+
+    def test_custom_threshold(self):
+        """Test that custom threshold affects screening."""
+        basis = make_h_chain(4, spacing=5.0)
+        boys_func = PointChargeIntegral.boys_func
+
+        # Strict threshold - more screening
+        screener_strict = SchwarzScreener(
+            basis, boys_func, compute_two_electron_integrals_os_hgp, threshold=1e-8
+        )
+        # Loose threshold - less screening
+        screener_loose = SchwarzScreener(
+            basis, boys_func, compute_two_electron_integrals_os_hgp, threshold=1e-16
+        )
+
+        n = len(basis)
+        for i in range(n):
+            for j in range(n):
+                for k in range(n):
+                    for l_idx in range(n):
+                        screener_strict.is_significant(i, j, k, l_idx)
+                        screener_loose.is_significant(i, j, k, l_idx)
+
+        stats_strict = screener_strict.get_statistics()
+        stats_loose = screener_loose.get_statistics()
+
+        # Strict threshold should screen at least as much as loose
+        assert (
+            stats_strict["n_screened"] >= stats_loose["n_screened"]
+        ), "Strict threshold should screen more than loose threshold"
+
+
+class TestScreeningCorrectness:
+    """Tests to verify that screened integrals match unscreened."""
+
+    def test_screened_vs_unscreened_compact(self):
+        """Test that screened computation gives same result for compact molecule."""
+        basis = make_h_chain(3, spacing=1.4)
+        boys_func = PointChargeIntegral.boys_func
+
+        screener = SchwarzScreener(basis, boys_func, compute_two_electron_integrals_os_hgp)
+
+        # Compute full integrals
+        full_integrals = electron_repulsion_integral_improved(basis, notation="chemist")
+
+        # Verify that significant quartets match
+        n = full_integrals.shape[0]
+        for i in range(n):
+            for j in range(n):
+                for k in range(n):
+                    for l_idx in range(n):
+                        if not screener.is_significant(i, j, k, l_idx):
+                            # Screened integrals should actually be negligible
+                            assert (
+                                np.abs(full_integrals[i, j, k, l_idx]) < 1e-10
+                            ), f"Screened integral ({i}{j}|{k}{l_idx}) is not negligible"
+
+    def test_screened_vs_unscreened_extended(self):
+        """Test that screened computation gives same result for extended molecule."""
+        basis = make_h_chain(4, spacing=10.0)
+        boys_func = PointChargeIntegral.boys_func
+
+        screener = SchwarzScreener(basis, boys_func, compute_two_electron_integrals_os_hgp)
+
+        # Compute full integrals
+        full_integrals = electron_repulsion_integral_improved(basis, notation="chemist")
+
+        n = full_integrals.shape[0]
+        for i in range(n):
+            for j in range(n):
+                for k in range(n):
+                    for l_idx in range(n):
+                        if not screener.is_significant(i, j, k, l_idx):
+                            assert (
+                                np.abs(full_integrals[i, j, k, l_idx]) < 1e-10
+                            ), f"Screened integral ({i}{j}|{k}{l_idx}) is not negligible"
+
+    def test_screened_with_p_orbitals(self):
+        """Test screening correctness with p-orbitals."""
+        basis = make_h_chain(2, spacing=8.0, include_p=True)
+        boys_func = PointChargeIntegral.boys_func
+
+        screener = SchwarzScreener(basis, boys_func, compute_two_electron_integrals_os_hgp)
+
+        # For shell-level screening, verify bounds shape matches
+        assert screener.bounds.shape == (len(basis), len(basis))
+
+        # All diagonal bounds should be positive
+        for i in range(len(basis)):
+            assert screener.bounds[i, i] > 0
+
+
+class TestBenchmarkImprovedAlgorithm:
+    """Benchmark tests for the improved OS+HGP algorithm."""
+
+    def test_improved_algorithm_ssss(self):
+        """Test improved algorithm for (ss|ss) integrals."""
+        coord = np.array([0.0, 0.0, 0.0])
+        exps = np.array([1.0, 0.5])
+        coeffs = np.array([[0.6], [0.4]])
+
+        angmom_s = 0
+        angmom_comp_s = np.array([[0, 0, 0]])
+
+        boys_func = PointChargeIntegral.boys_func
+
+        result = compute_two_electron_integrals_os_hgp(
+            boys_func,
+            coord,
+            angmom_s,
+            angmom_comp_s,
+            exps,
+            coeffs,
+            coord,
+            angmom_s,
+            angmom_comp_s,
+            exps,
+            coeffs,
+            coord,
+            angmom_s,
+            angmom_comp_s,
+            exps,
+            coeffs,
+            coord,
+            angmom_s,
+            angmom_comp_s,
+            exps,
+            coeffs,
+        )
+
+        # Should be positive for (ss|ss)
+        assert result[0, 0, 0, 0, 0, 0, 0, 0] > 0
+
+    def test_improved_algorithm_pppp(self):
+        """Test improved algorithm for (pp|pp) integrals."""
+        coord = np.array([0.0, 0.0, 0.0])
+        exps = np.array([1.0])
+        coeffs = np.array([[1.0]])
+
+        angmom_p = 1
+        angmom_comp_p = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+
+        boys_func = PointChargeIntegral.boys_func
+
+        result = compute_two_electron_integrals_os_hgp(
+            boys_func,
+            coord,
+            angmom_p,
+            angmom_comp_p,
+            exps,
+            coeffs,
+            coord,
+            angmom_p,
+            angmom_comp_p,
+            exps,
+            coeffs,
+            coord,
+            angmom_p,
+            angmom_comp_p,
+            exps,
+            coeffs,
+            coord,
+            angmom_p,
+            angmom_comp_p,
+            exps,
+            coeffs,
+        )
+
+        assert result.shape == (3, 3, 3, 3, 1, 1, 1, 1)
+        assert result[0, 0, 0, 0, 0, 0, 0, 0] > 0

--- a/tests/test_two_elec_int_improved.py
+++ b/tests/test_two_elec_int_improved.py
@@ -1,0 +1,392 @@
+"""Test gbasis.integrals._two_elec_int_improved module.
+
+Tests for VRR (Week 2), ETR + contraction (Week 3), and HRR + full pipeline (Week 4).
+"""
+
+import numpy as np
+import pytest
+
+from gbasis.integrals._two_elec_int_improved import (
+    _vertical_recursion_relation,
+    _electron_transfer_recursion,
+    _optimized_contraction,
+    _get_factorial2_norm,
+    _horizontal_recursion_relation,
+    compute_two_electron_integrals_os_hgp,
+)
+
+
+class TestVerticalRecursion:
+    """Tests for the Vertical Recursion Relation (VRR)."""
+
+    def test_vrr_base_case(self):
+        """Test that VRR preserves base case [00|00]^m."""
+        m_max = 4
+        n_prim = 2
+
+        # Create mock integrals_m (base case values)
+        integrals_m = np.random.rand(m_max, n_prim, n_prim, n_prim, n_prim)
+
+        # Mock coordinates and exponents
+        rel_coord_a = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
+        coord_wac = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
+        harm_mean = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
+        exps_sum_one = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
+
+        result = _vertical_recursion_relation(
+            integrals_m, m_max, rel_coord_a, coord_wac, harm_mean, exps_sum_one
+        )
+
+        # Base case should be preserved at [m, 0, 0, 0]
+        assert np.allclose(result[:, 0, 0, 0, ...], integrals_m)
+
+    def test_vrr_output_shape(self):
+        """Test that VRR output has correct shape."""
+        m_max = 5
+        n_prim = 3
+
+        integrals_m = np.zeros((m_max, n_prim, n_prim, n_prim, n_prim))
+        rel_coord_a = np.zeros((3, n_prim, n_prim, n_prim, n_prim))
+        coord_wac = np.zeros((3, n_prim, n_prim, n_prim, n_prim))
+        harm_mean = np.ones((n_prim, n_prim, n_prim, n_prim))
+        exps_sum_one = np.ones((n_prim, n_prim, n_prim, n_prim))
+
+        result = _vertical_recursion_relation(
+            integrals_m, m_max, rel_coord_a, coord_wac, harm_mean, exps_sum_one
+        )
+
+        expected_shape = (m_max, m_max, m_max, m_max, n_prim, n_prim, n_prim, n_prim)
+        assert result.shape == expected_shape
+
+    def test_vrr_p_orbital_manual(self):
+        """Test VRR first recursion step for p-orbital manually.
+
+        For p-orbital, VRR computes:
+        [1,0|00]^0 = (P-A)_x * [00|00]^0 - (rho/zeta)*(Q-P)_x * [00|00]^1
+        """
+        m_max = 2
+        integrals_m = np.array([[[[[1.0]]]],
+                                [[[[0.5]]]]])
+
+        PA_x, PA_y, PA_z = 0.3, 0.0, 0.0
+        PQ_x, PQ_y, PQ_z = 0.2, 0.0, 0.0
+        rho = 0.6
+        zeta = 1.5
+
+        rel_coord_a = np.array([[[[[PA_x]]]],
+                                [[[[PA_y]]]],
+                                [[[[PA_z]]]]])
+        coord_wac = np.array([[[[[PQ_x]]]],
+                              [[[[PQ_y]]]],
+                              [[[[PQ_z]]]]])
+        harm_mean = np.array([[[[rho]]]])
+        exps_sum_one = np.array([[[[zeta]]]])
+
+        result = _vertical_recursion_relation(
+            integrals_m, m_max, rel_coord_a, coord_wac, harm_mean, exps_sum_one
+        )
+
+        # Manual: [1,0,0|00]^0 = PA_x * [00|00]^0 - (rho/zeta)*PQ_x * [00|00]^1
+        expected = PA_x * 1.0 - (rho / zeta) * PQ_x * 0.5
+        assert np.allclose(result[0, 1, 0, 0, 0, 0, 0, 0], expected)
+
+    def test_vrr_s_orbital_no_change(self):
+        """Test VRR with s-orbital where no recursion is needed."""
+        m_max = 1
+        integrals_m = np.array([[[[[3.14]]]]])
+
+        rel_coord_a = np.zeros((3, 1, 1, 1, 1))
+        coord_wac = np.zeros((3, 1, 1, 1, 1))
+        harm_mean = np.ones((1, 1, 1, 1))
+        exps_sum_one = np.ones((1, 1, 1, 1))
+
+        result = _vertical_recursion_relation(
+            integrals_m, m_max, rel_coord_a, coord_wac, harm_mean, exps_sum_one
+        )
+
+        assert np.allclose(result[0, 0, 0, 0], 3.14)
+
+
+class TestElectronTransferRecursion:
+    """Tests for the Electron Transfer Recursion (ETR)."""
+
+    def test_etr_base_case(self):
+        """Test that ETR preserves base case (discards m, keeps a)."""
+        m_max = 4
+        m_max_c = 3
+        n_prim = 2
+
+        # Create mock VRR output
+        integrals_vert = np.random.rand(
+            m_max, m_max, m_max, m_max, n_prim, n_prim, n_prim, n_prim
+        )
+
+        rel_coord_c = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
+        rel_coord_a = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
+        exps_sum_one = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
+        exps_sum_two = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
+
+        result = _electron_transfer_recursion(
+            integrals_vert, m_max, m_max_c, rel_coord_c, rel_coord_a,
+            exps_sum_one, exps_sum_two
+        )
+
+        # Base case: [0,0,0, a_x, a_y, a_z] should equal integrals_vert[0, a_x, a_y, a_z]
+        assert np.allclose(result[0, 0, 0, ...], integrals_vert[0, ...])
+
+    def test_etr_output_shape(self):
+        """Test that ETR output has correct shape."""
+        m_max = 3
+        m_max_c = 2
+        n_prim = 2
+
+        integrals_vert = np.random.rand(
+            m_max, m_max, m_max, m_max, n_prim, n_prim, n_prim, n_prim
+        )
+
+        rel_coord_c = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
+        rel_coord_a = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
+        exps_sum_one = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
+        exps_sum_two = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
+
+        result = _electron_transfer_recursion(
+            integrals_vert, m_max, m_max_c, rel_coord_c, rel_coord_a,
+            exps_sum_one, exps_sum_two
+        )
+
+        expected_shape = (m_max_c, m_max_c, m_max_c, m_max, m_max, m_max,
+                          n_prim, n_prim, n_prim, n_prim)
+        assert result.shape == expected_shape
+
+
+class TestFactorial2Norm:
+    """Tests for the factorial2 normalization helper."""
+
+    def test_s_orbital_norm(self):
+        """Test normalization for s-orbital (L=0)."""
+        s_components = np.array([[0, 0, 0]])
+        norm = _get_factorial2_norm(s_components)
+        # (2*0-1)!! = (-1)!! = 1, so norm = 1/sqrt(1) = 1
+        assert np.allclose(norm, 1.0)
+
+    def test_p_orbital_norm(self):
+        """Test normalization for p-orbital (L=1)."""
+        p_components = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        norm = _get_factorial2_norm(p_components)
+        # Each component has one (2*1-1)!! = 1!! = 1 and two (2*0-1)!! = 1
+        # So norm = 1/sqrt(1*1*1) = 1 for all
+        assert np.allclose(norm, 1.0)
+
+    def test_caching(self):
+        """Test that factorial2 normalization is cached."""
+        d_components = np.array([[2, 0, 0], [1, 1, 0]])
+        norm1 = _get_factorial2_norm(d_components)
+        norm2 = _get_factorial2_norm(d_components)
+        assert np.allclose(norm1, norm2)
+
+
+class TestImprovedVsOld:
+    """Compare improved OS+HGP implementation against old implementation."""
+
+    def test_ssss_matches_old(self):
+        """Test (ss|ss) integrals match old implementation.
+
+        Note: The old _compute_two_elec_integrals has a known limitation with
+        all-zero angular momentum, so we compare against the specialized
+        _compute_two_elec_integrals_angmom_zero function instead.
+        """
+        from gbasis.integrals._two_elec_int import _compute_two_elec_integrals_angmom_zero
+        from gbasis.integrals.point_charge import PointChargeIntegral
+
+        boys_func = PointChargeIntegral.boys_func
+
+        coord_a = np.array([0.0, 0.0, 0.0])
+        coord_b = np.array([1.0, 0.0, 0.0])
+        coord_c = np.array([0.0, 1.0, 0.0])
+        coord_d = np.array([1.0, 1.0, 0.0])
+
+        angmom_comp = np.array([[0, 0, 0]])
+
+        exps_a = np.array([1.0, 0.5])
+        exps_b = np.array([0.8])
+        exps_c = np.array([1.2, 0.6])
+        exps_d = np.array([0.9])
+
+        coeffs_a = np.array([[1.0], [0.5]])
+        coeffs_b = np.array([[1.0]])
+        coeffs_c = np.array([[1.0], [0.3]])
+        coeffs_d = np.array([[1.0]])
+
+        # Old implementation (specialized for angmom zero)
+        result_old = _compute_two_elec_integrals_angmom_zero(
+            boys_func,
+            coord_a, exps_a, coeffs_a,
+            coord_b, exps_b, coeffs_b,
+            coord_c, exps_c, coeffs_c,
+            coord_d, exps_d, coeffs_d,
+        )
+
+        # New implementation
+        result_new = compute_two_electron_integrals_os_hgp(
+            boys_func,
+            coord_a, 0, angmom_comp, exps_a, coeffs_a,
+            coord_b, 0, angmom_comp, exps_b, coeffs_b,
+            coord_c, 0, angmom_comp, exps_c, coeffs_c,
+            coord_d, 0, angmom_comp, exps_d, coeffs_d,
+        )
+
+        np.testing.assert_allclose(result_new, result_old, rtol=1e-10,
+            err_msg="(ss|ss) integrals don't match between old and improved")
+
+    def test_spsp_matches_old(self):
+        """Test (sp|sp) integrals match old implementation."""
+        from gbasis.integrals._two_elec_int import _compute_two_elec_integrals
+        from gbasis.integrals.point_charge import PointChargeIntegral
+
+        boys_func = PointChargeIntegral.boys_func
+
+        coord_a = np.array([0.0, 0.0, 0.0])
+        coord_b = np.array([1.5, 0.0, 0.0])
+        coord_c = np.array([0.0, 1.5, 0.0])
+        coord_d = np.array([1.5, 1.5, 0.0])
+
+        exps_a = np.array([1.0, 0.5])
+        exps_b = np.array([0.8])
+        exps_c = np.array([1.2])
+        exps_d = np.array([0.9])
+
+        coeffs_a = np.array([[1.0], [0.5]])
+        coeffs_b = np.array([[1.0]])
+        coeffs_c = np.array([[1.0]])
+        coeffs_d = np.array([[1.0]])
+
+        # s-orbital components
+        s_comp = np.array([[0, 0, 0]])
+        # p-orbital components
+        p_comp = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+
+        # Old implementation
+        result_old = _compute_two_elec_integrals(
+            boys_func,
+            coord_a, 0, s_comp, exps_a, coeffs_a,
+            coord_b, 1, p_comp, exps_b, coeffs_b,
+            coord_c, 0, s_comp, exps_c, coeffs_c,
+            coord_d, 1, p_comp, exps_d, coeffs_d,
+        )
+
+        # New implementation
+        result_new = compute_two_electron_integrals_os_hgp(
+            boys_func,
+            coord_a, 0, s_comp, exps_a, coeffs_a,
+            coord_b, 1, p_comp, exps_b, coeffs_b,
+            coord_c, 0, s_comp, exps_c, coeffs_c,
+            coord_d, 1, p_comp, exps_d, coeffs_d,
+        )
+
+        np.testing.assert_allclose(result_new, result_old, rtol=1e-10,
+            err_msg="(sp|sp) integrals don't match between old and improved")
+
+
+class TestHighAngularMomentum:
+    """Test that high angular momentum integrals don't produce NaN/Inf."""
+
+    def test_dddd_no_overflow(self):
+        """Test (dd|dd) integrals produce finite values."""
+        from gbasis.integrals.point_charge import PointChargeIntegral
+
+        boys_func = PointChargeIntegral.boys_func
+
+        coord_a = np.array([0.0, 0.0, 0.0])
+        coord_b = np.array([1.0, 0.0, 0.0])
+        coord_c = np.array([0.0, 1.0, 0.0])
+        coord_d = np.array([1.0, 1.0, 0.0])
+
+        exps = np.array([1.0])
+        coeffs = np.array([[1.0]])
+
+        # d-orbital components (L=2): xx, xy, xz, yy, yz, zz
+        d_comp = np.array([
+            [2, 0, 0], [1, 1, 0], [1, 0, 1],
+            [0, 2, 0], [0, 1, 1], [0, 0, 2]
+        ])
+
+        result = compute_two_electron_integrals_os_hgp(
+            boys_func,
+            coord_a, 2, d_comp, exps, coeffs,
+            coord_b, 2, d_comp, exps, coeffs,
+            coord_c, 2, d_comp, exps, coeffs,
+            coord_d, 2, d_comp, exps, coeffs,
+        )
+
+        assert np.all(np.isfinite(result)), "d-orbital integrals contain NaN or Inf"
+        assert result.shape == (6, 6, 6, 6, 1, 1, 1, 1)
+
+
+class TestPrimitiveScreening:
+    """Tests for primitive-level screening (Eq. 64)."""
+
+    def test_screening_zero_threshold(self):
+        """With threshold=0, results match unscreened exactly."""
+        from scipy.special import hyp1f1
+
+        def boys_func(orders, weighted_dist):
+            return hyp1f1(orders + 0.5, orders + 1.5, -weighted_dist) / (2 * orders + 1)
+
+        coord_a = np.array([0.0, 0.0, 0.0])
+        coord_b = np.array([1.0, 0.0, 0.0])
+        exps = np.array([1.0, 0.5])
+        coeffs = np.array([[1.0], [1.0]])
+        s_comp = np.array([[0, 0, 0]])
+        p_comp = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+
+        result_no_screen = compute_two_electron_integrals_os_hgp(
+            boys_func,
+            coord_a, 0, s_comp, exps, coeffs,
+            coord_b, 1, p_comp, exps, coeffs,
+            coord_a, 0, s_comp, exps, coeffs,
+            coord_b, 1, p_comp, exps, coeffs,
+        )
+
+        result_screened = compute_two_electron_integrals_os_hgp(
+            boys_func,
+            coord_a, 0, s_comp, exps, coeffs,
+            coord_b, 1, p_comp, exps, coeffs,
+            coord_a, 0, s_comp, exps, coeffs,
+            coord_b, 1, p_comp, exps, coeffs,
+            primitive_threshold=0.0,
+        )
+
+        np.testing.assert_array_equal(result_no_screen, result_screened)
+
+    def test_screening_reasonable_threshold(self):
+        """With reasonable threshold, results match within tolerance."""
+        from scipy.special import hyp1f1
+
+        def boys_func(orders, weighted_dist):
+            return hyp1f1(orders + 0.5, orders + 1.5, -weighted_dist) / (2 * orders + 1)
+
+        coord_a = np.array([0.0, 0.0, 0.0])
+        coord_b = np.array([1.0, 0.0, 0.0])
+        exps = np.array([1.0, 0.5, 0.1])
+        coeffs = np.array([[1.0], [1.0], [1.0]])
+        s_comp = np.array([[0, 0, 0]])
+
+        result_no_screen = compute_two_electron_integrals_os_hgp(
+            boys_func,
+            coord_a, 0, s_comp, exps, coeffs,
+            coord_b, 0, s_comp, exps, coeffs,
+            coord_a, 0, s_comp, exps, coeffs,
+            coord_b, 0, s_comp, exps, coeffs,
+        )
+
+        result_screened = compute_two_electron_integrals_os_hgp(
+            boys_func,
+            coord_a, 0, s_comp, exps, coeffs,
+            coord_b, 0, s_comp, exps, coeffs,
+            coord_a, 0, s_comp, exps, coeffs,
+            coord_b, 0, s_comp, exps, coeffs,
+            primitive_threshold=1e-12,
+        )
+
+        np.testing.assert_allclose(result_no_screen, result_screened, atol=1e-10)
+

--- a/tests/test_two_elec_int_improved.py
+++ b/tests/test_two_elec_int_improved.py
@@ -7,6 +7,7 @@ import numpy as np
 from scipy.special import hyp1f1
 
 from gbasis.contractions import GeneralizedContractionShell
+from gbasis.integrals._schwarz_screening import SchwarzScreener
 from gbasis.integrals._two_elec_int import (
     _compute_two_elec_integrals,
     _compute_two_elec_integrals_angmom_zero,
@@ -18,7 +19,10 @@ from gbasis.integrals._two_elec_int_improved import (
     _vertical_recursion_relation,
     compute_two_electron_integrals_os_hgp,
 )
-from gbasis.integrals.electron_repulsion import ElectronRepulsionIntegralImproved
+from gbasis.integrals.electron_repulsion import (
+    ElectronRepulsionIntegralImproved,
+    electron_repulsion_integral_improved,
+)
 from gbasis.integrals.point_charge import PointChargeIntegral
 
 
@@ -697,3 +701,80 @@ class TestContractionReordering:
             rtol=1e-10,
             err_msg="Reordered (pd|sp) doesn't match direct computation",
         )
+
+
+class TestSchwarzScreening:
+    """Tests for Schwarz screening integration."""
+
+    def test_schwarz_no_effect(self):
+        """With threshold=0, results match unscreened exactly."""
+        coord_a = np.array([0.0, 0.0, 0.0])
+        coord_b = np.array([1.0, 0.0, 0.0])
+
+        shell_s = GeneralizedContractionShell(
+            0, coord_a, np.array([[1.0]]), np.array([1.0]), "cartesian"
+        )
+        shell_p = GeneralizedContractionShell(
+            1, coord_b, np.array([[1.0]]), np.array([0.8]), "cartesian"
+        )
+        basis = [shell_s, shell_p]
+
+        result_no_screen = electron_repulsion_integral_improved(basis, notation="chemist")
+        result_screened = electron_repulsion_integral_improved(
+            basis, notation="chemist", schwarz_threshold=0.0
+        )
+
+        np.testing.assert_array_equal(result_no_screen, result_screened)
+
+    def test_schwarz_screening_tight(self):
+        """With tight threshold, results match within tolerance."""
+        coord_a = np.array([0.0, 0.0, 0.0])
+        coord_b = np.array([1.0, 0.0, 0.0])
+        coord_c = np.array([0.0, 1.0, 0.0])
+
+        shell_s1 = GeneralizedContractionShell(
+            0, coord_a, np.array([[1.0]]), np.array([1.0]), "cartesian"
+        )
+        shell_s2 = GeneralizedContractionShell(
+            0, coord_b, np.array([[1.0]]), np.array([0.8]), "cartesian"
+        )
+        shell_s3 = GeneralizedContractionShell(
+            0, coord_c, np.array([[1.0]]), np.array([0.6]), "cartesian"
+        )
+        basis = [shell_s1, shell_s2, shell_s3]
+
+        result_no_screen = electron_repulsion_integral_improved(basis, notation="chemist")
+        result_screened = electron_repulsion_integral_improved(
+            basis, notation="chemist", schwarz_threshold=1e-12
+        )
+
+        np.testing.assert_allclose(result_no_screen, result_screened, atol=1e-10)
+
+    def test_schwarz_statistics(self):
+        """Verify screening statistics are tracked."""
+        shell_s1 = GeneralizedContractionShell(
+            0, np.array([0.0, 0.0, 0.0]), np.array([[1.0]]), np.array([1.0]), "cartesian"
+        )
+        shell_s2 = GeneralizedContractionShell(
+            0, np.array([100.0, 0.0, 0.0]), np.array([[1.0]]), np.array([1.0]), "cartesian"
+        )
+        shell_s3 = GeneralizedContractionShell(
+            0, np.array([0.0, 100.0, 0.0]), np.array([[1.0]]), np.array([1.0]), "cartesian"
+        )
+        basis = [shell_s1, shell_s2, shell_s3]
+
+        screener = SchwarzScreener(
+            list(basis),
+            PointChargeIntegral.boys_func,
+            compute_two_electron_integrals_os_hgp,
+            threshold=1e-10,
+        )
+        stats = screener.get_statistics()
+        # Far-apart shells should have some bounds below threshold
+        assert stats["total"] == 0  # No quartets checked yet via is_significant
+
+        # Now run full computation with screening
+        result = electron_repulsion_integral_improved(
+            basis, notation="chemist", schwarz_threshold=1e-10
+        )
+        assert np.all(np.isfinite(result))

--- a/tests/test_two_elec_int_improved.py
+++ b/tests/test_two_elec_int_improved.py
@@ -159,22 +159,22 @@ class TestFactorial2Norm:
 
     def test_s_orbital_norm(self):
         """Test normalization for s-orbital (L=0)."""
-        s_components = np.array([[0, 0, 0]])
-        norm = _get_factorial2_norm(s_components)
+        s_key = ((0, 0, 0),)
+        norm = _get_factorial2_norm(s_key)
         # (2*0-1)!! = (-1)!! = 1, so norm = 1/sqrt(1) = 1
         assert np.allclose(norm, 1.0)
 
     def test_p_orbital_norm(self):
         """Test normalization for p-orbital (L=1)."""
-        p_components = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
-        norm = _get_factorial2_norm(p_components)
+        p_key = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+        norm = _get_factorial2_norm(p_key)
         # Each component has one (2*1-1)!! = 1!! = 1 and two (2*0-1)!! = 1
         # So norm = 1/sqrt(1*1*1) = 1 for all
         assert np.allclose(norm, 1.0)
 
     def test_caching(self):
         """Test that factorial2 normalization is cached."""
-        d_components = np.array([[2, 0, 0], [1, 1, 0]])
-        norm1 = _get_factorial2_norm(d_components)
-        norm2 = _get_factorial2_norm(d_components)
+        d_key = ((2, 0, 0), (1, 1, 0))
+        norm1 = _get_factorial2_norm(d_key)
+        norm2 = _get_factorial2_norm(d_key)
         assert np.allclose(norm1, norm2)

--- a/tests/test_two_elec_int_improved.py
+++ b/tests/test_two_elec_int_improved.py
@@ -1,0 +1,183 @@
+"""Test gbasis.integrals._two_elec_int_improved module.
+
+Tests for VRR (Week 2) and ETR + contraction (Week 3).
+"""
+
+import numpy as np
+import pytest
+
+from gbasis.integrals._two_elec_int_improved import (
+    _vertical_recursion_relation,
+    _electron_transfer_recursion,
+    _optimized_contraction,
+    _get_factorial2_norm,
+)
+
+
+class TestVerticalRecursion:
+    """Tests for the Vertical Recursion Relation (VRR)."""
+
+    def test_vrr_base_case(self):
+        """Test that VRR preserves base case [00|00]^m."""
+        m_max = 4
+        n_prim = 2
+
+        # Create mock integrals_m (base case values)
+        integrals_m = np.random.rand(m_max, n_prim, n_prim, n_prim, n_prim)
+
+        # Mock coordinates and exponents
+        rel_coord_a = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
+        coord_wac = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
+        harm_mean = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
+        exps_sum_one = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
+
+        result = _vertical_recursion_relation(
+            integrals_m, m_max, rel_coord_a, coord_wac, harm_mean, exps_sum_one
+        )
+
+        # Base case should be preserved at [m, 0, 0, 0]
+        assert np.allclose(result[:, 0, 0, 0, ...], integrals_m)
+
+    def test_vrr_output_shape(self):
+        """Test that VRR output has correct shape."""
+        m_max = 5
+        n_prim = 3
+
+        integrals_m = np.zeros((m_max, n_prim, n_prim, n_prim, n_prim))
+        rel_coord_a = np.zeros((3, n_prim, n_prim, n_prim, n_prim))
+        coord_wac = np.zeros((3, n_prim, n_prim, n_prim, n_prim))
+        harm_mean = np.ones((n_prim, n_prim, n_prim, n_prim))
+        exps_sum_one = np.ones((n_prim, n_prim, n_prim, n_prim))
+
+        result = _vertical_recursion_relation(
+            integrals_m, m_max, rel_coord_a, coord_wac, harm_mean, exps_sum_one
+        )
+
+        expected_shape = (m_max, m_max, m_max, m_max, n_prim, n_prim, n_prim, n_prim)
+        assert result.shape == expected_shape
+
+    def test_vrr_p_orbital_manual(self):
+        """Test VRR first recursion step for p-orbital manually.
+
+        For p-orbital, VRR computes:
+        [1,0|00]^0 = (P-A)_x * [00|00]^0 - (rho/zeta)*(Q-P)_x * [00|00]^1
+        """
+        m_max = 2
+        integrals_m = np.array([[[[[1.0]]]],
+                                [[[[0.5]]]]])
+
+        PA_x, PA_y, PA_z = 0.3, 0.0, 0.0
+        PQ_x, PQ_y, PQ_z = 0.2, 0.0, 0.0
+        rho = 0.6
+        zeta = 1.5
+
+        rel_coord_a = np.array([[[[[PA_x]]]],
+                                [[[[PA_y]]]],
+                                [[[[PA_z]]]]])
+        coord_wac = np.array([[[[[PQ_x]]]],
+                              [[[[PQ_y]]]],
+                              [[[[PQ_z]]]]])
+        harm_mean = np.array([[[[rho]]]])
+        exps_sum_one = np.array([[[[zeta]]]])
+
+        result = _vertical_recursion_relation(
+            integrals_m, m_max, rel_coord_a, coord_wac, harm_mean, exps_sum_one
+        )
+
+        # Manual: [1,0,0|00]^0 = PA_x * [00|00]^0 - (rho/zeta)*PQ_x * [00|00]^1
+        expected = PA_x * 1.0 - (rho / zeta) * PQ_x * 0.5
+        assert np.allclose(result[0, 1, 0, 0, 0, 0, 0, 0], expected)
+
+    def test_vrr_s_orbital_no_change(self):
+        """Test VRR with s-orbital where no recursion is needed."""
+        m_max = 1
+        integrals_m = np.array([[[[[3.14]]]]])
+
+        rel_coord_a = np.zeros((3, 1, 1, 1, 1))
+        coord_wac = np.zeros((3, 1, 1, 1, 1))
+        harm_mean = np.ones((1, 1, 1, 1))
+        exps_sum_one = np.ones((1, 1, 1, 1))
+
+        result = _vertical_recursion_relation(
+            integrals_m, m_max, rel_coord_a, coord_wac, harm_mean, exps_sum_one
+        )
+
+        assert np.allclose(result[0, 0, 0, 0], 3.14)
+
+
+class TestElectronTransferRecursion:
+    """Tests for the Electron Transfer Recursion (ETR)."""
+
+    def test_etr_base_case(self):
+        """Test that ETR preserves base case (discards m, keeps a)."""
+        m_max = 4
+        m_max_c = 3
+        n_prim = 2
+
+        # Create mock VRR output
+        integrals_vert = np.random.rand(
+            m_max, m_max, m_max, m_max, n_prim, n_prim, n_prim, n_prim
+        )
+
+        rel_coord_c = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
+        rel_coord_a = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
+        exps_sum_one = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
+        exps_sum_two = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
+
+        result = _electron_transfer_recursion(
+            integrals_vert, m_max, m_max_c, rel_coord_c, rel_coord_a,
+            exps_sum_one, exps_sum_two
+        )
+
+        # Base case: [0,0,0, a_x, a_y, a_z] should equal integrals_vert[0, a_x, a_y, a_z]
+        assert np.allclose(result[0, 0, 0, ...], integrals_vert[0, ...])
+
+    def test_etr_output_shape(self):
+        """Test that ETR output has correct shape."""
+        m_max = 3
+        m_max_c = 2
+        n_prim = 2
+
+        integrals_vert = np.random.rand(
+            m_max, m_max, m_max, m_max, n_prim, n_prim, n_prim, n_prim
+        )
+
+        rel_coord_c = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
+        rel_coord_a = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
+        exps_sum_one = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
+        exps_sum_two = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
+
+        result = _electron_transfer_recursion(
+            integrals_vert, m_max, m_max_c, rel_coord_c, rel_coord_a,
+            exps_sum_one, exps_sum_two
+        )
+
+        expected_shape = (m_max_c, m_max_c, m_max_c, m_max, m_max, m_max,
+                          n_prim, n_prim, n_prim, n_prim)
+        assert result.shape == expected_shape
+
+
+class TestFactorial2Norm:
+    """Tests for the factorial2 normalization helper."""
+
+    def test_s_orbital_norm(self):
+        """Test normalization for s-orbital (L=0)."""
+        s_components = np.array([[0, 0, 0]])
+        norm = _get_factorial2_norm(s_components)
+        # (2*0-1)!! = (-1)!! = 1, so norm = 1/sqrt(1) = 1
+        assert np.allclose(norm, 1.0)
+
+    def test_p_orbital_norm(self):
+        """Test normalization for p-orbital (L=1)."""
+        p_components = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        norm = _get_factorial2_norm(p_components)
+        # Each component has one (2*1-1)!! = 1!! = 1 and two (2*0-1)!! = 1
+        # So norm = 1/sqrt(1*1*1) = 1 for all
+        assert np.allclose(norm, 1.0)
+
+    def test_caching(self):
+        """Test that factorial2 normalization is cached."""
+        d_components = np.array([[2, 0, 0], [1, 1, 0]])
+        norm1 = _get_factorial2_norm(d_components)
+        norm2 = _get_factorial2_norm(d_components)
+        assert np.allclose(norm1, norm2)

--- a/tests/test_two_elec_int_improved.py
+++ b/tests/test_two_elec_int_improved.py
@@ -6,6 +6,7 @@ Tests for VRR (Week 2), ETR + contraction (Week 3), and HRR + full pipeline (Wee
 import numpy as np
 from scipy.special import hyp1f1
 
+from gbasis.contractions import GeneralizedContractionShell
 from gbasis.integrals._two_elec_int import (
     _compute_two_elec_integrals,
     _compute_two_elec_integrals_angmom_zero,
@@ -17,6 +18,7 @@ from gbasis.integrals._two_elec_int_improved import (
     _vertical_recursion_relation,
     compute_two_electron_integrals_os_hgp,
 )
+from gbasis.integrals.electron_repulsion import ElectronRepulsionIntegralImproved
 from gbasis.integrals.point_charge import PointChargeIntegral
 
 
@@ -553,3 +555,145 @@ class TestPrimitiveScreening:
         )
 
         np.testing.assert_allclose(result_no_screen, result_screened, atol=1e-10)
+
+
+class TestContractionReordering:
+    """Tests for contraction reordering (l_a >= l_b, l_c >= l_d, l_a >= l_c)."""
+
+    def test_sp_ps_reordering(self):
+        """Test that (sp|ps) gives correct results with bra/ket swapping."""
+        coord_a = np.array([0.0, 0.0, 0.0])
+        coord_b = np.array([1.0, 0.0, 0.0])
+        coord_c = np.array([0.0, 1.0, 0.0])
+        coord_d = np.array([1.0, 1.0, 0.0])
+
+        # Create shells: s (L=0) and p (L=1)
+        shell_s_a = GeneralizedContractionShell(
+            0, coord_a, np.array([[1.0]]), np.array([1.0]), "cartesian"
+        )
+        shell_p_b = GeneralizedContractionShell(
+            1, coord_b, np.array([[1.0]]), np.array([1.0]), "cartesian"
+        )
+        shell_p_c = GeneralizedContractionShell(
+            1, coord_c, np.array([[1.0]]), np.array([1.0]), "cartesian"
+        )
+        shell_s_d = GeneralizedContractionShell(
+            0, coord_d, np.array([[1.0]]), np.array([1.0]), "cartesian"
+        )
+
+        # (sp|ps) triggers bra_swapped and ket_swapped
+        result = ElectronRepulsionIntegralImproved.construct_array_contraction(
+            shell_s_a, shell_p_b, shell_p_c, shell_s_d
+        )
+
+        # Verify result is finite and has correct shape
+        # Shape: (M_a, L_a, M_b, L_b, M_c, L_c, M_d, L_d)
+        assert result.shape == (1, 1, 1, 3, 1, 3, 1, 1)
+        assert np.all(np.isfinite(result)), "Reordered integrals contain NaN or Inf"
+
+        # Compare with direct compute (no reordering) to verify correctness
+        boys_func = PointChargeIntegral.boys_func
+
+        s_comp = np.array([[0, 0, 0]])
+        p_comp = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+
+        direct = compute_two_electron_integrals_os_hgp(
+            boys_func,
+            coord_a,
+            0,
+            s_comp,
+            np.array([1.0]),
+            np.array([[1.0]]),
+            coord_b,
+            1,
+            p_comp,
+            np.array([1.0]),
+            np.array([[1.0]]),
+            coord_c,
+            1,
+            p_comp,
+            np.array([1.0]),
+            np.array([[1.0]]),
+            coord_d,
+            0,
+            s_comp,
+            np.array([1.0]),
+            np.array([[1.0]]),
+        )
+        # direct shape: (L_a, L_b, L_c, L_d, M_a, M_b, M_c, M_d)
+        direct_transposed = np.transpose(direct, (4, 0, 5, 1, 6, 2, 7, 3))
+
+        np.testing.assert_allclose(
+            result,
+            direct_transposed,
+            rtol=1e-10,
+            err_msg="Reordered (sp|ps) doesn't match direct computation",
+        )
+
+    def test_pd_sp_braket_reordering(self):
+        """Test (pd|sp) triggers bra-ket swap as well."""
+        coord_a = np.array([0.0, 0.0, 0.0])
+        coord_b = np.array([1.0, 0.0, 0.0])
+        coord_c = np.array([0.0, 1.0, 0.0])
+        coord_d = np.array([1.0, 1.0, 0.0])
+
+        shell_p_a = GeneralizedContractionShell(
+            1, coord_a, np.array([[1.0]]), np.array([1.0]), "cartesian"
+        )
+        shell_d_b = GeneralizedContractionShell(
+            2, coord_b, np.array([[1.0]]), np.array([1.0]), "cartesian"
+        )
+        shell_s_c = GeneralizedContractionShell(
+            0, coord_c, np.array([[1.0]]), np.array([1.0]), "cartesian"
+        )
+        shell_p_d = GeneralizedContractionShell(
+            1, coord_d, np.array([[1.0]]), np.array([1.0]), "cartesian"
+        )
+
+        # (pd|sp): bra_swapped (p<d), ket_swapped (s<p), then braket_swapped (d>p, no swap)
+        result = ElectronRepulsionIntegralImproved.construct_array_contraction(
+            shell_p_a, shell_d_b, shell_s_c, shell_p_d
+        )
+
+        # Shape: (M_a, L_p, M_b, L_d, M_c, L_s, M_d, L_p)
+        assert result.shape == (1, 3, 1, 6, 1, 1, 1, 3)
+        assert np.all(np.isfinite(result)), "Reordered integrals contain NaN or Inf"
+
+        # Compare with direct (no reordering)
+        boys_func = PointChargeIntegral.boys_func
+
+        s_comp = np.array([[0, 0, 0]])
+        p_comp = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        d_comp = np.array([[2, 0, 0], [1, 1, 0], [1, 0, 1], [0, 2, 0], [0, 1, 1], [0, 0, 2]])
+
+        direct = compute_two_electron_integrals_os_hgp(
+            boys_func,
+            coord_a,
+            1,
+            p_comp,
+            np.array([1.0]),
+            np.array([[1.0]]),
+            coord_b,
+            2,
+            d_comp,
+            np.array([1.0]),
+            np.array([[1.0]]),
+            coord_c,
+            0,
+            s_comp,
+            np.array([1.0]),
+            np.array([[1.0]]),
+            coord_d,
+            1,
+            p_comp,
+            np.array([1.0]),
+            np.array([[1.0]]),
+        )
+        direct_transposed = np.transpose(direct, (4, 0, 5, 1, 6, 2, 7, 3))
+
+        np.testing.assert_allclose(
+            result,
+            direct_transposed,
+            rtol=1e-10,
+            err_msg="Reordered (pd|sp) doesn't match direct computation",
+        )

--- a/tests/test_two_elec_int_improved.py
+++ b/tests/test_two_elec_int_improved.py
@@ -4,16 +4,19 @@ Tests for VRR (Week 2), ETR + contraction (Week 3), and HRR + full pipeline (Wee
 """
 
 import numpy as np
-import pytest
+from scipy.special import hyp1f1
 
+from gbasis.integrals._two_elec_int import (
+    _compute_two_elec_integrals,
+    _compute_two_elec_integrals_angmom_zero,
+)
 from gbasis.integrals._two_elec_int_improved import (
-    _vertical_recursion_relation,
     _electron_transfer_recursion,
-    _optimized_contraction,
     _get_factorial2_norm,
-    _horizontal_recursion_relation,
+    _vertical_recursion_relation,
     compute_two_electron_integrals_os_hgp,
 )
+from gbasis.integrals.point_charge import PointChargeIntegral
 
 
 class TestVerticalRecursion:
@@ -65,20 +68,15 @@ class TestVerticalRecursion:
         [1,0|00]^0 = (P-A)_x * [00|00]^0 - (rho/zeta)*(Q-P)_x * [00|00]^1
         """
         m_max = 2
-        integrals_m = np.array([[[[[1.0]]]],
-                                [[[[0.5]]]]])
+        integrals_m = np.array([[[[[1.0]]]], [[[[0.5]]]]])
 
         PA_x, PA_y, PA_z = 0.3, 0.0, 0.0
         PQ_x, PQ_y, PQ_z = 0.2, 0.0, 0.0
         rho = 0.6
         zeta = 1.5
 
-        rel_coord_a = np.array([[[[[PA_x]]]],
-                                [[[[PA_y]]]],
-                                [[[[PA_z]]]]])
-        coord_wac = np.array([[[[[PQ_x]]]],
-                              [[[[PQ_y]]]],
-                              [[[[PQ_z]]]]])
+        rel_coord_a = np.array([[[[[PA_x]]]], [[[[PA_y]]]], [[[[PA_z]]]]])
+        coord_wac = np.array([[[[[PQ_x]]]], [[[[PQ_y]]]], [[[[PQ_z]]]]])
         harm_mean = np.array([[[[rho]]]])
         exps_sum_one = np.array([[[[zeta]]]])
 
@@ -117,9 +115,7 @@ class TestElectronTransferRecursion:
         n_prim = 2
 
         # Create mock VRR output
-        integrals_vert = np.random.rand(
-            m_max, m_max, m_max, m_max, n_prim, n_prim, n_prim, n_prim
-        )
+        integrals_vert = np.random.rand(m_max, m_max, m_max, m_max, n_prim, n_prim, n_prim, n_prim)
 
         rel_coord_c = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
         rel_coord_a = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
@@ -127,8 +123,7 @@ class TestElectronTransferRecursion:
         exps_sum_two = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
 
         result = _electron_transfer_recursion(
-            integrals_vert, m_max, m_max_c, rel_coord_c, rel_coord_a,
-            exps_sum_one, exps_sum_two
+            integrals_vert, m_max, m_max_c, rel_coord_c, rel_coord_a, exps_sum_one, exps_sum_two
         )
 
         # Base case: [0,0,0, a_x, a_y, a_z] should equal integrals_vert[0, a_x, a_y, a_z]
@@ -140,9 +135,7 @@ class TestElectronTransferRecursion:
         m_max_c = 2
         n_prim = 2
 
-        integrals_vert = np.random.rand(
-            m_max, m_max, m_max, m_max, n_prim, n_prim, n_prim, n_prim
-        )
+        integrals_vert = np.random.rand(m_max, m_max, m_max, m_max, n_prim, n_prim, n_prim, n_prim)
 
         rel_coord_c = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
         rel_coord_a = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
@@ -150,12 +143,21 @@ class TestElectronTransferRecursion:
         exps_sum_two = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
 
         result = _electron_transfer_recursion(
-            integrals_vert, m_max, m_max_c, rel_coord_c, rel_coord_a,
-            exps_sum_one, exps_sum_two
+            integrals_vert, m_max, m_max_c, rel_coord_c, rel_coord_a, exps_sum_one, exps_sum_two
         )
 
-        expected_shape = (m_max_c, m_max_c, m_max_c, m_max, m_max, m_max,
-                          n_prim, n_prim, n_prim, n_prim)
+        expected_shape = (
+            m_max_c,
+            m_max_c,
+            m_max_c,
+            m_max,
+            m_max,
+            m_max,
+            n_prim,
+            n_prim,
+            n_prim,
+            n_prim,
+        )
         assert result.shape == expected_shape
 
 
@@ -195,9 +197,6 @@ class TestImprovedVsOld:
         all-zero angular momentum, so we compare against the specialized
         _compute_two_elec_integrals_angmom_zero function instead.
         """
-        from gbasis.integrals._two_elec_int import _compute_two_elec_integrals_angmom_zero
-        from gbasis.integrals.point_charge import PointChargeIntegral
-
         boys_func = PointChargeIntegral.boys_func
 
         coord_a = np.array([0.0, 0.0, 0.0])
@@ -220,29 +219,54 @@ class TestImprovedVsOld:
         # Old implementation (specialized for angmom zero)
         result_old = _compute_two_elec_integrals_angmom_zero(
             boys_func,
-            coord_a, exps_a, coeffs_a,
-            coord_b, exps_b, coeffs_b,
-            coord_c, exps_c, coeffs_c,
-            coord_d, exps_d, coeffs_d,
+            coord_a,
+            exps_a,
+            coeffs_a,
+            coord_b,
+            exps_b,
+            coeffs_b,
+            coord_c,
+            exps_c,
+            coeffs_c,
+            coord_d,
+            exps_d,
+            coeffs_d,
         )
 
         # New implementation
         result_new = compute_two_electron_integrals_os_hgp(
             boys_func,
-            coord_a, 0, angmom_comp, exps_a, coeffs_a,
-            coord_b, 0, angmom_comp, exps_b, coeffs_b,
-            coord_c, 0, angmom_comp, exps_c, coeffs_c,
-            coord_d, 0, angmom_comp, exps_d, coeffs_d,
+            coord_a,
+            0,
+            angmom_comp,
+            exps_a,
+            coeffs_a,
+            coord_b,
+            0,
+            angmom_comp,
+            exps_b,
+            coeffs_b,
+            coord_c,
+            0,
+            angmom_comp,
+            exps_c,
+            coeffs_c,
+            coord_d,
+            0,
+            angmom_comp,
+            exps_d,
+            coeffs_d,
         )
 
-        np.testing.assert_allclose(result_new, result_old, rtol=1e-10,
-            err_msg="(ss|ss) integrals don't match between old and improved")
+        np.testing.assert_allclose(
+            result_new,
+            result_old,
+            rtol=1e-10,
+            err_msg="(ss|ss) integrals don't match between old and improved",
+        )
 
     def test_spsp_matches_old(self):
         """Test (sp|sp) integrals match old implementation."""
-        from gbasis.integrals._two_elec_int import _compute_two_elec_integrals
-        from gbasis.integrals.point_charge import PointChargeIntegral
-
         boys_func = PointChargeIntegral.boys_func
 
         coord_a = np.array([0.0, 0.0, 0.0])
@@ -268,23 +292,59 @@ class TestImprovedVsOld:
         # Old implementation
         result_old = _compute_two_elec_integrals(
             boys_func,
-            coord_a, 0, s_comp, exps_a, coeffs_a,
-            coord_b, 1, p_comp, exps_b, coeffs_b,
-            coord_c, 0, s_comp, exps_c, coeffs_c,
-            coord_d, 1, p_comp, exps_d, coeffs_d,
+            coord_a,
+            0,
+            s_comp,
+            exps_a,
+            coeffs_a,
+            coord_b,
+            1,
+            p_comp,
+            exps_b,
+            coeffs_b,
+            coord_c,
+            0,
+            s_comp,
+            exps_c,
+            coeffs_c,
+            coord_d,
+            1,
+            p_comp,
+            exps_d,
+            coeffs_d,
         )
 
         # New implementation
         result_new = compute_two_electron_integrals_os_hgp(
             boys_func,
-            coord_a, 0, s_comp, exps_a, coeffs_a,
-            coord_b, 1, p_comp, exps_b, coeffs_b,
-            coord_c, 0, s_comp, exps_c, coeffs_c,
-            coord_d, 1, p_comp, exps_d, coeffs_d,
+            coord_a,
+            0,
+            s_comp,
+            exps_a,
+            coeffs_a,
+            coord_b,
+            1,
+            p_comp,
+            exps_b,
+            coeffs_b,
+            coord_c,
+            0,
+            s_comp,
+            exps_c,
+            coeffs_c,
+            coord_d,
+            1,
+            p_comp,
+            exps_d,
+            coeffs_d,
         )
 
-        np.testing.assert_allclose(result_new, result_old, rtol=1e-10,
-            err_msg="(sp|sp) integrals don't match between old and improved")
+        np.testing.assert_allclose(
+            result_new,
+            result_old,
+            rtol=1e-10,
+            err_msg="(sp|sp) integrals don't match between old and improved",
+        )
 
 
 class TestHighAngularMomentum:
@@ -292,8 +352,6 @@ class TestHighAngularMomentum:
 
     def test_dddd_no_overflow(self):
         """Test (dd|dd) integrals produce finite values."""
-        from gbasis.integrals.point_charge import PointChargeIntegral
-
         boys_func = PointChargeIntegral.boys_func
 
         coord_a = np.array([0.0, 0.0, 0.0])
@@ -305,17 +363,30 @@ class TestHighAngularMomentum:
         coeffs = np.array([[1.0]])
 
         # d-orbital components (L=2): xx, xy, xz, yy, yz, zz
-        d_comp = np.array([
-            [2, 0, 0], [1, 1, 0], [1, 0, 1],
-            [0, 2, 0], [0, 1, 1], [0, 0, 2]
-        ])
+        d_comp = np.array([[2, 0, 0], [1, 1, 0], [1, 0, 1], [0, 2, 0], [0, 1, 1], [0, 0, 2]])
 
         result = compute_two_electron_integrals_os_hgp(
             boys_func,
-            coord_a, 2, d_comp, exps, coeffs,
-            coord_b, 2, d_comp, exps, coeffs,
-            coord_c, 2, d_comp, exps, coeffs,
-            coord_d, 2, d_comp, exps, coeffs,
+            coord_a,
+            2,
+            d_comp,
+            exps,
+            coeffs,
+            coord_b,
+            2,
+            d_comp,
+            exps,
+            coeffs,
+            coord_c,
+            2,
+            d_comp,
+            exps,
+            coeffs,
+            coord_d,
+            2,
+            d_comp,
+            exps,
+            coeffs,
         )
 
         assert np.all(np.isfinite(result)), "d-orbital integrals contain NaN or Inf"
@@ -327,7 +398,6 @@ class TestPrimitiveScreening:
 
     def test_screening_zero_threshold(self):
         """With threshold=0, results match unscreened exactly."""
-        from scipy.special import hyp1f1
 
         def boys_func(orders, weighted_dist):
             return hyp1f1(orders + 0.5, orders + 1.5, -weighted_dist) / (2 * orders + 1)
@@ -341,18 +411,50 @@ class TestPrimitiveScreening:
 
         result_no_screen = compute_two_electron_integrals_os_hgp(
             boys_func,
-            coord_a, 0, s_comp, exps, coeffs,
-            coord_b, 1, p_comp, exps, coeffs,
-            coord_a, 0, s_comp, exps, coeffs,
-            coord_b, 1, p_comp, exps, coeffs,
+            coord_a,
+            0,
+            s_comp,
+            exps,
+            coeffs,
+            coord_b,
+            1,
+            p_comp,
+            exps,
+            coeffs,
+            coord_a,
+            0,
+            s_comp,
+            exps,
+            coeffs,
+            coord_b,
+            1,
+            p_comp,
+            exps,
+            coeffs,
         )
 
         result_screened = compute_two_electron_integrals_os_hgp(
             boys_func,
-            coord_a, 0, s_comp, exps, coeffs,
-            coord_b, 1, p_comp, exps, coeffs,
-            coord_a, 0, s_comp, exps, coeffs,
-            coord_b, 1, p_comp, exps, coeffs,
+            coord_a,
+            0,
+            s_comp,
+            exps,
+            coeffs,
+            coord_b,
+            1,
+            p_comp,
+            exps,
+            coeffs,
+            coord_a,
+            0,
+            s_comp,
+            exps,
+            coeffs,
+            coord_b,
+            1,
+            p_comp,
+            exps,
+            coeffs,
             primitive_threshold=0.0,
         )
 
@@ -360,7 +462,6 @@ class TestPrimitiveScreening:
 
     def test_screening_reasonable_threshold(self):
         """With reasonable threshold, results match within tolerance."""
-        from scipy.special import hyp1f1
 
         def boys_func(orders, weighted_dist):
             return hyp1f1(orders + 0.5, orders + 1.5, -weighted_dist) / (2 * orders + 1)
@@ -373,20 +474,51 @@ class TestPrimitiveScreening:
 
         result_no_screen = compute_two_electron_integrals_os_hgp(
             boys_func,
-            coord_a, 0, s_comp, exps, coeffs,
-            coord_b, 0, s_comp, exps, coeffs,
-            coord_a, 0, s_comp, exps, coeffs,
-            coord_b, 0, s_comp, exps, coeffs,
+            coord_a,
+            0,
+            s_comp,
+            exps,
+            coeffs,
+            coord_b,
+            0,
+            s_comp,
+            exps,
+            coeffs,
+            coord_a,
+            0,
+            s_comp,
+            exps,
+            coeffs,
+            coord_b,
+            0,
+            s_comp,
+            exps,
+            coeffs,
         )
 
         result_screened = compute_two_electron_integrals_os_hgp(
             boys_func,
-            coord_a, 0, s_comp, exps, coeffs,
-            coord_b, 0, s_comp, exps, coeffs,
-            coord_a, 0, s_comp, exps, coeffs,
-            coord_b, 0, s_comp, exps, coeffs,
+            coord_a,
+            0,
+            s_comp,
+            exps,
+            coeffs,
+            coord_b,
+            0,
+            s_comp,
+            exps,
+            coeffs,
+            coord_a,
+            0,
+            s_comp,
+            exps,
+            coeffs,
+            coord_b,
+            0,
+            s_comp,
+            exps,
+            coeffs,
             primitive_threshold=1e-12,
         )
 
         np.testing.assert_allclose(result_no_screen, result_screened, atol=1e-10)
-

--- a/tests/test_two_elec_int_improved.py
+++ b/tests/test_two_elec_int_improved.py
@@ -8,6 +8,7 @@ import numpy as np
 from gbasis.integrals._two_elec_int_improved import (
     _electron_transfer_recursion,
     _get_factorial2_norm,
+    _optimized_contraction,
     _vertical_recursion_relation,
 )
 
@@ -151,6 +152,36 @@ class TestElectronTransferRecursion:
             n_prim,
             n_prim,
         )
+        assert result.shape == expected_shape
+
+
+class TestOptimizedContraction:
+    """Tests for the optimized primitive contraction."""
+
+    def test_output_shape(self):
+        """Test that contraction output has correct shape."""
+        K, M = 2, 3
+        integrals_etransf = np.random.rand(1, 1, 1, 1, 1, 1, K, K, K, K)
+        exps = np.random.rand(4, K) + 0.1
+        coeffs = np.random.rand(4, K, M)
+        angmoms = np.array([0, 0, 0, 0])
+
+        result = _optimized_contraction(integrals_etransf, exps, coeffs, angmoms)
+
+        expected_shape = (1, 1, 1, 1, 1, 1, M, M, M, M)
+        assert result.shape == expected_shape
+
+    def test_accepts_tuples(self):
+        """Test that contraction accepts tuples as well as arrays."""
+        K, M = 2, 2
+        integrals_etransf = np.random.rand(1, 1, 1, 1, 1, 1, K, K, K, K)
+        exps = tuple(np.random.rand(K) + 0.1 for _ in range(4))
+        coeffs = tuple(np.random.rand(K, M) for _ in range(4))
+        angmoms = (0, 0, 0, 0)
+
+        result = _optimized_contraction(integrals_etransf, exps, coeffs, angmoms)
+
+        expected_shape = (1, 1, 1, 1, 1, 1, M, M, M, M)
         assert result.shape == expected_shape
 
 

--- a/tests/test_two_elec_int_improved.py
+++ b/tests/test_two_elec_int_improved.py
@@ -4,13 +4,11 @@ Tests for VRR (Week 2) and ETR + contraction (Week 3).
 """
 
 import numpy as np
-import pytest
 
 from gbasis.integrals._two_elec_int_improved import (
-    _vertical_recursion_relation,
     _electron_transfer_recursion,
-    _optimized_contraction,
     _get_factorial2_norm,
+    _vertical_recursion_relation,
 )
 
 
@@ -63,20 +61,15 @@ class TestVerticalRecursion:
         [1,0|00]^0 = (P-A)_x * [00|00]^0 - (rho/zeta)*(Q-P)_x * [00|00]^1
         """
         m_max = 2
-        integrals_m = np.array([[[[[1.0]]]],
-                                [[[[0.5]]]]])
+        integrals_m = np.array([[[[[1.0]]]], [[[[0.5]]]]])
 
         PA_x, PA_y, PA_z = 0.3, 0.0, 0.0
         PQ_x, PQ_y, PQ_z = 0.2, 0.0, 0.0
         rho = 0.6
         zeta = 1.5
 
-        rel_coord_a = np.array([[[[[PA_x]]]],
-                                [[[[PA_y]]]],
-                                [[[[PA_z]]]]])
-        coord_wac = np.array([[[[[PQ_x]]]],
-                              [[[[PQ_y]]]],
-                              [[[[PQ_z]]]]])
+        rel_coord_a = np.array([[[[[PA_x]]]], [[[[PA_y]]]], [[[[PA_z]]]]])
+        coord_wac = np.array([[[[[PQ_x]]]], [[[[PQ_y]]]], [[[[PQ_z]]]]])
         harm_mean = np.array([[[[rho]]]])
         exps_sum_one = np.array([[[[zeta]]]])
 
@@ -115,9 +108,7 @@ class TestElectronTransferRecursion:
         n_prim = 2
 
         # Create mock VRR output
-        integrals_vert = np.random.rand(
-            m_max, m_max, m_max, m_max, n_prim, n_prim, n_prim, n_prim
-        )
+        integrals_vert = np.random.rand(m_max, m_max, m_max, m_max, n_prim, n_prim, n_prim, n_prim)
 
         rel_coord_c = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
         rel_coord_a = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
@@ -125,8 +116,7 @@ class TestElectronTransferRecursion:
         exps_sum_two = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
 
         result = _electron_transfer_recursion(
-            integrals_vert, m_max, m_max_c, rel_coord_c, rel_coord_a,
-            exps_sum_one, exps_sum_two
+            integrals_vert, m_max, m_max_c, rel_coord_c, rel_coord_a, exps_sum_one, exps_sum_two
         )
 
         # Base case: [0,0,0, a_x, a_y, a_z] should equal integrals_vert[0, a_x, a_y, a_z]
@@ -138,9 +128,7 @@ class TestElectronTransferRecursion:
         m_max_c = 2
         n_prim = 2
 
-        integrals_vert = np.random.rand(
-            m_max, m_max, m_max, m_max, n_prim, n_prim, n_prim, n_prim
-        )
+        integrals_vert = np.random.rand(m_max, m_max, m_max, m_max, n_prim, n_prim, n_prim, n_prim)
 
         rel_coord_c = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
         rel_coord_a = np.random.rand(3, n_prim, n_prim, n_prim, n_prim)
@@ -148,12 +136,21 @@ class TestElectronTransferRecursion:
         exps_sum_two = np.random.rand(n_prim, n_prim, n_prim, n_prim) + 0.1
 
         result = _electron_transfer_recursion(
-            integrals_vert, m_max, m_max_c, rel_coord_c, rel_coord_a,
-            exps_sum_one, exps_sum_two
+            integrals_vert, m_max, m_max_c, rel_coord_c, rel_coord_a, exps_sum_one, exps_sum_two
         )
 
-        expected_shape = (m_max_c, m_max_c, m_max_c, m_max, m_max, m_max,
-                          n_prim, n_prim, n_prim, n_prim)
+        expected_shape = (
+            m_max_c,
+            m_max_c,
+            m_max_c,
+            m_max,
+            m_max,
+            m_max,
+            n_prim,
+            n_prim,
+            n_prim,
+            n_prim,
+        )
         assert result.shape == expected_shape
 
 


### PR DESCRIPTION
## Summary
- Implemented `SchwarzScreener` class — uses Schwarz inequality to skip negligible two-electron integrals before computing them
- Implemented shell-pair prescreening — uses Gaussian decay factor `exp(-a*b/(a+b) * |A-B|^2)` to skip distant shell pairs
- Integrated Schwarz screening into `electron_repulsion_integral_improved()` via `schwarz_threshold` parameter (default `0.0` = disabled)
- Part of Issue [WoC: 2-electron integrals: better performance and more flexibility #221](https://github.com/theochem/gbasis/issues/221) (Week 7),
- builds on PR [\[PR-5\] feat: integrate OS+HGP algorithm into electron repulsion module #239](https://github.com/theochem/gbasis/pull/239) (OS+HGP integration)

## What Changed

| File | Lines | What |
|------|-------|------|
| `gbasis/integrals/_schwarz_screening.py` | +218 | New module: `compute_schwarz_bound_shell_pair`, `compute_schwarz_bounds`, `shell_pair_significant`, `SchwarzScreener` class with `is_significant()` and `get_statistics()` |
| `gbasis/integrals/electron_repulsion.py` | +67 | Added `_screener` and `_contraction_index_map` class attributes to `ElectronRepulsionIntegralImproved`, Schwarz screening block in `construct_array_contraction`, `schwarz_threshold` parameter in `electron_repulsion_integral_improved()` |
| `tests/test_schwarz_screening.py` | +460 | 23 tests: `TestShellPairPrescreening`, `TestSchwarzBounds`, `TestSchwarzScreener`, `TestScreeningCorrectness`, `TestBenchmarkImprovedAlgorithm` |
| `tests/test_two_elec_int_improved.py` | +83 | Added `TestSchwarzScreening` class: `test_schwarz_no_effect`, `test_schwarz_screening_tight`, `test_schwarz_statistics` |

## Mathematical Reference

The Schwarz inequality for electron repulsion integrals:

$$|(\mu\nu|\lambda\sigma)| \leq \sqrt{(\mu\nu|\mu\nu)} \cdot \sqrt{(\lambda\sigma|\lambda\sigma)}$$

If $\sqrt{(\mu\nu|\mu\nu)} \cdot \sqrt{(\lambda\sigma|\lambda\sigma)} < \tau$, the quartet $(\mu\nu|\lambda\sigma)$ is skipped.

Shell-pair prescreening uses the Gaussian product decay factor:

$$\exp\left(-\frac{ab}{a+b}|\mathbf{A}-\mathbf{B}|^2\right)$$

**References:**
- Häser, M. & Ahlrichs, R. *J. Comput. Chem.* **1989**, 10, 104.
- Gill, P. M. W.; Johnson, B. G.; Pople, J. A. *Int. J. Quantum Chem.* **1991**, 40, 745.

## How To Test

```bash
# Schwarz screening unit tests
python -m pytest tests/test_schwarz_screening.py -v

# Integration tests (includes TestSchwarzScreening)
python -m pytest tests/test_two_elec_int_improved.py -v

# All 44 tests together
python -m pytest tests/test_schwarz_screening.py tests/test_two_elec_int_improved.py -v

# Coverage
python -m pytest tests/test_schwarz_screening.py tests/test_two_elec_int_improved.py --cov=gbasis/integrals --cov-report=term-missing
```

## Proof That It Works

###  Unit tests (SchwarzScreener) 
<img width="1836" height="778" alt="image" src="https://github.com/user-attachments/assets/12b7ac14-8629-40d0-89d4-3d99fca522f2" />

###  Integration tests (screening inside ERI computation) 
<img width="1836" height="778" alt="image" src="https://github.com/user-attachments/assets/63a7538e-878c-4438-898f-c65c020653c4" />

###  All 44 tests 

<img width="1850" height="961" alt="image" src="https://github.com/user-attachments/assets/1e0e9c0e-1051-47f1-b0cb-20b7e55c4b93" />

### Coverage
<img width="1850" height="961" alt="image" src="https://github.com/user-attachments/assets/97b8c9ef-f51e-4f80-aea1-b6030974b2f4" />


###  black & ruff 
<img width="1855" height="257" alt="image" src="https://github.com/user-attachments/assets/a9f05f5c-df80-4399-a1ff-aa0d512189dd" />


## First Checklist

- ✅ Tests added for each new function
- ✅ All 44 tests pass
- ✅ Black formatted
- ✅ Ruff linting clean
- ✅ Existing tests not broken
- ✅ Docstrings in numpydoc format
- ✅ No new dependencies added (uses existing numpy)
- ✅ Pure Python only (no C/Fortran)

## Scope Of this PR

- Implements Schwarz screening as optional optimization for `electron_repulsion_integral_improved()`
- Adds `SchwarzScreener` class with precomputed bounds matrix and statistics tracking
- Does **not** modify existing `electron_repulsion_integral()` — only improved version gets screening
- Screening is opt-in via `schwarz_threshold` parameter — default `0.0` disables it (backward compatible)
- Week 7 deliverable building on OS+HGP pipeline (PR #239)

## Second Checklist

- ✅ Write a good description of what the PR does.
- ✅ Add tests for each unit of code added (e.g. function, class)
- ☐ Update documentation
- ☐ Squash commits that can be grouped together
- ☐ Rebase onto master

## Type of Changes

| Type | Checked |
|------|---------|
| 🐛 Bug fix | |
| ✨ New feature | ✓ |
| 🔨 Refactoring | |
| 📜 Docs | |
### 