### PR TITLE
fix: correct compute_contraction_upper_bond typo

### DIFF
--- a/gbasis/screening.py
+++ b/gbasis/screening.py
@@ -159,7 +159,7 @@ def compute_primitive_cutoff_radius(c, alpha, angm, deriv_order, tol_screen):
     return np.sqrt(-(eff_angm / (2 * alpha)) * lambertw(lambert_input_value, k=-1).real)
 
 # TODO: Fix this, it fails for some reason, it is needed for screening of 1rdms
-def compute_contraction_upper_bond(contractions, deriv_order):
+def compute_contraction_upper_bound(contractions, deriv_order):
     r"""Compute an upper bound for a contraction or its derivatives for any point.
 
     The upper bound for a contraction or its Cartesian derivative at any point is given by the

--- a/tests/test_screening.py
+++ b/tests/test_screening.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 from gbasis.parsers import make_contractions, parse_nwchem
 from gbasis.screening import is_two_index_overlap_screened, compute_primitive_upper_bound
-from gbasis.screening import compute_primitive_cutoff_radius, compute_contraction_upper_bond
+from gbasis.screening import compute_primitive_cutoff_radius, compute_contraction_upper_bound
 from gbasis.evals.eval_deriv import _eval_deriv_contractions
 from gbasis.utils import factorial2
 from utils import find_datafile
@@ -106,7 +106,7 @@ def test_compute_compute_primitive_upper_bound():
 
 @pytest.mark.skip(reason="The implementation fails for some reason")
 @pytest.mark.parametrize("deriv_order", [0, 2])
-def test_compute_contraction_upper_bond(deriv_order):
+def test_compute_contraction_upper_bound(deriv_order):
     """Test the computation of the contraction upper bound."""
 
     atcoord = np.array([[0.0, 0.0, 0.0]])
@@ -118,7 +118,7 @@ def test_compute_contraction_upper_bond(deriv_order):
 
     basis = get_atom_contractions_data("O", atcoord)
     for contractions in basis:
-        computed_upper_bound = compute_contraction_upper_bond(contractions, deriv_order=deriv_order)
+        computed_upper_bound = compute_contraction_upper_bound(contractions, deriv_order=deriv_order)
         alphas = contractions.exps
         prim_coeffs = contractions.coeffs
         angmom_comps = contractions.angmom_components_cart


### PR DESCRIPTION
@FarnazH 
This PR fixes a typo in the function name `compute_contraction_upper_bond` located in gbasis/screening.py . It has been correctly renamed to` compute_contraction_upper_bound `.
All corresponding imports and usages, specifically in `tests/test_screening.py` , have also been updated to reflect the new spelling.

closes #243