### PR TITLE
WIP: Implement cibuildwheel pipeline for libcint distribution

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,0 +1,23 @@
+name: GBasis Build Wheels Prototype
+
+on:
+  workflow_dispatch: # This allows you to trigger the build manually from GitHub
+
+jobs:
+  build_wheels:
+    name: Build wheels on ubuntu-latest
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.22.0
+        env:
+          # For our prototype, we will just target Python 3.11 on Linux
+          CIBW_BUILD: cp311-manylinux_x86_64
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: gbasis-wheels
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,7 +1,7 @@
 name: GBasis Build Wheels Prototype
 
 on:
-  workflow_dispatch: # This allows you to trigger the build manually from GitHub
+  workflow_dispatch:
 
 jobs:
   build_wheels:
@@ -14,8 +14,15 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.22.0
         env:
-          # For our prototype, we will just target Python 3.11 on Linux
           CIBW_BUILD: cp311-manylinux_x86_64
+          CIBW_BUILD_VERBOSITY: 1
+          CIBW_BEFORE_ALL: >
+            yum install -y cmake git &&
+            git clone https://github.com/sunqm/libcint.git &&
+            cd libcint &&
+            mkdir build && cd build &&
+            cmake -DCMAKE_INSTALL_PREFIX=/usr .. &&
+            make && make install
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Addresses #229 

### Description
This is a Draft PR to prototype an automated `cibuildwheel` pipeline via GitHub Actions. The goal is to solve the PyPi distribution issues by compiling `libcint` inside isolated manylinux/mac/windows runners and generating pre-compiled wheels.

### Current Progress
- [x] Initialized `cibuildwheel` workflow.
- [x] Configured `CIBW_BEFORE_ALL` to install CMake and build `libcint` from source inside the runner environment before the Python build process begins.
- [ ] Verify successful Linux `.whl` generation.
- [ ] Expand matrix to Windows and macOS runners.
- [ ] Establish Python/C interface standardization for new integrals.

### Note to Mentors
I am opening this as a draft to share my progress on the GSoC 2026 Issue #229. I am currently monitoring the runner logs to ensure the CMake linking step correctly exposes the C-headers to the GBasis setup process. Feedback on the build strategy is highly appreciated!