### PR TITLE
PR[1]: build: migrate from setuptools to scikit-build-core

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -33,7 +33,7 @@ jobs:
         if: ${{ matrix.py == '3.9'}}
         # Ensure these versions are consistent with the minimal version requirements
         # in pyproject.toml
-        run: pip install numpy==2.0 scipy==1.11.1
+        run: pip install numpy==2.0 scipy==1.13.0
       - name: Install development version
         run: |
           # Need editable mode in order to include the test files

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -33,7 +33,7 @@ jobs:
         if: ${{ matrix.py == '3.9'}}
         # Ensure these versions are consistent with the minimal version requirements
         # in pyproject.toml
-        run: pip install numpy==1.22 scipy==1.11.1
+        run: pip install numpy==2.0 scipy==1.11.1
       - name: Install development version
         run: |
           # Need editable mode in order to include the test files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,94 @@
+# CMakeLists.txt — Build C extension for GBasis libcint integration  (Issue: #229)
+
+# Usage:
+#   Default (all platforms):  pip install gbasis
+#   qcint (x86+AVX2 only):   pip install gbasis -C cmake.args="-DUSE_QCINT=ON"
+
+
+cmake_minimum_required(VERSION 3.17)
+project(gbasis_libcint C)
+
+# Python and NumPy are required to build the C extension module
+
+find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
+find_package(Python COMPONENTS NumPy REQUIRED)
+
+# Get NumPy include path for C extension (numpy/arrayobject.h)
+
+execute_process(
+    COMMAND "${Python_EXECUTABLE}" "-c"
+            "import numpy; print(numpy.get_include())"
+    OUTPUT_VARIABLE NumPy_INCLUDE_DIRS
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# ── Platform Detection — x86 vs ARM ──────────────────────
+# Detect platform: use qcint on x86+AVX2, libcint on ARM/non-AVX
+# qcint is an optimized version of libcint for x86 with SIMD support
+include(CheckCCompilerFlag)
+check_c_compiler_flag("-mavx2" HAS_AVX2)
+
+if(HAS_AVX2 AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
+    set(USE_QCINT ON)
+    message(STATUS "Architecture: x86 + AVX2 detected → use qcint")
+else()
+    set(USE_QCINT OFF)
+    message(STATUS "Architecture: ARM/non-AVX detected → use libcint")
+endif()
+
+# ── FetchContent — libcint ya qcint download karo ─────────
+
+# Download libcint or qcint based on platform detection
+# Both are pinned to v6.1.2 for stability
+# qcint: optimized for x86+AVX2
+# libcint: generic, works on all platforms
+
+include(FetchContent)
+
+if(USE_QCINT)
+    FetchContent_Declare(
+        libcint
+        GIT_REPOSITORY https://github.com/sunqm/qcint.git
+        GIT_TAG        v6.1.2
+    )
+else()
+    FetchContent_Declare(
+        libcint
+        GIT_REPOSITORY https://github.com/sunqm/libcint.git
+        GIT_TAG        v6.1.2
+    )
+endif()
+
+# Compile libcint — Fortran disabled, range-separated Coulomb enabled
+
+set(WITH_FORTRAN OFF CACHE BOOL "" FORCE)
+# Enable range-separated Coulomb integrals
+set(WITH_RANGE_COULOMB ON CACHE BOOL "" FORCE)
+
+# Redirect libcint's install to build directory to avoid permission issues
+set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/local" CACHE PATH "" FORCE)
+set(SKIP_INSTALL_ALL ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(libcint)
+
+# Build Python C extension module from libcint_wrap.c
+python_add_library(libcint_bindings MODULE
+    gbasis/integrals/src/libcint_wrap.c
+    WITH_SOABI
+)
+
+# Include NumPy and libcint headers
+target_include_directories(libcint_bindings PRIVATE
+    ${NumPy_INCLUDE_DIRS}
+    ${libcint_SOURCE_DIR}/include
+)
+
+# Link C extension with libcint
+target_link_libraries(libcint_bindings PRIVATE cint)
+
+# Prevent libcint from installing to system directories
+set(CINT_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/cint_install CACHE PATH "" FORCE)
+
+# Install only the Python extension into the wheel
+install(TARGETS libcint_bindings
+    LIBRARY DESTINATION ${SKBUILD_PLATLIB_DIR}/gbasis/integrals/lib
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 # CMakeLists.txt — Build C extension for GBasis libcint integration  (Issue: #229)
 
 # Usage:
-#   Default (all platforms):  pip install gbasis
-#   qcint (x86+AVX2 only):   pip install gbasis -C cmake.args="-DUSE_QCINT=ON"
+#   Default (all platforms):  pip install qc-gbasis
+#   qcint (x86+AVX2 only):   pip install qc-gbasis -C cmake.args="-DUSE_QCINT=ON"
 
 
 cmake_minimum_required(VERSION 3.17)
@@ -26,14 +26,22 @@ execute_process(
 # Detect platform: use qcint on x86+AVX2, libcint on ARM/non-AVX
 # qcint is an optimized version of libcint for x86 with SIMD support
 include(CheckCCompilerFlag)
-check_c_compiler_flag("-mavx2" HAS_AVX2)
 
-if(HAS_AVX2 AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
-    set(USE_QCINT ON)
-    message(STATUS "Architecture: x86 + AVX2 detected → use qcint")
+if(MSVC)
+    check_c_compiler_flag("/arch:AVX2" HAS_AVX2)
 else()
-    set(USE_QCINT OFF)
-    message(STATUS "Architecture: ARM/non-AVX detected → use libcint")
+    check_c_compiler_flag("-mavx2" HAS_AVX2)
+endif()
+
+# Respect user override via -DUSE_QCINT=ON/OFF; otherwise auto-detect
+if(NOT DEFINED USE_QCINT)
+    if(HAS_AVX2 AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
+        set(USE_QCINT ON CACHE BOOL "Use qcint instead of libcint" FORCE)
+        message(STATUS "Architecture: x86 + AVX2 detected — use qcint")
+    else()
+        set(USE_QCINT OFF CACHE BOOL "Use qcint instead of libcint" FORCE)
+        message(STATUS "Architecture: ARM/non-AVX detected — use libcint")
+    endif()
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,6 @@ else()
     message(STATUS "Architecture: ARM/non-AVX detected → use libcint")
 endif()
 
-# ── FetchContent — libcint ya qcint download karo ─────────
 
 # Download libcint or qcint based on platform detection
 # Both are pinned to v6.1.2 for stability

--- a/gbasis/integrals/src/libcint_wrap.c
+++ b/gbasis/integrals/src/libcint_wrap.c
@@ -1,4 +1,6 @@
 
-/* libcint Python/C API bindings
- * PR 3 mein implement hoga
- */
+
+ /* libcint Python/C API bindings.
+  * The full bindings will be implemented in a follow-up PR.
+  */
+  

--- a/gbasis/integrals/src/libcint_wrap.c
+++ b/gbasis/integrals/src/libcint_wrap.c
@@ -1,0 +1,4 @@
+
+/* libcint Python/C API bindings
+ * PR 3 mein implement hoga
+ */

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # as part of the Python wheel build
 
 [build-system]
-requires = ["numpy>=2.0", "scikit-build-core>=0.9"]
+requires = ["numpy>=2.0", "scikit-build-core>=0.9","setuptools-scm>=8"]
 build-backend = "scikit_build_core.build"
 
 
@@ -40,7 +40,7 @@ dependencies = [
     # Updated to numpy>=2.0 required for scikit-build-core C extension support
     # Note: Keep consistent with .github/workflows/pytest.yaml
     "numpy>=2.0",
-    "scipy>=1.11.1",
+    "scipy>=1.13.0",
     "importlib_resources",
     "sympy",
 ]
@@ -67,7 +67,7 @@ provider = "scikit_build_core.metadata.setuptools_scm"
 
 [project.optional-dependencies]
 
-# Install with: pip install gbasis[dev]
+# Install with: pip install qc-gbasis[dev]
 
 dev = [
     "tox",
@@ -83,7 +83,7 @@ dev = [
     "sphinx-copybutton",
 ]
 
-# Install with: pip install gbasis[doc]
+# Install with: pip install qc-gbasis[doc]
 
 doc = [
     "numpydoc",
@@ -100,13 +100,13 @@ doc = [
 #  "qc-iodata@git+https://github.com/theochem/iodata.git@main"
 # ]
 
-# Install with: pip install gbasis[iodata]
+# Install with: pip install qc-gbasis[iodata]
 
 iodata = [
     "qc-iodata>=1.0.0a5"
 ]
 
-# Install with: pip install gbasis[pyscf]
+# Install with: pip install qc-gbasis[pyscf]
 
 pyscf = [
     "pyscf>=1.6.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,12 @@
+# Replaced setuptools with scikit-build-core
+# Reason: setuptools cannot compile C code or call CMake
+# scikit-build-core can call CMake which will compile libcint
+
 [build-system]
 requires = ["numpy>=2.0", "scikit-build-core>=0.9"]
 build-backend = "scikit_build_core.build"
+
+
 
 [project]
 name = "qc-gbasis"
@@ -31,6 +37,8 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
+    # Updated to numpy>=2.0 required for scikit-build-core C extension support
+    # Note: Keep consistent with .github/workflows/pytest.yaml
     "numpy>=2.0",
     "scipy>=1.11.1",
     "importlib_resources",
@@ -39,15 +47,28 @@ dependencies = [
 dynamic = ["version"]
 
 [tool.scikit-build]
+# Build type: Release for optimized production build (no debug symbols)
 cmake.build-type = "Release"
+
+# Replaces [tool.setuptools.packages.find] from old setuptools config
+# Only pack gbasis folder in the wheel
 wheel.packages = ["gbasis"]
 
+
+
 [tool.scikit-build.metadata.version]
+# Automatically get version from git tags via setuptools_scm
 provider = "scikit_build_core.metadata.setuptools_scm"
 
+# Required to activate setuptools_scm for automatic versioning from git tags
 [tool.setuptools_scm]
 
+
+
 [project.optional-dependencies]
+
+# Install with: pip install gbasis[dev]
+
 dev = [
     "tox",
     "pre-commit",
@@ -61,6 +82,9 @@ dev = [
     "sphinx_autodoc_typehints",
     "sphinx-copybutton",
 ]
+
+# Install with: pip install gbasis[doc]
+
 doc = [
     "numpydoc",
     "sphinx_copybutton",
@@ -68,15 +92,26 @@ doc = [
     "nbsphinx",
     "sphinx_rtd_theme",
     "sphinx_autodoc_typehints",
-    "docutils==0.16",
+    "docutils==0.16", # Needed to show bullet points in sphinx_rtd_theme
     "nbsphinx-link"
 ]
+
+# iodata = [
+#  "qc-iodata@git+https://github.com/theochem/iodata.git@main"
+# ]
+
+# Install with: pip install gbasis[iodata]
+
 iodata = [
     "qc-iodata>=1.0.0a5"
 ]
+
+# Install with: pip install gbasis[pyscf]
+
 pyscf = [
     "pyscf>=1.6.1"
 ]
+
 
 [project.urls]
 Documentation = "https://gbasis.qcdevs.org"
@@ -89,6 +124,14 @@ Organization = "https://github.com/theochem/"
 line-length = 100
 
 [tool.ruff]
+# E is pycodestyle
+# F is pyflakes
+# UP is pyupgrade - automatically updates syntax
+# B is flake8-bugbear
+# I is sort imports alphabetically
+# PGH is pygrep-hooks
+# PL is pylint
+# RUF is Ruff-specific rules
 select = ["E", "F", "UP", "B", "I", "PGH", "PL", "RUF"]
 line-length = 100
 ignore = ["PLR2004", "PLR0913", "PLR0912", "PLW2901", "PLR0915", "RUF013"]
@@ -98,3 +141,8 @@ extend-exclude = ["doc/*", "doc/*/*"]
 minversion = "7.0"
 testpaths = ["tests"]
 addopts = "-v"
+
+#[tool.setuptools_scm]
+#write_to = "src/gbasis/_version.py"
+#version_scheme = "post-release"
+#local_scheme = "no-local-version"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=64", "setuptools-scm>=8"]
-build-backend = "setuptools.build_meta"
+requires = ["numpy>=2.0", "scikit-build-core>=0.9"]
+build-backend = "scikit_build_core.build"
 
 [project]
 name = "qc-gbasis"
@@ -31,14 +31,19 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    # Ensure the minimal versions are kept consistent with those in .github/workflows/pytest.yaml
-    "numpy >=1.22, <2.0.0; platform_system=='Windows'",
-    "numpy >=1.22; platform_system=='Linux'",
+    "numpy>=2.0",
     "scipy>=1.11.1",
     "importlib_resources",
     "sympy",
 ]
 dynamic = ["version"]
+
+[tool.scikit-build]
+cmake.build-type = "Release"
+wheel.packages = ["gbasis"]
+
+[tool.scikit-build.metadata.version]
+provider = "scikit_build_core.metadata.setuptools_scm"
 
 [tool.setuptools_scm]
 
@@ -63,22 +68,15 @@ doc = [
     "nbsphinx",
     "sphinx_rtd_theme",
     "sphinx_autodoc_typehints",
-    "docutils==0.16",  # Needed to show bullet points in sphinx_rtd_theme
+    "docutils==0.16",
     "nbsphinx-link"
 ]
-# iodata = [
-#  "qc-iodata@git+https://github.com/theochem/iodata.git@main"
-# ]
 iodata = [
     "qc-iodata>=1.0.0a5"
 ]
 pyscf = [
     "pyscf>=1.6.1"
 ]
-
-[tool.setuptools.packages.find]
-where = ["."]  # list of folders that contain the packages (["."] by default)
-include = ["gbasis"]  # package names should match these glob patterns (["*"] by default)
 
 [project.urls]
 Documentation = "https://gbasis.qcdevs.org"
@@ -91,14 +89,6 @@ Organization = "https://github.com/theochem/"
 line-length = 100
 
 [tool.ruff]
-# E is pycodestyle
-# F is pyflakes
-# UP is pyupgrade - automatically updates syntax
-# B is flake8-bugbear
-# I is sort imports alphabetically
-# PGH is pygrep-hooks
-# PL is pylint
-# RUF is Ruff-specific rules
 select = ["E", "F", "UP", "B", "I", "PGH", "PL", "RUF"]
 line-length = 100
 ignore = ["PLR2004", "PLR0913", "PLR0912", "PLW2901", "PLR0915", "RUF013"]
@@ -108,11 +98,3 @@ extend-exclude = ["doc/*", "doc/*/*"]
 minversion = "7.0"
 testpaths = ["tests"]
 addopts = "-v"
-
-#[tool.setuptools_scm]
-#write_to = "src/gbasis/_version.py"
-#version_scheme = "post-release"
-#local_scheme = "no-local-version"
-
-[tool.setuptools.package-data]
-gbasis = ["integrals/include/cint*.h", "integrals/lib/libcint.so*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # Replaced setuptools with scikit-build-core
-# Reason: setuptools cannot compile C code or call CMake
-# scikit-build-core can call CMake which will compile libcint
+# Reason: use a CMake-based build (via scikit-build-core) to compile and bundle libcint/qcint
+# as part of the Python wheel build
 
 [build-system]
 requires = ["numpy>=2.0", "scikit-build-core>=0.9"]


### PR DESCRIPTION
## Summary
- I migrated the build system from setuptools to scikit-build-core.
- In the existing pyproject.toml, setuptools was being used — but setuptools cannot compile C code. So I replaced it with  
scikit-build-core — because scikit-build-core can call CMake, and CMake will compile libcint.
- I referred to the repo [matrix-permanent](https://github.com/theochem/matrix-permanent)  project for this — it already had the same
scikit-build-core setup.  so I followed the same structure.

- Added CMakeLists.txt with FetchContent for automatic libcint/qcint download
- Platform detection: x86+AVX2 → qcint (optimized), ARM/non-AVX → libcint (generic)
- Referenced matrix-permanent repo and Libcint 6 paper (Section IV) for structure and compile flags



- Part of Issue #229  (PR-1)[Week-1]


## Description:
- Migrated build backend from setuptools to scikit-build-core
- Updated numpy dependency to >=2.0
- Removed setuptools specific configurations
- Added scikit-build configuration
- This enables CMake integration for libcint compilation
- Added root level CMakeLists.txt
- FetchContent automatically downloads and compiles libcint or qcint based on platform
- x86 + AVX2 → qcint (SIMD optimized)
- ARM/non-AVX → libcint (generic, works on all platforms)
- Compile flags: WITH_FORTRAN=OFF, WITH_RANGE_COULOMB=ON
- Added placeholder gbasis/integrals/src/libcint_wrap.c (actual C wrapper will be in next PR)
- Updated numpy version in .github/workflows/pytest.yaml for consistency with pyproject.toml


## How To Test

**Tested locally on Mac M5 (ARM):**


**Prerequisites:**
```bash
pip install scikit-build-core==0.9.0
```

**Build locally:**
```bash
pip install -e . --no-build-isolation -v
```


<img width="1470" height="956" alt="Screenshot 2026-06-08 at 1 02 43 AM" src="https://github.com/user-attachments/assets/c3ecf0c9-2aad-468e-b722-b54d42f605be" />

<img width="1470" height="956" alt="Screenshot 2026-06-08 at 1 04 25 AM" src="https://github.com/user-attachments/assets/ba248e94-2022-48aa-8bac-b26e66cf40dd" />
...
...
...
...
<img width="1470" height="956" alt="Screenshot 2026-06-08 at 1 05 21 AM" src="https://github.com/user-attachments/assets/629953ab-2e66-4605-86f7-cbdc5874247a" />


**Expected output during build:**
```
-- Architecture: ARM/non-AVX detected — use libcint   (on ARM/Mac M-series)
-- Architecture: x86 + AVX2 detected — use qcint      (on Intel/AMD x86)
-- Configuring done
-- Build files have been written to: ...
Successfully installed qc-gbasis
```

**Verify installation:**
```bash
python -c "import gbasis; print('gbasis import successful')"
```

**Expected output:**
```
gbasis import successful
```


<img width="1432" height="83" alt="Screenshot 2026-06-08 at 12 57 06 AM" src="https://github.com/user-attachments/assets/607c32c8-072c-4a7c-ab17-d0e371cc2b0d" />



## IMPORTANT NOTES: 
> Note: CMakeLists.txt has been included in this PR.
> Note: CMakeLists.txt has been included in this PR.
> Note: pytest CI checks are expected to fail — CI/CD will be configured in a later PR.
> Note: C wrapper (libcint_wrap.c) is a placeholder — actual implementation will follow in next PR.