### PR TITLE
PR-5 - feat: add C shell loop for all 1-electron integrals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,108 +1,66 @@
-# CMakeLists.txt — Build C extension for GBasis libcint integration  (Issue: #229)
 
-# Usage:
-#   Default (all platforms):  pip install gbasis
-#   qcint (x86+AVX2 only):   pip install gbasis -C cmake.args="-DUSE_QCINT=ON"
+# Require (a relatively recent) version of CMake.
+cmake_minimum_required(VERSION 3.18)
 
+# Declare project.
+project(gbasis LANGUAGES C)
 
-cmake_minimum_required(VERSION 3.17)
-project(gbasis_libcint C)
+# Import necessary Python modules.
+find_package(Python REQUIRED COMPONENTS Interpreter Development.Module NumPy)
 
-# Python and NumPy are required to build the C extension module
-
-find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
-find_package(Python COMPONENTS NumPy REQUIRED)
-
-# Get NumPy include path for C extension (numpy/arrayobject.h)
-
-execute_process(
-    COMMAND "${Python_EXECUTABLE}" "-c"
-            "import numpy; print(numpy.get_include())"
-    OUTPUT_VARIABLE NumPy_INCLUDE_DIRS
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-# ── Platform Detection — x86 vs ARM ──────────────────────
-# Detect platform: use qcint on x86+AVX2, libcint on ARM/non-AVX
-# qcint is an optimized version of libcint for x86 with SIMD support
+# Use qcint on x86 systems with (at least) SSE3, and libcint on non-x86/non-SSE3 systems.
+# qcint is an optimized version of libcint for x86 systems with SIMD support;
+# both are pinned to v6.1.2 for stability.
 include(CheckCCompilerFlag)
-check_c_compiler_flag("-mavx2" HAS_AVX2)
-
-if(HAS_AVX2 AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
-    set(USE_QCINT ON)
-    message(STATUS "Architecture: x86 + AVX2 detected → use qcint")
+set(GBASIS_CINT_REPO "https://github.com/sunqm/libcint.git")
+set(GBASIS_CINT_VERSION "v6.1.2")
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)|(i386)|(i686)")
+    check_c_compiler_flag("-msse3" GBASIS_HAS_SSE3)
+    if(GBASIS_HAS_SSE3)
+        message(STATUS "Architecture: x86 with (at least) SSE3 -> use qcint")
+        set(GBASIS_CINT_REPO "https://github.com/sunqm/qcint.git")
+    else()
+        message(STATUS "Architecture: x86 without SSE3 -> use libcint")
+    endif()
 else()
-    set(USE_QCINT OFF)
-    message(STATUS "Architecture: ARM/non-AVX detected → use libcint")
+    message(STATUS "Architecture: not x86 -> use libcint")
 endif()
 
-
-# Download libcint or qcint based on platform detection
-# Both are pinned to v6.1.2 for stability
-# qcint: optimized for x86+AVX2
-# libcint: generic, works on all platforms
-
+# Download libcint or qcint based on platform.
 include(FetchContent)
+FetchContent_Declare(cint
+    GIT_REPOSITORY ${GBASIS_CINT_REPO}
+    GIT_TAG ${GBASIS_CINT_VERSION}
+    GIT_SHALLOW
+    EXCLUDE_FROM_ALL)
 
-if(USE_QCINT)
-    FetchContent_Declare(
-        libcint
-        GIT_REPOSITORY https://github.com/sunqm/qcint.git
-        GIT_TAG        v6.1.2
-    )
-else()
-    FetchContent_Declare(
-        libcint
-        GIT_REPOSITORY https://github.com/sunqm/libcint.git
-        GIT_TAG        v6.1.2
-    )
-endif()
+# Configure libcint/qcint.
+set(ENABLE_STATIC ON)
+set(WITH_FORTRAN OFF)
+set(WITH_RANGE_COULOMB ON)
 
-# Compile libcint — Fortran disabled, range-separated Coulomb enabled
+# Import libcint/qcint CMake project.
+FetchContent_MakeAvailable(cint)
 
-set(WITH_FORTRAN OFF CACHE BOOL "" FORCE)
-# Enable range-separated Coulomb integrals
-set(WITH_RANGE_COULOMB ON CACHE BOOL "" FORCE)
+# Declare C extension module.
+set(GBASIS_EXTENSION_SOURCE "gbasis/integrals/src/libcint_wrap.c")
+python_add_library(gbasis_ext MODULE WITH_SOABI ${GBASIS_EXTENSION_SOURCE})
 
-# Redirect libcint's install to build directory to avoid permission issues
-set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/local" CACHE PATH "" FORCE)
-set(SKIP_INSTALL_ALL ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(libcint)
-
-# Build Python C extension module from libcint_wrap.c
-python_add_library(libcint_bindings MODULE
-    gbasis/integrals/src/libcint_wrap.c
-    WITH_SOABI
-)
-
-
-
-
-# Include NumPy and libcint headers
-target_include_directories(libcint_bindings PRIVATE
-    ${NumPy_INCLUDE_DIRS}
-    ${libcint_SOURCE_DIR}/include
-)
-
-# Link C extension with libcint
-target_link_libraries(libcint_bindings PRIVATE cint)
-
-# Prevent libcint from installing to system directories
-set(CINT_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/cint_install CACHE PATH "" FORCE)
-
-# Set RPATH so libcint.dylib is found at runtime
-set_target_properties(libcint_bindings PROPERTIES
+# Set C extension module properties.
+set_target_properties(gbasis_ext PROPERTIES
+    # Set target library output name.
+    OUTPUT_NAME libcint_bindings
+    # Set RPATH so libcint.dylib is found at runtime.
     INSTALL_RPATH "@loader_path"
-    BUILD_WITH_INSTALL_RPATH TRUE
-)
+    BUILD_WITH_INSTALL_RPATH TRUE)
 
-# Install only the Python extension into the wheel
-install(TARGETS libcint_bindings
-    LIBRARY DESTINATION ${SKBUILD_PLATLIB_DIR}/gbasis/integrals/lib
-)
+# Expose Python and NumPy include directories to C extension module.
+target_include_directories(gbasis_ext PRIVATE
+    ${Python_INCLUDE_DIRS} ${Python_NumPy_INCLUDE_DIRS})
 
-# Install libcint shared library alongside the extension
-install(FILES $<TARGET_FILE:cint>
-    DESTINATION ${SKBUILD_PLATLIB_DIR}/gbasis/integrals/lib
-    RENAME libcint.6.dylib
-)
+# Link C extension module with libcint/qcint.
+target_link_libraries(gbasis_ext PRIVATE cint)
+
+# Install C extension module.
+set(GBASIS_WHEEL_DIRECTORY "${SKBUILD_PLATLIB_DIR}/gbasis/integrals/lib")
+install(TARGETS gbasis_ext LIBRARY DESTINATION ${GBASIS_WHEEL_DIRECTORY})

--- a/gbasis/integrals/libcint.py
+++ b/gbasis/integrals/libcint.py
@@ -2,6 +2,7 @@ r"""
 Python C-API bindings for ``libcint`` GTO integrals library.
 
 """
+from gbasis.integrals.lib import libcint_bindings
 
 from contextlib import contextmanager
 
@@ -1097,7 +1098,6 @@ class CBasis:
             Integral array.
 
         """
-        from gbasis.integrals.lib import libcint_bindings
         out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
         libcint_bindings.overlap_integral_shellloop(
             out, self.natm, self.atm, self.nbas,
@@ -1115,7 +1115,6 @@ class CBasis:
             Integral array.
 
         """
-        from gbasis.integrals.lib import libcint_bindings
         out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
         libcint_bindings.kinetic_integral_shellloop(
             out, self.natm, self.atm, self.nbas,
@@ -1133,7 +1132,6 @@ class CBasis:
             Integral array.
 
         """
-        from gbasis.integrals.lib import libcint_bindings
         out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
         libcint_bindings.nuclear_integral_shellloop(
             out, self.natm, self.atm, self.nbas,
@@ -1151,7 +1149,6 @@ class CBasis:
             Integral array.
 
         """
-        from gbasis.integrals.lib import libcint_bindings
         out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
         libcint_bindings.momentum_integral_shellloop(
             out, self.natm, self.atm, self.nbas,
@@ -1169,7 +1166,6 @@ class CBasis:
             Integral array.
 
         """
-        from gbasis.integrals.lib import libcint_bindings
         out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
         libcint_bindings.rinv_integral_shellloop(
             out, self.natm, self.atm, self.nbas,
@@ -1187,7 +1183,6 @@ class CBasis:
             Integral array.
 
         """
-        from gbasis.integrals.lib import libcint_bindings
         out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
         libcint_bindings.dipole_integral_shellloop(
             out, self.natm, self.atm, self.nbas,
@@ -1205,7 +1200,6 @@ class CBasis:
             Integral array.
 
         """
-        from gbasis.integrals.lib import libcint_bindings
         out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
         libcint_bindings.quadrupole_integral_shellloop(
             out, self.natm, self.atm, self.nbas,
@@ -1223,7 +1217,6 @@ class CBasis:
             Integral array.
 
         """
-        from gbasis.integrals.lib import libcint_bindings
         out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
         libcint_bindings.octupole_integral_shellloop(
             out, self.natm, self.atm, self.nbas,

--- a/gbasis/integrals/libcint.py
+++ b/gbasis/integrals/libcint.py
@@ -1088,14 +1088,21 @@ class CBasis:
         """
         return self._nuc(notation=notation, transform=transform)
 
-    def overlap_shellloop(self):
+    def overlap(self):
         r"""
-        Compute overlap integral using C shell loop.
+        Compute the overlap integrals.
+
+        The overlap integral measures the degree to which two basis functions
+        :math:`\phi_i` and :math:`\phi_j` occupy the same region of space,
+        and is defined as:
+
+        .. math::
+            S_{ij} = \langle \phi_i | \phi_j \rangle
 
         Returns
         -------
         out : np.ndarray(Nbasis, Nbasis, dtype=float)
-            Integral array.
+            Overlap integral array.
 
         """
         out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
@@ -1105,14 +1112,21 @@ class CBasis:
         )
         return out
 
-    def kinetic_energy_shellloop(self):
+    def kinetic_energy(self):
         r"""
-        Compute kinetic energy integral using C shell loop.
+        Compute the kinetic energy integrals.
+
+        The kinetic energy integral represents the expectation value of the
+        kinetic energy operator between basis functions :math:`\phi_i` and
+        :math:`\phi_j`, and is defined as:
+
+        .. math::
+            T_{ij} = \langle \phi_i | -\frac{1}{2}\nabla^2 | \phi_j \rangle
 
         Returns
         -------
         out : np.ndarray(Nbasis, Nbasis, dtype=float)
-            Integral array.
+            Kinetic energy integral array.
 
         """
         out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
@@ -1122,14 +1136,24 @@ class CBasis:
         )
         return out
 
-    def nuclear_attraction_shellloop(self):
+    def nuclear_attraction(self):
         r"""
-        Compute nuclear attraction integral using C shell loop.
+        Compute the nuclear attraction integrals.
+
+        The nuclear attraction integral represents the electrostatic attraction
+        between electrons and nuclei. For each pair of basis functions
+        :math:`\phi_i` and :math:`\phi_j`, it is defined as:
+
+        .. math::
+            V_{ij} = \langle \phi_i | \sum_A \frac{Z_A}{|\mathbf{r} - \mathbf{R}_A|} | \phi_j \rangle
+
+        where :math:`Z_A` is the nuclear charge and :math:`\mathbf{R}_A` is
+        the position of atom :math:`A`.
 
         Returns
         -------
         out : np.ndarray(Nbasis, Nbasis, dtype=float)
-            Integral array.
+            Nuclear attraction integral array.
 
         """
         out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
@@ -1139,16 +1163,31 @@ class CBasis:
         )
         return out
 
-    def momentum_shellloop(self):
+    def momentum(self):
         r"""
-        Compute momentum integral using C shell loop.
+        Compute the momentum integrals.
+
+        The momentum integral represents the expectation value of the momentum
+        operator between basis functions :math:`\phi_i` and :math:`\phi_j`,
+        and is defined as:
+
+        .. math::
+            p_{ij} = \langle \phi_i | -i\nabla | \phi_j \rangle
 
         Returns
         -------
         out : np.ndarray(Nbasis, Nbasis, dtype=float)
-            Integral array.
+            Momentum integral array.
+
+        Notes
+        -----
+        Returns the raw single-component output from ``int1e_ipovlp_sph``
+        without the :math:`-i` scaling factor. The full 3-component momentum
+        integral (x, y, z) with proper scaling is available via
+        ``momentum_integral()``.
 
         """
+
         out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
         libcint_bindings.momentum_integral_shellloop(
             out, self.natm, self.atm, self.nbas,
@@ -1156,14 +1195,21 @@ class CBasis:
         )
         return out
 
-    def rinv_shellloop(self):
+    def rinv(self):
         r"""
-        Compute 1/r integral using C shell loop.
+        Compute the :math:`1/\left|\mathbf{r} - \mathbf{R}_\text{inv}\right|` integrals.
+
+        The :math:`1/r` integral represents the electrostatic potential due to
+        a unit point charge at a given origin. For each pair of basis functions
+        :math:`\phi_i` and :math:`\phi_j`, it is defined as:
+
+        .. math::
+            V_{ij} = \langle \phi_i | \frac{1}{|\mathbf{r} - \mathbf{R}_\text{inv}|} | \phi_j \rangle
 
         Returns
         -------
         out : np.ndarray(Nbasis, Nbasis, dtype=float)
-            Integral array.
+            1/r integral array.
 
         """
         out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
@@ -1173,14 +1219,27 @@ class CBasis:
         )
         return out
 
-    def dipole_shellloop(self):
+    def dipole(self):
         r"""
-        Compute dipole integral using C shell loop.
+        Compute the dipole moment integrals.
+
+        The dipole moment integral represents the expectation value of the
+        position operator between basis functions :math:`\phi_i` and
+        :math:`\phi_j`, and is defined as:
+
+        .. math::
+            \mu_{ij} = \langle \phi_i | \mathbf{r} | \phi_j \rangle
 
         Returns
         -------
         out : np.ndarray(Nbasis, Nbasis, dtype=float)
-            Integral array.
+            Dipole moment integral array.
+
+        Notes
+        -----
+        Returns the first component (x) of the dipole integral from
+        ``int1e_r_sph``. The full 3-component dipole integral is
+        available via ``moment_integral()``.
 
         """
         out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
@@ -1190,14 +1249,27 @@ class CBasis:
         )
         return out
 
-    def quadrupole_shellloop(self):
+    def quadrupole(self):
         r"""
-        Compute quadrupole integral using C shell loop.
+        Compute the quadrupole moment integrals.
+
+        The quadrupole moment integral represents the expectation value of the
+        second-order position operator between basis functions :math:`\phi_i`
+        and :math:`\phi_j`, and is defined as:
+
+        .. math::
+            Q_{ij} = \langle \phi_i | \mathbf{r}\mathbf{r} | \phi_j \rangle
 
         Returns
         -------
         out : np.ndarray(Nbasis, Nbasis, dtype=float)
-            Integral array.
+            Quadrupole moment integral array.
+
+        Notes
+        -----
+        Returns the first component of the quadrupole integral from
+        ``int1e_rr_sph``. The full 9-component quadrupole integral is
+        available via ``moment_integral()``.
 
         """
         out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
@@ -1207,14 +1279,27 @@ class CBasis:
         )
         return out
 
-    def octupole_shellloop(self):
+    def octupole(self):
         r"""
-        Compute octupole integral using C shell loop.
+        Compute the octupole moment integrals.
+
+        The octupole moment integral represents the expectation value of the
+        third-order position operator between basis functions :math:`\phi_i`
+        and :math:`\phi_j`, and is defined as:
+
+        .. math::
+            O_{ij} = \langle \phi_i | \mathbf{r}\mathbf{r}\mathbf{r} | \phi_j \rangle
 
         Returns
         -------
         out : np.ndarray(Nbasis, Nbasis, dtype=float)
-            Integral array.
+            Octupole moment integral array.
+
+        Notes
+        -----
+        Returns the first component of the octupole integral from
+        ``int1e_rrr_sph``. The full 27-component octupole integral is
+        available via ``moment_integral()``.
 
         """
         out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')

--- a/gbasis/integrals/libcint.py
+++ b/gbasis/integrals/libcint.py
@@ -1087,6 +1087,152 @@ class CBasis:
         """
         return self._nuc(notation=notation, transform=transform)
 
+    def overlap_shellloop(self):
+        r"""
+        Compute overlap integral using C shell loop.
+
+        Returns
+        -------
+        out : np.ndarray(Nbasis, Nbasis, dtype=float)
+            Integral array.
+
+        """
+        from gbasis.integrals.lib import libcint_bindings
+        out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
+        libcint_bindings.overlap_integral_shellloop(
+            out, self.natm, self.atm, self.nbas,
+            self.bas, self.env, self._offs, self.nbfn
+        )
+        return out
+
+    def kinetic_energy_shellloop(self):
+        r"""
+        Compute kinetic energy integral using C shell loop.
+
+        Returns
+        -------
+        out : np.ndarray(Nbasis, Nbasis, dtype=float)
+            Integral array.
+
+        """
+        from gbasis.integrals.lib import libcint_bindings
+        out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
+        libcint_bindings.kinetic_integral_shellloop(
+            out, self.natm, self.atm, self.nbas,
+            self.bas, self.env, self._offs, self.nbfn
+        )
+        return out
+
+    def nuclear_attraction_shellloop(self):
+        r"""
+        Compute nuclear attraction integral using C shell loop.
+
+        Returns
+        -------
+        out : np.ndarray(Nbasis, Nbasis, dtype=float)
+            Integral array.
+
+        """
+        from gbasis.integrals.lib import libcint_bindings
+        out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
+        libcint_bindings.nuclear_integral_shellloop(
+            out, self.natm, self.atm, self.nbas,
+            self.bas, self.env, self._offs, self.nbfn
+        )
+        return out
+
+    def momentum_shellloop(self):
+        r"""
+        Compute momentum integral using C shell loop.
+
+        Returns
+        -------
+        out : np.ndarray(Nbasis, Nbasis, dtype=float)
+            Integral array.
+
+        """
+        from gbasis.integrals.lib import libcint_bindings
+        out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
+        libcint_bindings.momentum_integral_shellloop(
+            out, self.natm, self.atm, self.nbas,
+            self.bas, self.env, self._offs, self.nbfn
+        )
+        return out
+
+    def rinv_shellloop(self):
+        r"""
+        Compute 1/r integral using C shell loop.
+
+        Returns
+        -------
+        out : np.ndarray(Nbasis, Nbasis, dtype=float)
+            Integral array.
+
+        """
+        from gbasis.integrals.lib import libcint_bindings
+        out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
+        libcint_bindings.rinv_integral_shellloop(
+            out, self.natm, self.atm, self.nbas,
+            self.bas, self.env, self._offs, self.nbfn
+        )
+        return out
+
+    def dipole_shellloop(self):
+        r"""
+        Compute dipole integral using C shell loop.
+
+        Returns
+        -------
+        out : np.ndarray(Nbasis, Nbasis, dtype=float)
+            Integral array.
+
+        """
+        from gbasis.integrals.lib import libcint_bindings
+        out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
+        libcint_bindings.dipole_integral_shellloop(
+            out, self.natm, self.atm, self.nbas,
+            self.bas, self.env, self._offs, self.nbfn
+        )
+        return out
+
+    def quadrupole_shellloop(self):
+        r"""
+        Compute quadrupole integral using C shell loop.
+
+        Returns
+        -------
+        out : np.ndarray(Nbasis, Nbasis, dtype=float)
+            Integral array.
+
+        """
+        from gbasis.integrals.lib import libcint_bindings
+        out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
+        libcint_bindings.quadrupole_integral_shellloop(
+            out, self.natm, self.atm, self.nbas,
+            self.bas, self.env, self._offs, self.nbfn
+        )
+        return out
+
+    def octupole_shellloop(self):
+        r"""
+        Compute octupole integral using C shell loop.
+
+        Returns
+        -------
+        out : np.ndarray(Nbasis, Nbasis, dtype=float)
+            Integral array.
+
+        """
+        from gbasis.integrals.lib import libcint_bindings
+        out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
+        libcint_bindings.octupole_integral_shellloop(
+            out, self.natm, self.atm, self.nbas,
+            self.bas, self.env, self._offs, self.nbfn
+        )
+        return out
+
+    
+
     def electron_repulsion_integral(self, notation="physicist", transform=None):
         r"""
         Compute the electron repulsion integrals.

--- a/gbasis/integrals/src/libcint_wrap.c
+++ b/gbasis/integrals/src/libcint_wrap.c
@@ -141,60 +141,76 @@ electron_repulsion_sph(PyObject *self, PyObject *args)
     return PyLong_FromLong(result);
 }
 
-/* overlap_integral_shellloop — shell-by-shell loop in C for overlap */
-static PyObject *
-overlap_integral_shellloop(PyObject *self, PyObject *args)
-{
-    PyArrayObject *out_arr, *atm_arr, *bas_arr, *env_arr, *offs_arr;
-    int natm, nbas, nbfn;
-
-    if (!PyArg_ParseTuple(args, "O!iO!iO!O!O!i",
-                          &PyArray_Type, &out_arr,
-                          &natm,
-                          &PyArray_Type, &atm_arr,
-                          &nbas,
-                          &PyArray_Type, &bas_arr,
-                          &PyArray_Type, &env_arr,
-                          &PyArray_Type, &offs_arr,
-                          &nbfn))
-        return NULL;
-
-    double *out  = (double *)PyArray_DATA(out_arr);
-    int    *atm  = (int *)   PyArray_GETPTR2(atm_arr, 0, 0);
-    int    *bas  = (int *)   PyArray_GETPTR2(bas_arr, 0, 0);
-    double *env  = (double *)PyArray_GETPTR1(env_arr, 0);
-    int    *offs = (int *)   PyArray_GETPTR1(offs_arr, 0);
-
-    int shls[2];
-    double buf[10000] = {0};
-
-    int ipos = 0;
-    for (int ishl = 0; ishl < nbas; ishl++) {
-        shls[0] = ishl;
-        int p_off = offs[ishl];
-        int jpos = 0;
-        for (int jshl = 0; jshl <= ishl; jshl++) {
-            shls[1] = jshl;
-            int q_off = offs[jshl];
-            int1e_ovlp_sph(buf, NULL, shls, atm, natm, bas, nbas, env, NULL, NULL);
-            for (int p = 0; p < p_off; p++) {
-                for (int q = 0; q < q_off; q++) {
-                    double val = buf[p + q * p_off];
-                    out[(ipos+p) * nbfn + (jpos+q)] = val;
-                    out[(jpos+q) * nbfn + (ipos+p)] = val;
-                }
-            }
-            memset(buf, 0, sizeof(buf));
-            jpos += q_off;
-        }
-        ipos += p_off;
-    }
-    Py_RETURN_NONE;
+/*
+ * DEFINE_SHELLLOOP_INT1e(func_name, libcint_func)
+ * Generates a C shell-loop wrapper for a 1-electron libcint integral that
+ * returns the FULL integral array over all shells (not just one shell pair).
+ * Loops over shells I, J; calls libcint_func per shell pair; fills the
+ * symmetric output matrix using PyArray_GETPTR (NumPy C-API).
+ */
+#define DEFINE_SHELLLOOP_INT1e(func_name, libcint_func)                           \
+static PyObject *                                                                  \
+func_name(PyObject *self, PyObject *args)                                          \
+{                                                                                  \
+    PyArrayObject *out_arr, *atm_arr, *bas_arr, *env_arr, *offs_arr;              \
+    int natm, nbas, nbfn;                                                          \
+    if (!PyArg_ParseTuple(args, "O!iO!iO!O!O!i",                                  \
+                          &PyArray_Type, &out_arr,                                 \
+                          &natm,                                                   \
+                          &PyArray_Type, &atm_arr,                                 \
+                          &nbas,                                                   \
+                          &PyArray_Type, &bas_arr,                                 \
+                          &PyArray_Type, &env_arr,                                 \
+                          &PyArray_Type, &offs_arr,                                \
+                          &nbfn))                                                  \
+        return NULL;                                                               \
+    double *out  = (double *)PyArray_DATA(out_arr);                               \
+    int    *atm  = (int *)   PyArray_GETPTR2(atm_arr, 0, 0);                      \
+    int    *bas  = (int *)   PyArray_GETPTR2(bas_arr, 0, 0);                      \
+    double *env  = (double *)PyArray_GETPTR1(env_arr, 0);                         \
+    int    *offs = (int *)   PyArray_GETPTR1(offs_arr, 0);                        \
+    int shls[2];                                                                   \
+    double buf[10000] = {0};                                                      \
+    int ipos = 0;                                                                  \
+    for (int ishl = 0; ishl < nbas; ishl++) {                                     \
+        shls[0] = ishl;                                                            \
+        int p_off = offs[ishl];                                                   \
+        int jpos = 0;                                                              \
+        for (int jshl = 0; jshl <= ishl; jshl++) {                                \
+            shls[1] = jshl;                                                        \
+            int q_off = offs[jshl];                                               \
+            libcint_func(buf, NULL, shls, atm, natm, bas, nbas, env, NULL, NULL); \
+            for (int p = 0; p < p_off; p++) {                                     \
+                for (int q = 0; q < q_off; q++) {                                 \
+                    double val = buf[p + q * p_off];                              \
+                    out[(ipos+p) * nbfn + (jpos+q)] = val;                        \
+                    out[(jpos+q) * nbfn + (ipos+p)] = val;                        \
+                }                                                                  \
+            }                                                                      \
+            memset(buf, 0, sizeof(buf));                                          \
+            jpos += q_off;                                                         \
+        }                                                                          \
+        ipos += p_off;                                                             \
+    }                                                                              \
+    Py_RETURN_NONE;                                                                \
 }
+
+/* Generate shell-loop wrappers for all 1-electron integrals using the macro */
+DEFINE_SHELLLOOP_INT1e(overlap_integral_shellloop,    int1e_ovlp_sph)
+DEFINE_SHELLLOOP_INT1e(kinetic_integral_shellloop,    int1e_kin_sph)
+DEFINE_SHELLLOOP_INT1e(nuclear_integral_shellloop,    int1e_nuc_sph)
+DEFINE_SHELLLOOP_INT1e(momentum_integral_shellloop,   int1e_ipovlp_sph)
+DEFINE_SHELLLOOP_INT1e(rinv_integral_shellloop,       int1e_rinv_sph)
+DEFINE_SHELLLOOP_INT1e(dipole_integral_shellloop,     int1e_r_sph)
+DEFINE_SHELLLOOP_INT1e(quadrupole_integral_shellloop, int1e_rr_sph)
+DEFINE_SHELLLOOP_INT1e(octupole_integral_shellloop,   int1e_rrr_sph)
+
+/* eri_shellloop — shell-by-shell loop in C for 2-electron ERI (4 shells: I,J,K,L) */
+
+
 
 static PyMethodDef LibcintMethods[] = {
     {"overlap_sph",          overlap_sph,          METH_VARARGS, "Overlap integral"},
-    {"overlap_integral_shellloop", overlap_integral_shellloop, METH_VARARGS, "Overlap integral (shell-by-shell)"},
     {"kinetic_sph",          kinetic_sph,          METH_VARARGS, "Kinetic energy integral"},
     {"nuclear_sph",          nuclear_sph,          METH_VARARGS, "Nuclear attraction integral"},
     {"momentum_sph",         momentum_sph,         METH_VARARGS, "Momentum integral"},
@@ -205,6 +221,13 @@ static PyMethodDef LibcintMethods[] = {
     {"octupole_sph",         octupole_sph,         METH_VARARGS, "Octupole moment integral"},
     {"electron_repulsion_sph", electron_repulsion_sph, METH_VARARGS, "Electron repulsion integral"},
     {"overlap_integral_shellloop", overlap_integral_shellloop, METH_VARARGS, "Overlap integral shell loop in C"},
+    {"kinetic_integral_shellloop", kinetic_integral_shellloop, METH_VARARGS, "Kinetic integral shell loop in C"},
+    {"nuclear_integral_shellloop", nuclear_integral_shellloop, METH_VARARGS, "Nuclear attraction integral shell loop in C"},
+    {"momentum_integral_shellloop", momentum_integral_shellloop, METH_VARARGS, "Momentum integral shell loop in C"},
+    {"rinv_integral_shellloop", rinv_integral_shellloop, METH_VARARGS, "1/r integral shell loop in C"},
+    {"dipole_integral_shellloop", dipole_integral_shellloop, METH_VARARGS, "Dipole integral shell loop in C"},
+    {"quadrupole_integral_shellloop", quadrupole_integral_shellloop, METH_VARARGS, "Quadrupole integral shell loop in C"},
+    {"octupole_integral_shellloop", octupole_integral_shellloop, METH_VARARGS, "Octupole integral shell loop in C"},
     {NULL, NULL, 0, NULL}
 };
 

--- a/gbasis/integrals/src/libcint_wrap.c
+++ b/gbasis/integrals/src/libcint_wrap.c
@@ -141,8 +141,60 @@ electron_repulsion_sph(PyObject *self, PyObject *args)
     return PyLong_FromLong(result);
 }
 
+/* overlap_integral_shellloop — shell-by-shell loop in C for overlap */
+static PyObject *
+overlap_integral_shellloop(PyObject *self, PyObject *args)
+{
+    PyArrayObject *out_arr, *atm_arr, *bas_arr, *env_arr, *offs_arr;
+    int natm, nbas, nbfn;
+
+    if (!PyArg_ParseTuple(args, "O!iO!iO!O!O!i",
+                          &PyArray_Type, &out_arr,
+                          &natm,
+                          &PyArray_Type, &atm_arr,
+                          &nbas,
+                          &PyArray_Type, &bas_arr,
+                          &PyArray_Type, &env_arr,
+                          &PyArray_Type, &offs_arr,
+                          &nbfn))
+        return NULL;
+
+    double *out  = (double *)PyArray_DATA(out_arr);
+    int    *atm  = (int *)   PyArray_GETPTR2(atm_arr, 0, 0);
+    int    *bas  = (int *)   PyArray_GETPTR2(bas_arr, 0, 0);
+    double *env  = (double *)PyArray_GETPTR1(env_arr, 0);
+    int    *offs = (int *)   PyArray_GETPTR1(offs_arr, 0);
+
+    int shls[2];
+    double buf[10000] = {0};
+
+    int ipos = 0;
+    for (int ishl = 0; ishl < nbas; ishl++) {
+        shls[0] = ishl;
+        int p_off = offs[ishl];
+        int jpos = 0;
+        for (int jshl = 0; jshl <= ishl; jshl++) {
+            shls[1] = jshl;
+            int q_off = offs[jshl];
+            int1e_ovlp_sph(buf, NULL, shls, atm, natm, bas, nbas, env, NULL, NULL);
+            for (int p = 0; p < p_off; p++) {
+                for (int q = 0; q < q_off; q++) {
+                    double val = buf[p + q * p_off];
+                    out[(ipos+p) * nbfn + (jpos+q)] = val;
+                    out[(jpos+q) * nbfn + (ipos+p)] = val;
+                }
+            }
+            memset(buf, 0, sizeof(buf));
+            jpos += q_off;
+        }
+        ipos += p_off;
+    }
+    Py_RETURN_NONE;
+}
+
 static PyMethodDef LibcintMethods[] = {
     {"overlap_sph",          overlap_sph,          METH_VARARGS, "Overlap integral"},
+    {"overlap_integral_shellloop", overlap_integral_shellloop, METH_VARARGS, "Overlap integral (shell-by-shell)"},
     {"kinetic_sph",          kinetic_sph,          METH_VARARGS, "Kinetic energy integral"},
     {"nuclear_sph",          nuclear_sph,          METH_VARARGS, "Nuclear attraction integral"},
     {"momentum_sph",         momentum_sph,         METH_VARARGS, "Momentum integral"},
@@ -152,6 +204,7 @@ static PyMethodDef LibcintMethods[] = {
     {"quadrupole_sph",       quadrupole_sph,       METH_VARARGS, "Quadrupole moment integral"},
     {"octupole_sph",         octupole_sph,         METH_VARARGS, "Octupole moment integral"},
     {"electron_repulsion_sph", electron_repulsion_sph, METH_VARARGS, "Electron repulsion integral"},
+    {"overlap_integral_shellloop", overlap_integral_shellloop, METH_VARARGS, "Overlap integral shell loop in C"},
     {NULL, NULL, 0, NULL}
 };
 


### PR DESCRIPTION


## Summary
- Expanded shell-by-shell loop in C from overlap-only to **all 8 one-electron integrals** using a shared macro
- Part of Issue #229 (PR-5) [Week-4]
- Previous version had a dedicated C function only for overlap — this update generalizes the pattern so all 1-electron integrals are bound with minimal duplicated code

- Python loop was slow — moving it to C gives significant speed improvement

## Changes

### libcint_wrap.c
- Added `DEFINE_SHELLLOOP_INT1e(func_name, libcint_func)` macro — generates a full shell-loop wrapper that returns the complete integral matrix over all shells (loops over shells I, J internally in C), instead of computing one shell pair at a time
- Used the macro to bind all 8 one-electron integrals in one line each:
  - `overlap_integral_shellloop` → `int1e_ovlp_sph`
  - `kinetic_integral_shellloop` → `int1e_kin_sph`
  - `nuclear_integral_shellloop` → `int1e_nuc_sph`
  - `momentum_integral_shellloop` → `int1e_ipovlp_sph`
  - `rinv_integral_shellloop` → `int1e_rinv_sph`
  - `dipole_integral_shellloop` → `int1e_r_sph`
  - `quadrupole_integral_shellloop` → `int1e_rr_sph`
  - `octupole_integral_shellloop` → `int1e_rrr_sph`
- Functions use `PyArray_DATA` and `PyArray_GETPTR2` for safe NumPy array access
- Registered all 8 in `PyMethodDef`


### libcint.py
- Added 8 corresponding `CBasis` methods (`overlap_shellloop`, `kinetic_energy_shellloop`, `nuclear_attraction_shellloop`, `momentum_shellloop`, `rinv_shellloop`, `dipole_shellloop`, `quadrupole_shellloop`, `octupole_shellloop`) that call the C functions directly


## Performance Results

Tested on H, He, Li with cc-pVDZ basis set (nbfn=24), comparing Python loop vs. C shell loop:

| Integral | Python Loop | C Loop   | Speedup | Match |
|----------|-------------|----------|---------|-------|
| overlap  | 0.733 ms    | 0.048 ms | ~15.2x  | ✅ True |
| kinetic  | 0.792 ms    | 0.065 ms | ~12.1x  | ✅ True |
| nuclear  | 0.793 ms    | 0.074 ms | ~10.8x  | ✅ True |
| rinv     | 0.775 ms    | 0.055 ms | ~14.0x  | ✅ True |

All four integrals match the Python implementation within `atol=1e-4`, with the C shell-loop bindings consistently **~11–15x faster**.





## Correctness Verification

Tested overlap integral output: Python implementation vs. new C shell-loop implementation (H, He, Li with cc-pVDZ basis):

```python
S_py = cb.overlap_integral()       # Python loop
S_c  = cb.overlap()      # C shell loop

np.allclose(S_py, S_c, atol=1e-4)  # → True
np.max(np.abs(S_py - S_c))         # → 0.0
```

**Result:**

| Metric | Value |
|---|---|
| Match within 1.0E-4 (`atol=1e-4`) | ✅ `True` |
| Max absolute difference | `0.0` |

The C shell-loop output is numerically identical to the Python implementation — even better than the ~1e-4 tolerance Michelle expected, given the algorithms differ.

## How To Test

**Build locally:**
```bash
pip install -e . --no-build-isolation
```

**Verify functions accessible:**
```bash
python3 -c "from gbasis.integrals.lib import libcint_bindings; print(dir(libcint_bindings))"
```

**Speed test:**
```bash
python3 << 'EOF'
from gbasis.integrals.libcint import CBasis
from gbasis.parsers import make_contractions, parse_nwchem
import numpy as np

basis_dict = parse_nwchem("tests/data_ccpvdz.nwchem")
atcoords = np.eye(3) / 0.5291772083
atsyms = ["H", "He", "Li"]
py_basis = make_contractions(basis_dict, atsyms, atcoords, coord_types="spherical")
cb = CBasis(py_basis, atsyms, atcoords)

print("overlap match:", np.allclose(cb.overlap_integral(), cb.overlap(), atol=1e-4))
print("kinetic match:", np.allclose(cb.kinetic_energy_integral(), cb.kinetic_energy(), atol=1e-4))
print("nuclear match:", np.allclose(cb.nuclear_attraction_integral(), cb.nuclear_attraction(), atol=1e-4))
print("rinv match:", np.allclose(cb.r_inv_integral(origin=np.zeros(3)), cb.rinv(), atol=1e-4))
EOF

```
### screenshot 
<img width="1467" height="621" alt="Screenshot 2026-06-22 at 1 36 44 AM" src="https://github.com/user-attachments/assets/a9dbf36f-c036-4a27-9121-9669f11ce193" />


## Note

- 2-electron (ERI) bindings intentionally out of scope for this PR — next week's focus per mentor guidance
