### PR TITLE
PR-6 - feat: add C shell loop binding for 2-electron ERI

### DIFF
--- a/gbasis/integrals/libcint.py
+++ b/gbasis/integrals/libcint.py
@@ -1326,12 +1326,12 @@ class CBasis:
             Electron repulsion integral array.
 
         """
-        out = np.zeros((self.nbfn, self.nbfn, self.nbfn, self.nbfn), dtype=c_double, order='F')
+        out = np.zeros((self.nbfn, self.nbfn, self.nbfn, self.nbfn), dtype=c_double)
         libcint_bindings.eri_shellloop(
             out, self.natm, self.atm, self.nbas,
             self.bas, self.env, self._offs, self.nbfn
         )
-        return out.transpose(0, 2, 1, 3)
+        return out
 
     def electron_repulsion_integral(self, notation="physicist", transform=None):
         r"""

--- a/gbasis/integrals/libcint.py
+++ b/gbasis/integrals/libcint.py
@@ -1309,7 +1309,29 @@ class CBasis:
         )
         return out
 
-    
+    def electron_repulsion(self):
+        r"""
+        Compute the electron repulsion integrals.
+
+        The two-electron repulsion integral between basis functions
+        :math:`\phi_i`, :math:`\phi_j`, :math:`\phi_k`, and :math:`\phi_l`
+        is defined as:
+
+        .. math::
+            g_{ijkl} = \langle \phi_i \phi_j | \frac{1}{r_{12}} | \phi_k \phi_l \rangle
+
+        Returns
+        -------
+        out : np.ndarray(Nbasis, Nbasis, Nbasis, Nbasis, dtype=float)
+            Electron repulsion integral array.
+
+        """
+        out = np.zeros((self.nbfn, self.nbfn, self.nbfn, self.nbfn), dtype=c_double, order='F')
+        libcint_bindings.eri_shellloop(
+            out, self.natm, self.atm, self.nbas,
+            self.bas, self.env, self._offs, self.nbfn
+        )
+        return out.transpose(0, 2, 1, 3)
 
     def electron_repulsion_integral(self, notation="physicist", transform=None):
         r"""

--- a/gbasis/integrals/src/libcint_wrap.c
+++ b/gbasis/integrals/src/libcint_wrap.c
@@ -68,13 +68,13 @@ extern int int1e_rrr_sph(double *out, int *dims, int *shls, int *atm, int natm, 
 extern int int2e_sph(double *out, int *dims, int *shls, int *atm, int natm, int *bas, int nbas, double *env, void *opt, double *cache);
 
 /*
- * DEFINE_INTEGRAL_INT1e(func_name, libcint_func)
+ * DEFINE_INT1E_ARRAY_FN(func_name, libcint_func)
  * Generates a Python/C API wrapper for a 1-electron libcint integral.
  * Accepts NumPy arrays directly — uses PyArray_GETPTR1 (NumPy C-API).
  */
 
 /* Macro for 1-electron wrappers */
-#define DEFINE_INTEGRAL_INT1e(func_name, libcint_func)                        \
+#define DEFINE_INT1E_ARRAY_FN(func_name, libcint_func)                        \
 static PyObject *                                                              \
 func_name(PyObject *self, PyObject *args)                                      \
 {                                                                              \
@@ -99,15 +99,15 @@ func_name(PyObject *self, PyObject *args)                                      \
     return PyLong_FromLong(result);                                            \
 }
 
-DEFINE_INTEGRAL_INT1e(overlap_sph,         int1e_ovlp_sph)
-DEFINE_INTEGRAL_INT1e(kinetic_sph,         int1e_kin_sph)
-DEFINE_INTEGRAL_INT1e(nuclear_sph,         int1e_nuc_sph)
-DEFINE_INTEGRAL_INT1e(momentum_sph,        int1e_ipovlp_sph)
-DEFINE_INTEGRAL_INT1e(angular_momentum_sph, int1e_cg_irxp_sph)
-DEFINE_INTEGRAL_INT1e(rinv_sph,            int1e_rinv_sph)
-DEFINE_INTEGRAL_INT1e(dipole_sph,          int1e_r_sph)
-DEFINE_INTEGRAL_INT1e(quadrupole_sph,      int1e_rr_sph)
-DEFINE_INTEGRAL_INT1e(octupole_sph,        int1e_rrr_sph)
+DEFINE_INT1E_ARRAY_FN(overlap_sph,         int1e_ovlp_sph)
+DEFINE_INT1E_ARRAY_FN(kinetic_sph,         int1e_kin_sph)
+DEFINE_INT1E_ARRAY_FN(nuclear_sph,         int1e_nuc_sph)
+DEFINE_INT1E_ARRAY_FN(momentum_sph,        int1e_ipovlp_sph)
+DEFINE_INT1E_ARRAY_FN(angular_momentum_sph, int1e_cg_irxp_sph)
+DEFINE_INT1E_ARRAY_FN(rinv_sph,            int1e_rinv_sph)
+DEFINE_INT1E_ARRAY_FN(dipole_sph,          int1e_r_sph)
+DEFINE_INT1E_ARRAY_FN(quadrupole_sph,      int1e_rr_sph)
+DEFINE_INT1E_ARRAY_FN(octupole_sph,        int1e_rrr_sph)
 
 /* 2-electron wrapper */
 
@@ -142,13 +142,13 @@ electron_repulsion_sph(PyObject *self, PyObject *args)
 }
 
 /*
- * DEFINE_SHELLLOOP_INT1e(func_name, libcint_func)
+ * DEFINE_INT1E_SHELLLOOP_FN(func_name, libcint_func)
  * Generates a C shell-loop wrapper for a 1-electron libcint integral that
  * returns the FULL integral array over all shells (not just one shell pair).
  * Loops over shells I, J; calls libcint_func per shell pair; fills the
  * symmetric output matrix using PyArray_GETPTR (NumPy C-API).
  */
-#define DEFINE_SHELLLOOP_INT1e(func_name, libcint_func)                           \
+#define DEFINE_INT1E_SHELLLOOP_FN(func_name, libcint_func)                           \
 static PyObject *                                                                  \
 func_name(PyObject *self, PyObject *args)                                          \
 {                                                                                  \
@@ -196,14 +196,14 @@ func_name(PyObject *self, PyObject *args)                                       
 }
 
 /* Generate shell-loop wrappers for all 1-electron integrals using the macro */
-DEFINE_SHELLLOOP_INT1e(overlap_integral_shellloop,    int1e_ovlp_sph)
-DEFINE_SHELLLOOP_INT1e(kinetic_integral_shellloop,    int1e_kin_sph)
-DEFINE_SHELLLOOP_INT1e(nuclear_integral_shellloop,    int1e_nuc_sph)
-DEFINE_SHELLLOOP_INT1e(momentum_integral_shellloop,   int1e_ipovlp_sph)
-DEFINE_SHELLLOOP_INT1e(rinv_integral_shellloop,       int1e_rinv_sph)
-DEFINE_SHELLLOOP_INT1e(dipole_integral_shellloop,     int1e_r_sph)
-DEFINE_SHELLLOOP_INT1e(quadrupole_integral_shellloop, int1e_rr_sph)
-DEFINE_SHELLLOOP_INT1e(octupole_integral_shellloop,   int1e_rrr_sph)
+DEFINE_INT1E_SHELLLOOP_FN(overlap_integral_shellloop,    int1e_ovlp_sph)
+DEFINE_INT1E_SHELLLOOP_FN(kinetic_integral_shellloop,    int1e_kin_sph)
+DEFINE_INT1E_SHELLLOOP_FN(nuclear_integral_shellloop,    int1e_nuc_sph)
+DEFINE_INT1E_SHELLLOOP_FN(momentum_integral_shellloop,   int1e_ipovlp_sph)
+DEFINE_INT1E_SHELLLOOP_FN(rinv_integral_shellloop,       int1e_rinv_sph)
+DEFINE_INT1E_SHELLLOOP_FN(dipole_integral_shellloop,     int1e_r_sph)
+DEFINE_INT1E_SHELLLOOP_FN(quadrupole_integral_shellloop, int1e_rr_sph)
+DEFINE_INT1E_SHELLLOOP_FN(octupole_integral_shellloop,   int1e_rrr_sph)
 
 /* eri_shellloop — shell-by-shell loop in C for 2-electron ERI (4 shells: I,J,K,L) */
 static PyObject *

--- a/gbasis/integrals/src/libcint_wrap.c
+++ b/gbasis/integrals/src/libcint_wrap.c
@@ -261,15 +261,14 @@ eri_shellloop(PyObject *self, PyObject *args)
                                 for (int s = 0; s < s_off; s++) {
                                     double val = buf[p + p_off*(q + q_off*(r + r_off*s))];
                                     int i = ipos+p, j = jpos+q, k = kpos+r, l = lpos+s;
-                                    out[i*nbfn*nbfn*nbfn + j*nbfn*nbfn + k*nbfn + l] = val;
-                                    out[i*nbfn*nbfn*nbfn + j*nbfn*nbfn + l*nbfn + k] = val;
-                                    out[j*nbfn*nbfn*nbfn + i*nbfn*nbfn + k*nbfn + l] = val;
-                                    out[j*nbfn*nbfn*nbfn + i*nbfn*nbfn + l*nbfn + k] = val;
-                                    out[k*nbfn*nbfn*nbfn + l*nbfn*nbfn + i*nbfn + j] = val;
-                                    out[k*nbfn*nbfn*nbfn + l*nbfn*nbfn + j*nbfn + i] = val;
-                                    out[l*nbfn*nbfn*nbfn + k*nbfn*nbfn + i*nbfn + j] = val;
-                                    out[l*nbfn*nbfn*nbfn + k*nbfn*nbfn + j*nbfn + i] = val;
-                                }
+                                    out[i*nbfn*nbfn*nbfn + k*nbfn*nbfn + j*nbfn + l] = val;
+                                    out[i*nbfn*nbfn*nbfn + l*nbfn*nbfn + j*nbfn + k] = val;
+                                    out[j*nbfn*nbfn*nbfn + k*nbfn*nbfn + i*nbfn + l] = val;
+                                    out[j*nbfn*nbfn*nbfn + l*nbfn*nbfn + i*nbfn + k] = val;
+                                    out[k*nbfn*nbfn*nbfn + i*nbfn*nbfn + l*nbfn + j] = val;
+                                    out[k*nbfn*nbfn*nbfn + j*nbfn*nbfn + l*nbfn + i] = val;
+                                    out[l*nbfn*nbfn*nbfn + i*nbfn*nbfn + k*nbfn + j] = val;
+                                    out[l*nbfn*nbfn*nbfn + j*nbfn*nbfn + k*nbfn + i] = val;                                }
                             }
                         }
                     }

--- a/gbasis/integrals/src/libcint_wrap.c
+++ b/gbasis/integrals/src/libcint_wrap.c
@@ -206,7 +206,84 @@ DEFINE_SHELLLOOP_INT1e(quadrupole_integral_shellloop, int1e_rr_sph)
 DEFINE_SHELLLOOP_INT1e(octupole_integral_shellloop,   int1e_rrr_sph)
 
 /* eri_shellloop — shell-by-shell loop in C for 2-electron ERI (4 shells: I,J,K,L) */
+static PyObject *
+eri_shellloop(PyObject *self, PyObject *args)
+{
+    PyArrayObject *out_arr, *atm_arr, *bas_arr, *env_arr, *offs_arr;
+    int natm, nbas, nbfn;
 
+    if (!PyArg_ParseTuple(args, "O!iO!iO!O!O!i",
+                          &PyArray_Type, &out_arr,
+                          &natm,
+                          &PyArray_Type, &atm_arr,
+                          &nbas,
+                          &PyArray_Type, &bas_arr,
+                          &PyArray_Type, &env_arr,
+                          &PyArray_Type, &offs_arr,
+                          &nbfn))
+        return NULL;
+
+    double *out  = (double *)PyArray_DATA(out_arr);
+    int    *atm  = (int *)   PyArray_GETPTR2(atm_arr, 0, 0);
+    int    *bas  = (int *)   PyArray_GETPTR2(bas_arr, 0, 0);
+    double *env  = (double *)PyArray_GETPTR1(env_arr, 0);
+    int    *offs = (int *)   PyArray_GETPTR1(offs_arr, 0);
+
+    int shls[4];
+    double buf[100000] = {0};
+
+    int ipos = 0;
+    for (int ishl = 0; ishl < nbas; ishl++) {
+        shls[0] = ishl;
+        int p_off = offs[ishl];
+        int jpos = 0;
+        for (int jshl = 0; jshl <= ishl; jshl++) {
+            int ij = ((ishl + 1) * ishl) / 2 + jshl;
+            shls[1] = jshl;
+            int q_off = offs[jshl];
+            int kpos = 0;
+            for (int kshl = 0; kshl < nbas; kshl++) {
+                shls[2] = kshl;
+                int r_off = offs[kshl];
+                int lpos = 0;
+                for (int lshl = 0; lshl <= kshl; lshl++) {
+                    int kl = ((kshl + 1) * kshl) / 2 + lshl;
+                    if (ij < kl) {
+                        lpos += offs[lshl];
+                        continue;
+                    }
+                    shls[3] = lshl;
+                    int s_off = offs[lshl];
+                    int2e_sph(buf, NULL, shls, atm, natm, bas, nbas, env, NULL, NULL);
+                    for (int p = 0; p < p_off; p++) {
+                        for (int q = 0; q < q_off; q++) {
+                            for (int r = 0; r < r_off; r++) {
+                                for (int s = 0; s < s_off; s++) {
+                                    double val = buf[p + p_off*(q + q_off*(r + r_off*s))];
+                                    int i = ipos+p, j = jpos+q, k = kpos+r, l = lpos+s;
+                                    out[i*nbfn*nbfn*nbfn + j*nbfn*nbfn + k*nbfn + l] = val;
+                                    out[i*nbfn*nbfn*nbfn + j*nbfn*nbfn + l*nbfn + k] = val;
+                                    out[j*nbfn*nbfn*nbfn + i*nbfn*nbfn + k*nbfn + l] = val;
+                                    out[j*nbfn*nbfn*nbfn + i*nbfn*nbfn + l*nbfn + k] = val;
+                                    out[k*nbfn*nbfn*nbfn + l*nbfn*nbfn + i*nbfn + j] = val;
+                                    out[k*nbfn*nbfn*nbfn + l*nbfn*nbfn + j*nbfn + i] = val;
+                                    out[l*nbfn*nbfn*nbfn + k*nbfn*nbfn + i*nbfn + j] = val;
+                                    out[l*nbfn*nbfn*nbfn + k*nbfn*nbfn + j*nbfn + i] = val;
+                                }
+                            }
+                        }
+                    }
+                    memset(buf, 0, sizeof(buf));
+                    lpos += s_off;
+                }
+                kpos += r_off;
+            }
+            jpos += q_off;
+        }
+        ipos += p_off;
+    }
+    Py_RETURN_NONE;
+}
 
 
 static PyMethodDef LibcintMethods[] = {
@@ -228,6 +305,7 @@ static PyMethodDef LibcintMethods[] = {
     {"dipole_integral_shellloop", dipole_integral_shellloop, METH_VARARGS, "Dipole integral shell loop in C"},
     {"quadrupole_integral_shellloop", quadrupole_integral_shellloop, METH_VARARGS, "Quadrupole integral shell loop in C"},
     {"octupole_integral_shellloop", octupole_integral_shellloop, METH_VARARGS, "Octupole integral shell loop in C"},
+    {"eri_shellloop", eri_shellloop, METH_VARARGS, "ERI 2-electron shell loop in C"},
     {NULL, NULL, 0, NULL}
 };
 


### PR DESCRIPTION
## Summary
- Added C shell-loop binding for 2-electron electron repulsion integrals (ERI)
- Part of Issue #229 (PR-6) [Week-4]
- Extends the `DEFINE_SHELLLOOP_INT1e` pattern from PR-5 to 2-electron integrals


## Changes

### libcint_wrap.c
- Added `eri_shellloop` — dedicated C function that loops over all 4 shells (I, J, K, L) internally and fills the complete 4-dimensional ERI tensor in one call
- Uses 8-fold permutation symmetry to fill all equivalent elements
- Registered in `PyMethodDef`

### libcint.py
- Added `electron_repulsion()` method in `CBasis` class that calls `eri_shellloop` directly
- Applies `transpose(0, 2, 1, 3)` to convert from chemist to physicist notation, matching the existing `electron_repulsion_integral()` output


## Performance Results
Tested on H, He, Li with cc-pVDZ basis set (nbfn=24):

| Integral | Python Loop | C Loop    | Speedup |
|----------|-------------|-----------|---------|
| overlap  | 0.792 ms    | 0.061 ms  | ~13.0x  |
| kinetic  | 0.788 ms    | 0.071 ms  | ~11.2x  |
| nuclear  | 0.788 ms    | 0.080 ms  | ~9.9x   |
| rinv     | 0.772 ms    | 0.063 ms  | ~12.3x  |
| ERI      | 119.656 ms  | 21.552 ms | ~5.6x   |




## Correctness Results
Tested on H, He, Li with cc-pVDZ basis set (nbfn=24), `atol=1e-4`:

| Integral | Match |
|----------|-------|
| overlap | ✅ True |
| kinetic | ✅ True |
| nuclear | ✅ True |
| rinv | ✅ True |
| ERI | ✅ True |



## How To Test

**Build locally:**
```bash
pip install -e . --no-build-isolation
```

**Correctness test:**
```bash
python3 << 'EOF'
from gbasis.integrals.libcint import CBasis
from gbasis.parsers import make_contractions, parse_nwchem
import numpy as np

basis_dict = parse_nwchem("tests/data_ccpvdz.nwchem")
atcoords = np.eye(3) / 0.5291772083
atsyms = ["H", "He", "Li"]
py_basis = make_contractions(basis_dict, atsyms, atcoords, coord_types="spherical")
cb = CBasis(py_basis, atsyms, atcoords)

print("eri match:", np.allclose(cb.electron_repulsion_integral(), cb.electron_repulsion(), atol=1e-4))
EOF
```
Output:
```

eri match: True

```

---
**Speed Test**
```bash
python3 << 'EOF'
from gbasis.integrals.libcint import CBasis
from gbasis.parsers import make_contractions, parse_nwchem
import numpy as np
import time

basis_dict = parse_nwchem("tests/data_ccpvdz.nwchem")
atcoords = np.eye(3) / 0.5291772083
atsyms = ["H", "He", "Li"]
py_basis = make_contractions(basis_dict, atsyms, atcoords, coord_types="spherical")
cb = CBasis(py_basis, atsyms, atcoords)

# Warm-up
cb.electron_repulsion_integral()
cb.electron_repulsion()

tests = [
    ("overlap", cb.overlap_integral, cb.overlap),
    ("kinetic", cb.kinetic_energy_integral, cb.kinetic_energy),
    ("nuclear", cb.nuclear_attraction_integral, cb.nuclear_attraction),
    ("rinv", lambda: cb.r_inv_integral(origin=np.zeros(3)), cb.rinv),
    ("eri", cb.electron_repulsion_integral, cb.electron_repulsion),
]

for name, py_fn, c_fn in tests:
    t0 = time.perf_counter()
    S_py = py_fn()
    t1 = time.perf_counter()
    t2 = time.perf_counter()
    S_c = c_fn()
    t3 = time.perf_counter()
    py_time = (t1-t0)*1000
    c_time = (t3-t2)*1000
    speedup = py_time/c_time
    print(f"{name:8s} | Python: {py_time:8.3f} ms | C: {c_time:8.3f} ms | Speedup: {speedup:6.1f}x")
EOF
```


Output:


<img width="1463" height="186" alt="Screenshot 2026-06-24 at 3 40 30 PM" src="https://github.com/user-attachments/assets/378eadea-7e08-4b06-ab9f-450c5ddee6b4" />

