### PR TITLE
PR-7 — feat: add C shell-loop bindings for point_charge, moment, momentum & tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ set_target_properties(gbasis_ext PROPERTIES
 
 # Expose Python and NumPy include directories to C extension module.
 target_include_directories(gbasis_ext PRIVATE
+    ${cint_SOURCE_DIR}/include
     ${Python_INCLUDE_DIRS} ${Python_NumPy_INCLUDE_DIRS})
 
 # Link C extension module with libcint/qcint.

--- a/gbasis/integrals/libcint.py
+++ b/gbasis/integrals/libcint.py
@@ -1163,7 +1163,7 @@ class CBasis:
         )
         return out
 
-    def momentum(self):
+    def momentum(self, origin=None):
         r"""
         Compute the momentum integrals.
 
@@ -1174,26 +1174,21 @@ class CBasis:
         .. math::
             p_{ij} = \langle \phi_i | -i\nabla | \phi_j \rangle
 
+        Parameters
+        ----------
+        origin : np.ndarray(3, dtype=float), default=[0, 0, 0]
+            Origin about which to evaluate integrals.
+
         Returns
         -------
-        out : np.ndarray(Nbasis, Nbasis, dtype=float)
+        out : np.ndarray(Nbasis, Nbasis, 3, dtype=complex)
             Momentum integral array.
 
-        Notes
-        -----
-        Returns the raw single-component output from ``int1e_ipovlp_sph``
-        without the :math:`-i` scaling factor. The full 3-component momentum
-        integral (x, y, z) with proper scaling is available via
-        ``momentum_integral()``.
-
         """
+        if origin is None:
+            origin = np.zeros(3)
+        return self._mom(origin=origin)
 
-        out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
-        libcint_bindings.momentum_integral_shellloop(
-            out, self.natm, self.atm, self.nbas,
-            self.bas, self.env, self._offs, self.nbfn
-        )
-        return out
 
     def rinv(self):
         r"""

--- a/gbasis/integrals/libcint.py
+++ b/gbasis/integrals/libcint.py
@@ -1326,12 +1326,12 @@ class CBasis:
             Electron repulsion integral array.
 
         """
-        out = np.zeros((self.nbfn, self.nbfn, self.nbfn, self.nbfn), dtype=c_double, order='F')
+        out = np.zeros((self.nbfn, self.nbfn, self.nbfn, self.nbfn), dtype=c_double)
         libcint_bindings.eri_shellloop(
             out, self.natm, self.atm, self.nbas,
             self.bas, self.env, self._offs, self.nbfn
         )
-        return out.transpose(0, 2, 1, 3)
+        return out
 
     def electron_repulsion_integral(self, notation="physicist", transform=None):
         r"""

--- a/gbasis/integrals/libcint.py
+++ b/gbasis/integrals/libcint.py
@@ -1106,7 +1106,7 @@ class CBasis:
 
         """
         out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
-        libcint_bindings.overlap_integral_shellloop(
+        libcint_bindings.overlap_integral_array(
             out, self.natm, self.atm, self.nbas,
             self.bas, self.env, self._offs, self.nbfn
         )
@@ -1130,7 +1130,7 @@ class CBasis:
 
         """
         out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
-        libcint_bindings.kinetic_integral_shellloop(
+        libcint_bindings.kinetic_integral_array(
             out, self.natm, self.atm, self.nbas,
             self.bas, self.env, self._offs, self.nbfn
         )
@@ -1157,7 +1157,7 @@ class CBasis:
 
         """
         out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
-        libcint_bindings.nuclear_integral_shellloop(
+        libcint_bindings.nuclear_integral_array(
             out, self.natm, self.atm, self.nbas,
             self.bas, self.env, self._offs, self.nbfn
         )
@@ -1213,7 +1213,7 @@ class CBasis:
 
         """
         out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
-        libcint_bindings.rinv_integral_shellloop(
+        libcint_bindings.rinv_integral_array(
             out, self.natm, self.atm, self.nbas,
             self.bas, self.env, self._offs, self.nbfn
         )
@@ -1243,7 +1243,7 @@ class CBasis:
 
         """
         out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
-        libcint_bindings.dipole_integral_shellloop(
+        libcint_bindings.dipole_integral_array(
             out, self.natm, self.atm, self.nbas,
             self.bas, self.env, self._offs, self.nbfn
         )
@@ -1273,7 +1273,7 @@ class CBasis:
 
         """
         out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
-        libcint_bindings.quadrupole_integral_shellloop(
+        libcint_bindings.quadrupole_integral_array(
             out, self.natm, self.atm, self.nbas,
             self.bas, self.env, self._offs, self.nbfn
         )
@@ -1303,7 +1303,7 @@ class CBasis:
 
         """
         out = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
-        libcint_bindings.octupole_integral_shellloop(
+        libcint_bindings.octupole_integral_array(
             out, self.natm, self.atm, self.nbas,
             self.bas, self.env, self._offs, self.nbfn
         )
@@ -1338,7 +1338,7 @@ class CBasis:
             # Set inv_origin in env for this charge
             self.env[4:7] = coord
             val = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
-            libcint_bindings.rinv_integral_shellloop(
+            libcint_bindings.rinv_integral_array(
                 val, self.natm, self.atm, self.nbas,
                 self.bas, self.env, self._offs, self.nbfn
             )
@@ -1401,7 +1401,7 @@ class CBasis:
 
         """
         out = np.zeros((self.nbfn, self.nbfn, self.nbfn, self.nbfn), dtype=c_double)
-        libcint_bindings.eri_shellloop(
+        libcint_bindings.eri_array(
             out, self.natm, self.atm, self.nbas,
             self.bas, self.env, self._offs, self.nbfn
         )

--- a/gbasis/integrals/libcint.py
+++ b/gbasis/integrals/libcint.py
@@ -1309,7 +1309,29 @@ class CBasis:
         )
         return out
 
-    
+    def electron_repulsion(self):
+        r"""
+        Compute the electron repulsion integrals.
+
+        The two-electron repulsion integral between basis functions
+        :math:`\phi_i`, :math:`\phi_j`, :math:`\phi_k`, and :math:`\phi_l`
+        is defined as:
+
+        .. math::
+            g_{ijkl} = \langle \phi_i \phi_j | \frac{1}{r_{12}} | \phi_k \phi_l \rangle
+
+        Returns
+        -------
+        out : np.ndarray(Nbasis, Nbasis, Nbasis, Nbasis, dtype=float)
+            Electron repulsion integral array.
+
+        """
+        out = np.zeros((self.nbfn, self.nbfn, self.nbfn, self.nbfn), dtype=c_double, order='F')
+        libcint_bindings.eri_shellloop(
+            out, self.natm, self.atm, self.nbas,
+            self.bas, self.env, self._offs, self.nbfn
+        )
+        return out.transpose(0, 2, 1, 3)
 
     def electron_repulsion_integral(self, notation="physicist", transform=None):
         r"""

--- a/gbasis/integrals/libcint.py
+++ b/gbasis/integrals/libcint.py
@@ -1345,7 +1345,7 @@ class CBasis:
             val *= -charge
             out[:, :, icharge] = val
         return out
-
+        
     def moment(self, orders, origin=None):
         r"""
         Compute the moment integrals.
@@ -1380,7 +1380,7 @@ class CBasis:
             if sum(order) == 0:
                 out[:, :, i] = self.overlap()
             else:
-                out[:, :, i] = self._moments[tuple(order)]()
+                out[:, :, i] = self._moments[tuple(order)](origin=origin)        
         return out
 
     def electron_repulsion(self):

--- a/gbasis/integrals/libcint.py
+++ b/gbasis/integrals/libcint.py
@@ -1184,7 +1184,12 @@ class CBasis:
         out : np.ndarray(Nbasis, Nbasis, 3, dtype=complex)
             Momentum integral array.
 
+        Notes
+        -----
+        Returns the full 3-component complex momentum integral (x, y, z)
+        with proper :math:`-i` scaling. Equivalent to ``momentum_integral()``.
         """
+        
         if origin is None:
             origin = np.zeros(3)
         return self._mom(origin=origin)

--- a/gbasis/integrals/libcint.py
+++ b/gbasis/integrals/libcint.py
@@ -1309,6 +1309,80 @@ class CBasis:
         )
         return out
 
+    def point_charge(self, point_coords, point_charges):
+        r"""
+        Compute the point charge integrals.
+
+        The point charge integral represents the electrostatic potential due to
+        a set of point charges at given coordinates. For each pair of basis
+        functions :math:`\phi_i` and :math:`\phi_j`, it is defined as:
+
+        .. math::
+            V_{ij}^{(n)} = -q_n \langle \phi_i | \frac{1}{|\mathbf{r} - \mathbf{R}_n|} | \phi_j \rangle
+
+        Parameters
+        ----------
+        point_coords : np.ndarray(N, 3, dtype=float)
+            Coordinates of point charges.
+        point_charges : np.ndarray(N, dtype=float)
+            Charges of point charges.
+
+        Returns
+        -------
+        out : np.ndarray(Nbasis, Nbasis, N, dtype=float)
+            Point charge integral array.
+
+        """
+        out = np.zeros((self.nbfn, self.nbfn, len(point_charges)), dtype=c_double, order='F')
+        for icharge, (coord, charge) in enumerate(zip(point_coords, point_charges)):
+            # Set inv_origin in env for this charge
+            self.env[4:7] = coord
+            val = np.zeros((self.nbfn, self.nbfn), dtype=c_double, order='F')
+            libcint_bindings.rinv_integral_shellloop(
+                val, self.natm, self.atm, self.nbas,
+                self.bas, self.env, self._offs, self.nbfn
+            )
+            val *= -charge
+            out[:, :, icharge] = val
+        return out
+
+    def moment(self, orders, origin=None):
+        r"""
+        Compute the moment integrals.
+
+        The moment integral represents the expectation value of the position
+        operator raised to a given order between basis functions :math:`\phi_i`
+        and :math:`\phi_j`.
+
+        Parameters
+        ----------
+        orders : np.ndarray(N, 3, dtype=int)
+            Moment orders :math:`\left[x, y, z\right]` to evaluate.
+        origin : np.ndarray(3, dtype=float), default=[0, 0, 0]
+            Origin about which to evaluate integrals.
+
+        Returns
+        -------
+        out : np.ndarray(Nbasis, Nbasis, N, dtype=float)
+            Moment integral array.
+
+        Notes
+        -----
+        Uses the C shell-loop bindings for dipole, quadrupole, and octupole
+        integrals internally. Supports up to 3rd order moments.
+
+        """
+        if origin is None:
+            origin = np.zeros(3)
+        out = np.zeros((self.nbfn, self.nbfn, len(orders)), dtype=np.float64)
+        for i, order in enumerate(orders):
+            self.env[1:4] = origin
+            if sum(order) == 0:
+                out[:, :, i] = self.overlap()
+            else:
+                out[:, :, i] = self._moments[tuple(order)]()
+        return out
+
     def electron_repulsion(self):
         r"""
         Compute the electron repulsion integrals.

--- a/gbasis/integrals/src/libcint_wrap.c
+++ b/gbasis/integrals/src/libcint_wrap.c
@@ -142,13 +142,13 @@ electron_repulsion_sph(PyObject *self, PyObject *args)
 }
 
 /*
- * DEFINE_INT1E_SHELLLOOP_FN(func_name, libcint_func)
+ * DEFINE_INT1E_LOOP_FN(func_name, libcint_func)
  * Generates a C shell-loop wrapper for a 1-electron libcint integral that
  * returns the FULL integral array over all shells (not just one shell pair).
  * Loops over shells I, J; calls libcint_func per shell pair; fills the
  * symmetric output matrix using PyArray_GETPTR (NumPy C-API).
  */
-#define DEFINE_INT1E_SHELLLOOP_FN(func_name, libcint_func)                           \
+#define DEFINE_INT1E_LOOP_FN(func_name, libcint_func)                               \
 static PyObject *                                                                  \
 func_name(PyObject *self, PyObject *args)                                          \
 {                                                                                  \
@@ -170,7 +170,13 @@ func_name(PyObject *self, PyObject *args)                                       
     double *env  = (double *)PyArray_GETPTR1(env_arr, 0);                         \
     int    *offs = (int *)   PyArray_GETPTR1(offs_arr, 0);                        \
     int shls[2];                                                                   \
-    double buf[10000] = {0};                                                      \
+    int max_off = 0;                                                               \
+    for (int i = 0; i < nbas; i++) {                                              \
+        if (offs[i] > max_off) max_off = offs[i];                                 \
+    }                                                                              \
+    size_t buf_size = (size_t)max_off * max_off;                                  \
+    double *buf = calloc(buf_size, sizeof(double));                               \
+    if (!buf) { PyErr_NoMemory(); return NULL; }                                   \
     int ipos = 0;                                                                  \
     for (int ishl = 0; ishl < nbas; ishl++) {                                     \
         shls[0] = ishl;                                                            \
@@ -187,27 +193,28 @@ func_name(PyObject *self, PyObject *args)                                       
                     out[(jpos+q) * nbfn + (ipos+p)] = val;                        \
                 }                                                                  \
             }                                                                      \
-            memset(buf, 0, sizeof(buf));                                          \
+            memset(buf, 0, buf_size * sizeof(double));                             \
             jpos += q_off;                                                         \
         }                                                                          \
         ipos += p_off;                                                             \
-    }                                                                              \
+    }                            \
+    free(buf);                                                                          \
     Py_RETURN_NONE;                                                                \
 }
 
 /* Generate shell-loop wrappers for all 1-electron integrals using the macro */
-DEFINE_INT1E_SHELLLOOP_FN(overlap_integral_shellloop,    int1e_ovlp_sph)
-DEFINE_INT1E_SHELLLOOP_FN(kinetic_integral_shellloop,    int1e_kin_sph)
-DEFINE_INT1E_SHELLLOOP_FN(nuclear_integral_shellloop,    int1e_nuc_sph)
-DEFINE_INT1E_SHELLLOOP_FN(momentum_integral_shellloop,   int1e_ipovlp_sph)
-DEFINE_INT1E_SHELLLOOP_FN(rinv_integral_shellloop,       int1e_rinv_sph)
-DEFINE_INT1E_SHELLLOOP_FN(dipole_integral_shellloop,     int1e_r_sph)
-DEFINE_INT1E_SHELLLOOP_FN(quadrupole_integral_shellloop, int1e_rr_sph)
-DEFINE_INT1E_SHELLLOOP_FN(octupole_integral_shellloop,   int1e_rrr_sph)
+DEFINE_INT1E_LOOP_FN(overlap_integral_array,    int1e_ovlp_sph)
+DEFINE_INT1E_LOOP_FN(kinetic_integral_array,    int1e_kin_sph)
+DEFINE_INT1E_LOOP_FN(nuclear_integral_array,    int1e_nuc_sph)
+DEFINE_INT1E_LOOP_FN(momentum_integral_array,   int1e_ipovlp_sph)
+DEFINE_INT1E_LOOP_FN(rinv_integral_array,       int1e_rinv_sph)
+DEFINE_INT1E_LOOP_FN(dipole_integral_array,     int1e_r_sph)
+DEFINE_INT1E_LOOP_FN(quadrupole_integral_array, int1e_rr_sph)
+DEFINE_INT1E_LOOP_FN(octupole_integral_array,   int1e_rrr_sph)
 
-/* eri_shellloop — shell-by-shell loop in C for 2-electron ERI (4 shells: I,J,K,L) */
+/* eri_array — array-based loop in C for 2-electron ERI (4 shells: I,J,K,L) */
 static PyObject *
-eri_shellloop(PyObject *self, PyObject *args)
+eri_array(PyObject *self, PyObject *args)
 {
     PyArrayObject *out_arr, *atm_arr, *bas_arr, *env_arr, *offs_arr;
     int natm, nbas, nbfn;
@@ -230,8 +237,13 @@ eri_shellloop(PyObject *self, PyObject *args)
     int    *offs = (int *)   PyArray_GETPTR1(offs_arr, 0);
 
     int shls[4];
-    double buf[100000] = {0};
-
+    int max_off = 0;
+    for (int i = 0; i < nbas; i++) {
+        if (offs[i] > max_off) max_off = offs[i];
+    }
+    size_t buf_size = (size_t)max_off * max_off * max_off * max_off;
+    double *buf = calloc(buf_size, sizeof(double));
+    if (!buf) { PyErr_NoMemory(); return NULL; }
     int ipos = 0;
     for (int ishl = 0; ishl < nbas; ishl++) {
         shls[0] = ishl;
@@ -272,7 +284,7 @@ eri_shellloop(PyObject *self, PyObject *args)
                             }
                         }
                     }
-                    memset(buf, 0, sizeof(buf));
+                    memset(buf, 0, buf_size * sizeof(double));
                     lpos += s_off;
                 }
                 kpos += r_off;
@@ -281,6 +293,7 @@ eri_shellloop(PyObject *self, PyObject *args)
         }
         ipos += p_off;
     }
+    free(buf);
     Py_RETURN_NONE;
 }
 
@@ -296,15 +309,15 @@ static PyMethodDef LibcintMethods[] = {
     {"quadrupole_sph",       quadrupole_sph,       METH_VARARGS, "Quadrupole moment integral"},
     {"octupole_sph",         octupole_sph,         METH_VARARGS, "Octupole moment integral"},
     {"electron_repulsion_sph", electron_repulsion_sph, METH_VARARGS, "Electron repulsion integral"},
-    {"overlap_integral_shellloop", overlap_integral_shellloop, METH_VARARGS, "Overlap integral shell loop in C"},
-    {"kinetic_integral_shellloop", kinetic_integral_shellloop, METH_VARARGS, "Kinetic integral shell loop in C"},
-    {"nuclear_integral_shellloop", nuclear_integral_shellloop, METH_VARARGS, "Nuclear attraction integral shell loop in C"},
-    {"momentum_integral_shellloop", momentum_integral_shellloop, METH_VARARGS, "Momentum integral shell loop in C"},
-    {"rinv_integral_shellloop", rinv_integral_shellloop, METH_VARARGS, "1/r integral shell loop in C"},
-    {"dipole_integral_shellloop", dipole_integral_shellloop, METH_VARARGS, "Dipole integral shell loop in C"},
-    {"quadrupole_integral_shellloop", quadrupole_integral_shellloop, METH_VARARGS, "Quadrupole integral shell loop in C"},
-    {"octupole_integral_shellloop", octupole_integral_shellloop, METH_VARARGS, "Octupole integral shell loop in C"},
-    {"eri_shellloop", eri_shellloop, METH_VARARGS, "ERI 2-electron shell loop in C"},
+    {"overlap_integral_array", overlap_integral_array, METH_VARARGS, "Overlap integral array in C"},
+    {"kinetic_integral_array", kinetic_integral_array, METH_VARARGS, "Kinetic integral array in C"},
+    {"nuclear_integral_array", nuclear_integral_array, METH_VARARGS, "Nuclear attraction integral array in C"},
+    {"momentum_integral_array", momentum_integral_array, METH_VARARGS, "Momentum integral array in C"},
+    {"rinv_integral_array", rinv_integral_array, METH_VARARGS, "1/r integral array in C"},
+    {"dipole_integral_array", dipole_integral_array, METH_VARARGS, "Dipole integral array in C"},
+    {"quadrupole_integral_array", quadrupole_integral_array, METH_VARARGS, "Quadrupole integral array in C"},
+    {"octupole_integral_array", octupole_integral_array, METH_VARARGS, "Octupole integral array in C"},
+    {"eri_array", eri_array, METH_VARARGS, "ERI 2-electron array in C"},
     {NULL, NULL, 0, NULL}
 };
 

--- a/gbasis/integrals/src/libcint_wrap.c
+++ b/gbasis/integrals/src/libcint_wrap.c
@@ -68,13 +68,13 @@ extern int int1e_rrr_sph(double *out, int *dims, int *shls, int *atm, int natm, 
 extern int int2e_sph(double *out, int *dims, int *shls, int *atm, int natm, int *bas, int nbas, double *env, void *opt, double *cache);
 
 /*
- * DEFINE_INTEGRAL_INT1e(func_name, libcint_func)
+ * DEFINE_INT1E_ARRAY_FN(func_name, libcint_func)
  * Generates a Python/C API wrapper for a 1-electron libcint integral.
  * Accepts NumPy arrays directly — uses PyArray_GETPTR1 (NumPy C-API).
  */
 
 /* Macro for 1-electron wrappers */
-#define DEFINE_INTEGRAL_INT1e(func_name, libcint_func)                        \
+#define DEFINE_INT1E_ARRAY_FN(func_name, libcint_func)                        \
 static PyObject *                                                              \
 func_name(PyObject *self, PyObject *args)                                      \
 {                                                                              \
@@ -99,15 +99,15 @@ func_name(PyObject *self, PyObject *args)                                      \
     return PyLong_FromLong(result);                                            \
 }
 
-DEFINE_INTEGRAL_INT1e(overlap_sph,         int1e_ovlp_sph)
-DEFINE_INTEGRAL_INT1e(kinetic_sph,         int1e_kin_sph)
-DEFINE_INTEGRAL_INT1e(nuclear_sph,         int1e_nuc_sph)
-DEFINE_INTEGRAL_INT1e(momentum_sph,        int1e_ipovlp_sph)
-DEFINE_INTEGRAL_INT1e(angular_momentum_sph, int1e_cg_irxp_sph)
-DEFINE_INTEGRAL_INT1e(rinv_sph,            int1e_rinv_sph)
-DEFINE_INTEGRAL_INT1e(dipole_sph,          int1e_r_sph)
-DEFINE_INTEGRAL_INT1e(quadrupole_sph,      int1e_rr_sph)
-DEFINE_INTEGRAL_INT1e(octupole_sph,        int1e_rrr_sph)
+DEFINE_INT1E_ARRAY_FN(overlap_sph,         int1e_ovlp_sph)
+DEFINE_INT1E_ARRAY_FN(kinetic_sph,         int1e_kin_sph)
+DEFINE_INT1E_ARRAY_FN(nuclear_sph,         int1e_nuc_sph)
+DEFINE_INT1E_ARRAY_FN(momentum_sph,        int1e_ipovlp_sph)
+DEFINE_INT1E_ARRAY_FN(angular_momentum_sph, int1e_cg_irxp_sph)
+DEFINE_INT1E_ARRAY_FN(rinv_sph,            int1e_rinv_sph)
+DEFINE_INT1E_ARRAY_FN(dipole_sph,          int1e_r_sph)
+DEFINE_INT1E_ARRAY_FN(quadrupole_sph,      int1e_rr_sph)
+DEFINE_INT1E_ARRAY_FN(octupole_sph,        int1e_rrr_sph)
 
 /* 2-electron wrapper */
 
@@ -142,13 +142,13 @@ electron_repulsion_sph(PyObject *self, PyObject *args)
 }
 
 /*
- * DEFINE_SHELLLOOP_INT1e(func_name, libcint_func)
+ * DEFINE_INT1E_SHELLLOOP_FN(func_name, libcint_func)
  * Generates a C shell-loop wrapper for a 1-electron libcint integral that
  * returns the FULL integral array over all shells (not just one shell pair).
  * Loops over shells I, J; calls libcint_func per shell pair; fills the
  * symmetric output matrix using PyArray_GETPTR (NumPy C-API).
  */
-#define DEFINE_SHELLLOOP_INT1e(func_name, libcint_func)                           \
+#define DEFINE_INT1E_SHELLLOOP_FN(func_name, libcint_func)                           \
 static PyObject *                                                                  \
 func_name(PyObject *self, PyObject *args)                                          \
 {                                                                                  \
@@ -196,14 +196,14 @@ func_name(PyObject *self, PyObject *args)                                       
 }
 
 /* Generate shell-loop wrappers for all 1-electron integrals using the macro */
-DEFINE_SHELLLOOP_INT1e(overlap_integral_shellloop,    int1e_ovlp_sph)
-DEFINE_SHELLLOOP_INT1e(kinetic_integral_shellloop,    int1e_kin_sph)
-DEFINE_SHELLLOOP_INT1e(nuclear_integral_shellloop,    int1e_nuc_sph)
-DEFINE_SHELLLOOP_INT1e(momentum_integral_shellloop,   int1e_ipovlp_sph)
-DEFINE_SHELLLOOP_INT1e(rinv_integral_shellloop,       int1e_rinv_sph)
-DEFINE_SHELLLOOP_INT1e(dipole_integral_shellloop,     int1e_r_sph)
-DEFINE_SHELLLOOP_INT1e(quadrupole_integral_shellloop, int1e_rr_sph)
-DEFINE_SHELLLOOP_INT1e(octupole_integral_shellloop,   int1e_rrr_sph)
+DEFINE_INT1E_SHELLLOOP_FN(overlap_integral_shellloop,    int1e_ovlp_sph)
+DEFINE_INT1E_SHELLLOOP_FN(kinetic_integral_shellloop,    int1e_kin_sph)
+DEFINE_INT1E_SHELLLOOP_FN(nuclear_integral_shellloop,    int1e_nuc_sph)
+DEFINE_INT1E_SHELLLOOP_FN(momentum_integral_shellloop,   int1e_ipovlp_sph)
+DEFINE_INT1E_SHELLLOOP_FN(rinv_integral_shellloop,       int1e_rinv_sph)
+DEFINE_INT1E_SHELLLOOP_FN(dipole_integral_shellloop,     int1e_r_sph)
+DEFINE_INT1E_SHELLLOOP_FN(quadrupole_integral_shellloop, int1e_rr_sph)
+DEFINE_INT1E_SHELLLOOP_FN(octupole_integral_shellloop,   int1e_rrr_sph)
 
 /* eri_shellloop — shell-by-shell loop in C for 2-electron ERI (4 shells: I,J,K,L) */
 static PyObject *

--- a/gbasis/integrals/src/libcint_wrap.c
+++ b/gbasis/integrals/src/libcint_wrap.c
@@ -37,7 +37,9 @@
 #include <numpy/arrayobject.h>
 #include <stdlib.h>
 #include <string.h>
-
+/* CINTOpt forward declaration */
+typedef struct CINTOpt CINTOpt;
+extern void CINTdel_optimizer(CINTOpt **);
 
 /* Forward declarations for libcint spherical integral functions.
  * Signature: (out, dims, shls, atm, natm, bas, nbas, env, opt, cache)
@@ -64,9 +66,21 @@ extern int int1e_r_sph(double *out, int *dims, int *shls, int *atm, int natm, in
 extern int int1e_rr_sph(double *out, int *dims, int *shls, int *atm, int natm, int *bas, int nbas, double *env, void *opt, double *cache);
 extern int int1e_rrr_sph(double *out, int *dims, int *shls, int *atm, int natm, int *bas, int nbas, double *env, void *opt, double *cache);
 
+/* Optimizer forward declarations */
+extern void int1e_ovlp_sph_optimizer(CINTOpt **, int *, int, int *, int, double *);
+extern void int1e_kin_sph_optimizer(CINTOpt **, int *, int, int *, int, double *);
+extern void int1e_nuc_sph_optimizer(CINTOpt **, int *, int, int *, int, double *);
+extern void int1e_ipovlp_sph_optimizer(CINTOpt **, int *, int, int *, int, double *);
+extern void int1e_cg_irxp_sph_optimizer(CINTOpt **, int *, int, int *, int, double *);
+extern void int1e_rinv_sph_optimizer(CINTOpt **, int *, int, int *, int, double *);
+extern void int1e_r_sph_optimizer(CINTOpt **, int *, int, int *, int, double *);
+extern void int1e_rr_sph_optimizer(CINTOpt **, int *, int, int *, int, double *);
+extern void int1e_rrr_sph_optimizer(CINTOpt **, int *, int, int *, int, double *);
+extern void int2e_sph_optimizer(CINTOpt **, int *, int, int *, int, double *);
 /* Forward declaration — 2-electron integral */
 extern int int2e_sph(double *out, int *dims, int *shls, int *atm, int natm, int *bas, int nbas, double *env, void *opt, double *cache);
-
+/* Optimizer macro using token pasting */
+#define MAKE_OPTIMIZER(func) func##_optimizer
 /*
  * DEFINE_INT1E_ARRAY_FN(func_name, libcint_func)
  * Generates a Python/C API wrapper for a 1-electron libcint integral.
@@ -141,6 +155,62 @@ electron_repulsion_sph(PyObject *self, PyObject *args)
     return PyLong_FromLong(result);
 }
 
+/* Macro for integrals WITH optimizer support */
+#define DEFINE_INT1E_LOOP_FN_OPT(func_name, libcint_func)                         \
+static PyObject *                                                                   \
+func_name(PyObject *self, PyObject *args)                                           \
+{                                                                                   \
+    PyArrayObject *out_arr, *atm_arr, *bas_arr, *env_arr, *offs_arr;               \
+    int natm, nbas, nbfn;                                                           \
+    if (!PyArg_ParseTuple(args, "O!iO!iO!O!O!i",                                   \
+                          &PyArray_Type, &out_arr, &natm,                           \
+                          &PyArray_Type, &atm_arr, &nbas,                           \
+                          &PyArray_Type, &bas_arr,                                  \
+                          &PyArray_Type, &env_arr,                                  \
+                          &PyArray_Type, &offs_arr,                                 \
+                          &nbfn))                                                   \
+        return NULL;                                                                \
+    double *out  = (double *)PyArray_DATA(out_arr);                                \
+    int    *atm  = (int *)   PyArray_GETPTR2(atm_arr, 0, 0);                       \
+    int    *bas  = (int *)   PyArray_GETPTR2(bas_arr, 0, 0);                       \
+    double *env  = (double *)PyArray_GETPTR1(env_arr, 0);                          \
+    int    *offs = (int *)   PyArray_GETPTR1(offs_arr, 0);                         \
+    int max_off = 0;                                                                \
+    for (int i = 0; i < nbas; i++) {                                               \
+        if (offs[i] > max_off) max_off = offs[i];                                  \
+    }                                                                               \
+    size_t buf_size = (size_t)max_off * max_off;                                   \
+    double *buf = calloc(buf_size, sizeof(double));                                \
+    if (!buf) { PyErr_NoMemory(); return NULL; }                                   \
+    CINTOpt *opt = NULL;                                                            \
+    MAKE_OPTIMIZER(libcint_func)(&opt, atm, natm, bas, nbas, env);                 \
+    int shls[2];                                                                    \
+    int ipos = 0;                                                                   \
+    for (int ishl = 0; ishl < nbas; ishl++) {                                      \
+        shls[0] = ishl;                                                             \
+        int p_off = offs[ishl];                                                     \
+        int jpos = 0;                                                               \
+        for (int jshl = 0; jshl <= ishl; jshl++) {                                 \
+            shls[1] = jshl;                                                         \
+            int q_off = offs[jshl];                                                 \
+            libcint_func(buf, NULL, shls, atm, natm, bas, nbas, env, opt, NULL);   \
+            for (int p = 0; p < p_off; p++) {                                      \
+                for (int q = 0; q < q_off; q++) {                                  \
+                    double val = buf[p + q * p_off];                               \
+                    out[(ipos+p) * nbfn + (jpos+q)] = val;                         \
+                    out[(jpos+q) * nbfn + (ipos+p)] = val;                         \
+                }                                                                   \
+            }                                                                       \
+            memset(buf, 0, buf_size * sizeof(double));                              \
+            jpos += q_off;                                                          \
+        }                                                                           \
+        ipos += p_off;                                                              \
+    }                                                                               \
+    CINTdel_optimizer(&opt);                                                        \
+    free(buf);                                                                      \
+    Py_RETURN_NONE;                                                                 \
+}
+
 /*
  * DEFINE_INT1E_LOOP_FN(func_name, libcint_func)
  * Generates a C shell-loop wrapper for a 1-electron libcint integral that
@@ -177,6 +247,8 @@ func_name(PyObject *self, PyObject *args)                                       
     size_t buf_size = (size_t)max_off * max_off;                                  \
     double *buf = calloc(buf_size, sizeof(double));                               \
     if (!buf) { PyErr_NoMemory(); return NULL; }                                   \
+    CINTOpt *opt = NULL;                                                               \
+    /*MAKE_OPTIMIZER(libcint_func)(&opt, atm, natm, bas, nbas, env);*/                   \
     int ipos = 0;                                                                  \
     for (int ishl = 0; ishl < nbas; ishl++) {                                     \
         shls[0] = ishl;                                                            \
@@ -185,7 +257,7 @@ func_name(PyObject *self, PyObject *args)                                       
         for (int jshl = 0; jshl <= ishl; jshl++) {                                \
             shls[1] = jshl;                                                        \
             int q_off = offs[jshl];                                               \
-            libcint_func(buf, NULL, shls, atm, natm, bas, nbas, env, NULL, NULL); \
+            libcint_func(buf, NULL, shls, atm, natm, bas, nbas, env, opt, NULL);  \
             for (int p = 0; p < p_off; p++) {                                     \
                 for (int q = 0; q < q_off; q++) {                                 \
                     double val = buf[p + q * p_off];                              \
@@ -198,6 +270,7 @@ func_name(PyObject *self, PyObject *args)                                       
         }                                                                          \
         ipos += p_off;                                                             \
     }                            \
+    CINTdel_optimizer(&opt);      \  
     free(buf);                                                                          \
     Py_RETURN_NONE;                                                                \
 }
@@ -244,6 +317,8 @@ eri_array(PyObject *self, PyObject *args)
     size_t buf_size = (size_t)max_off * max_off * max_off * max_off;
     double *buf = calloc(buf_size, sizeof(double));
     if (!buf) { PyErr_NoMemory(); return NULL; }
+    CINTOpt *opt = NULL;
+    /*int2e_sph_optimizer(&opt, atm, natm, bas, nbas, env);*/
     int ipos = 0;
     for (int ishl = 0; ishl < nbas; ishl++) {
         shls[0] = ishl;
@@ -266,7 +341,7 @@ eri_array(PyObject *self, PyObject *args)
                     }
                     shls[3] = lshl;
                     int s_off = offs[lshl];
-                    int2e_sph(buf, NULL, shls, atm, natm, bas, nbas, env, NULL, NULL);
+                    int2e_sph(buf, NULL, shls, atm, natm, bas, nbas, env, opt, NULL);
                     for (int p = 0; p < p_off; p++) {
                         for (int q = 0; q < q_off; q++) {
                             for (int r = 0; r < r_off; r++) {
@@ -293,6 +368,7 @@ eri_array(PyObject *self, PyObject *args)
         }
         ipos += p_off;
     }
+    CINTdel_optimizer(&opt);
     free(buf);
     Py_RETURN_NONE;
 }

--- a/gbasis/integrals/src/libcint_wrap.c
+++ b/gbasis/integrals/src/libcint_wrap.c
@@ -67,20 +67,22 @@ extern int int1e_rr_sph(double *out, int *dims, int *shls, int *atm, int natm, i
 extern int int1e_rrr_sph(double *out, int *dims, int *shls, int *atm, int natm, int *bas, int nbas, double *env, void *opt, double *cache);
 
 /* Optimizer forward declarations */
-extern void int1e_ovlp_sph_optimizer(CINTOpt **, int *, int, int *, int, double *);
-extern void int1e_kin_sph_optimizer(CINTOpt **, int *, int, int *, int, double *);
-extern void int1e_nuc_sph_optimizer(CINTOpt **, int *, int, int *, int, double *);
-extern void int1e_ipovlp_sph_optimizer(CINTOpt **, int *, int, int *, int, double *);
-extern void int1e_cg_irxp_sph_optimizer(CINTOpt **, int *, int, int *, int, double *);
-extern void int1e_rinv_sph_optimizer(CINTOpt **, int *, int, int *, int, double *);
-extern void int1e_r_sph_optimizer(CINTOpt **, int *, int, int *, int, double *);
-extern void int1e_rr_sph_optimizer(CINTOpt **, int *, int, int *, int, double *);
-extern void int1e_rrr_sph_optimizer(CINTOpt **, int *, int, int *, int, double *);
-extern void int2e_sph_optimizer(CINTOpt **, int *, int, int *, int, double *);
+extern void int1e_ovlp_optimizer(CINTOpt **, int *, int, int *, int, double *);
+extern void int1e_kin_optimizer(CINTOpt **, int *, int, int *, int, double *);
+extern void int1e_nuc_optimizer(CINTOpt **, int *, int, int *, int, double *);
+extern void int1e_ipovlp_optimizer(CINTOpt **, int *, int, int *, int, double *);
+extern void int1e_cg_irxp_optimizer(CINTOpt **, int *, int, int *, int, double *);
+extern void int1e_rinv_optimizer(CINTOpt **, int *, int, int *, int, double *);
+extern void int1e_r_optimizer(CINTOpt **, int *, int, int *, int, double *);
+extern void int1e_rr_optimizer(CINTOpt **, int *, int, int *, int, double *);
+extern void int1e_rrr_optimizer(CINTOpt **, int *, int, int *, int, double *);
+extern void cint2e_sph_optimizer(CINTOpt **, int *, int, int *, int, double *);
+extern void CINTall_1e_optimizer(CINTOpt **, int *, int, int *, int, double *);
 /* Forward declaration — 2-electron integral */
 extern int int2e_sph(double *out, int *dims, int *shls, int *atm, int natm, int *bas, int nbas, double *env, void *opt, double *cache);
 /* Optimizer macro using token pasting */
-#define MAKE_OPTIMIZER(func) func##_optimizer
+#define MAKE_OPTIMIZER(func) c##func##_optimizer
+
 /*
  * DEFINE_INT1E_ARRAY_FN(func_name, libcint_func)
  * Generates a Python/C API wrapper for a 1-electron libcint integral.
@@ -183,7 +185,7 @@ func_name(PyObject *self, PyObject *args)                                       
     double *buf = calloc(buf_size, sizeof(double));                                \
     if (!buf) { PyErr_NoMemory(); return NULL; }                                   \
     CINTOpt *opt = NULL;                                                            \
-    MAKE_OPTIMIZER(libcint_func)(&opt, atm, natm, bas, nbas, env);                 \
+    CINTall_1e_optimizer(&opt, atm, natm, bas, nbas, env);                    \
     int shls[2];                                                                    \
     int ipos = 0;                                                                   \
     for (int ishl = 0; ishl < nbas; ishl++) {                                      \
@@ -248,7 +250,7 @@ func_name(PyObject *self, PyObject *args)                                       
     double *buf = calloc(buf_size, sizeof(double));                               \
     if (!buf) { PyErr_NoMemory(); return NULL; }                                   \
     CINTOpt *opt = NULL;                                                               \
-    /*MAKE_OPTIMIZER(libcint_func)(&opt, atm, natm, bas, nbas, env);*/                   \
+    /* CINTall_1e_optimizer(&opt, atm, natm, bas, nbas, env); */                   \
     int ipos = 0;                                                                  \
     for (int ishl = 0; ishl < nbas; ishl++) {                                     \
         shls[0] = ishl;                                                            \
@@ -276,9 +278,9 @@ func_name(PyObject *self, PyObject *args)                                       
 }
 
 /* Generate shell-loop wrappers for all 1-electron integrals using the macro */
-DEFINE_INT1E_LOOP_FN(overlap_integral_array,    int1e_ovlp_sph)
-DEFINE_INT1E_LOOP_FN(kinetic_integral_array,    int1e_kin_sph)
-DEFINE_INT1E_LOOP_FN(nuclear_integral_array,    int1e_nuc_sph)
+DEFINE_INT1E_LOOP_FN_OPT(overlap_integral_array,    int1e_ovlp_sph)
+DEFINE_INT1E_LOOP_FN_OPT(kinetic_integral_array,    int1e_kin_sph)
+DEFINE_INT1E_LOOP_FN_OPT(nuclear_integral_array,    int1e_nuc_sph)
 DEFINE_INT1E_LOOP_FN(momentum_integral_array,   int1e_ipovlp_sph)
 DEFINE_INT1E_LOOP_FN(rinv_integral_array,       int1e_rinv_sph)
 DEFINE_INT1E_LOOP_FN(dipole_integral_array,     int1e_r_sph)
@@ -318,7 +320,7 @@ eri_array(PyObject *self, PyObject *args)
     double *buf = calloc(buf_size, sizeof(double));
     if (!buf) { PyErr_NoMemory(); return NULL; }
     CINTOpt *opt = NULL;
-    /*int2e_sph_optimizer(&opt, atm, natm, bas, nbas, env);*/
+    cint2e_sph_optimizer(&opt, atm, natm, bas, nbas, env);
     int ipos = 0;
     for (int ishl = 0; ishl < nbas; ishl++) {
         shls[0] = ishl;

--- a/gbasis/integrals/src/libcint_wrap.c
+++ b/gbasis/integrals/src/libcint_wrap.c
@@ -158,7 +158,7 @@ electron_repulsion_sph(PyObject *self, PyObject *args)
 }
 
 /* Macro for integrals WITH optimizer support */
-#define DEFINE_INT1E_LOOP_FN_OPT(func_name, libcint_func)                         \
+#define DEFINE_INT1E_LOOP_FN_OPT(func_name, libcint_func,opt_func)                         \
 static PyObject *                                                                   \
 func_name(PyObject *self, PyObject *args)                                           \
 {                                                                                   \
@@ -185,7 +185,7 @@ func_name(PyObject *self, PyObject *args)                                       
     double *buf = calloc(buf_size, sizeof(double));                                \
     if (!buf) { PyErr_NoMemory(); return NULL; }                                   \
     CINTOpt *opt = NULL;                                                            \
-    CINTall_1e_optimizer(&opt, atm, natm, bas, nbas, env);                    \
+    opt_func##_optimizer(&opt, atm, natm, bas, nbas, env);      \
     int shls[2];                                                                    \
     int ipos = 0;                                                                   \
     for (int ishl = 0; ishl < nbas; ishl++) {                                      \
@@ -220,72 +220,70 @@ func_name(PyObject *self, PyObject *args)                                       
  * Loops over shells I, J; calls libcint_func per shell pair; fills the
  * symmetric output matrix using PyArray_GETPTR (NumPy C-API).
  */
-#define DEFINE_INT1E_LOOP_FN(func_name, libcint_func)                               \
-static PyObject *                                                                  \
-func_name(PyObject *self, PyObject *args)                                          \
-{                                                                                  \
-    PyArrayObject *out_arr, *atm_arr, *bas_arr, *env_arr, *offs_arr;              \
-    int natm, nbas, nbfn;                                                          \
-    if (!PyArg_ParseTuple(args, "O!iO!iO!O!O!i",                                  \
-                          &PyArray_Type, &out_arr,                                 \
-                          &natm,                                                   \
-                          &PyArray_Type, &atm_arr,                                 \
-                          &nbas,                                                   \
-                          &PyArray_Type, &bas_arr,                                 \
-                          &PyArray_Type, &env_arr,                                 \
-                          &PyArray_Type, &offs_arr,                                \
-                          &nbfn))                                                  \
-        return NULL;                                                               \
-    double *out  = (double *)PyArray_DATA(out_arr);                               \
-    int    *atm  = (int *)   PyArray_GETPTR2(atm_arr, 0, 0);                      \
-    int    *bas  = (int *)   PyArray_GETPTR2(bas_arr, 0, 0);                      \
-    double *env  = (double *)PyArray_GETPTR1(env_arr, 0);                         \
-    int    *offs = (int *)   PyArray_GETPTR1(offs_arr, 0);                        \
-    int shls[2];                                                                   \
-    int max_off = 0;                                                               \
-    for (int i = 0; i < nbas; i++) {                                              \
-        if (offs[i] > max_off) max_off = offs[i];                                 \
-    }                                                                              \
-    size_t buf_size = (size_t)max_off * max_off;                                  \
-    double *buf = calloc(buf_size, sizeof(double));                               \
+#define DEFINE_INT1E_LOOP_FN(func_name, libcint_func, opt_func)                    \
+static PyObject *                                                                   \
+func_name(PyObject *self, PyObject *args)                                           \
+{                                                                                   \
+    PyArrayObject *out_arr, *atm_arr, *bas_arr, *env_arr, *offs_arr;               \
+    int natm, nbas, nbfn;                                                           \
+    if (!PyArg_ParseTuple(args, "O!iO!iO!O!O!i",                                   \
+                          &PyArray_Type, &out_arr, &natm,                           \
+                          &PyArray_Type, &atm_arr, &nbas,                           \
+                          &PyArray_Type, &bas_arr,                                  \
+                          &PyArray_Type, &env_arr,                                  \
+                          &PyArray_Type, &offs_arr,                                 \
+                          &nbfn))                                                   \
+        return NULL;                                                                \
+    double *out  = (double *)PyArray_DATA(out_arr);                                \
+    int    *atm  = (int *)   PyArray_GETPTR2(atm_arr, 0, 0);                       \
+    int    *bas  = (int *)   PyArray_GETPTR2(bas_arr, 0, 0);                       \
+    double *env  = (double *)PyArray_GETPTR1(env_arr, 0);                          \
+    int    *offs = (int *)   PyArray_GETPTR1(offs_arr, 0);                         \
+    int shls[2];                                                                    \
+    int max_off = 0;                                                                \
+    for (int i = 0; i < nbas; i++) {                                               \
+        if (offs[i] > max_off) max_off = offs[i];                                  \
+    }                                                                               \
+    size_t buf_size = (size_t)max_off * max_off * 27;                                   \
+    double *buf = calloc(buf_size, sizeof(double));                                \
     if (!buf) { PyErr_NoMemory(); return NULL; }                                   \
-    CINTOpt *opt = NULL;                                                               \
-    /* CINTall_1e_optimizer(&opt, atm, natm, bas, nbas, env); */                   \
-    int ipos = 0;                                                                  \
-    for (int ishl = 0; ishl < nbas; ishl++) {                                     \
-        shls[0] = ishl;                                                            \
-        int p_off = offs[ishl];                                                   \
-        int jpos = 0;                                                              \
-        for (int jshl = 0; jshl <= ishl; jshl++) {                                \
-            shls[1] = jshl;                                                        \
-            int q_off = offs[jshl];                                               \
-            libcint_func(buf, NULL, shls, atm, natm, bas, nbas, env, opt, NULL);  \
-            for (int p = 0; p < p_off; p++) {                                     \
-                for (int q = 0; q < q_off; q++) {                                 \
-                    double val = buf[p + q * p_off];                              \
-                    out[(ipos+p) * nbfn + (jpos+q)] = val;                        \
-                    out[(jpos+q) * nbfn + (ipos+p)] = val;                        \
-                }                                                                  \
-            }                                                                      \
-            memset(buf, 0, buf_size * sizeof(double));                             \
-            jpos += q_off;                                                         \
-        }                                                                          \
-        ipos += p_off;                                                             \
-    }                            \
-    CINTdel_optimizer(&opt);      \  
-    free(buf);                                                                          \
-    Py_RETURN_NONE;                                                                \
+    CINTOpt *opt = NULL;                                                            \
+    opt_func##_optimizer(&opt, atm, natm, bas, nbas, env);                         \
+    int ipos = 0;                                                                   \
+    for (int ishl = 0; ishl < nbas; ishl++) {                                      \
+        shls[0] = ishl;                                                             \
+        int p_off = offs[ishl];                                                     \
+        int jpos = 0;                                                               \
+        for (int jshl = 0; jshl <= ishl; jshl++) {                                 \
+            shls[1] = jshl;                                                         \
+            int q_off = offs[jshl];                                                 \
+            libcint_func(buf, NULL, shls, atm, natm, bas, nbas, env, opt, NULL);   \
+            for (int p = 0; p < p_off; p++) {                                      \
+                for (int q = 0; q < q_off; q++) {                                  \
+                    double val = buf[p + q * p_off];                               \
+                    out[(ipos+p) * nbfn + (jpos+q)] = val;                         \
+                    out[(jpos+q) * nbfn + (ipos+p)] = val;                         \
+                }                                                                   \
+            }                                                                       \
+            memset(buf, 0, buf_size * sizeof(double));                              \
+            jpos += q_off;                                                          \
+        }                                                                           \
+        ipos += p_off;                                                              \
+    }                                                                               \
+    CINTdel_optimizer(&opt);                                                        \
+    free(buf);                                                                      \
+    Py_RETURN_NONE;                                                                 \
 }
 
 /* Generate shell-loop wrappers for all 1-electron integrals using the macro */
-DEFINE_INT1E_LOOP_FN_OPT(overlap_integral_array,    int1e_ovlp_sph)
-DEFINE_INT1E_LOOP_FN_OPT(kinetic_integral_array,    int1e_kin_sph)
-DEFINE_INT1E_LOOP_FN_OPT(nuclear_integral_array,    int1e_nuc_sph)
-DEFINE_INT1E_LOOP_FN(momentum_integral_array,   int1e_ipovlp_sph)
-DEFINE_INT1E_LOOP_FN(rinv_integral_array,       int1e_rinv_sph)
-DEFINE_INT1E_LOOP_FN(dipole_integral_array,     int1e_r_sph)
-DEFINE_INT1E_LOOP_FN(quadrupole_integral_array, int1e_rr_sph)
-DEFINE_INT1E_LOOP_FN(octupole_integral_array,   int1e_rrr_sph)
+DEFINE_INT1E_LOOP_FN_OPT(overlap_integral_array, int1e_ovlp_sph, int1e_ovlp)
+DEFINE_INT1E_LOOP_FN_OPT(kinetic_integral_array, int1e_kin_sph,  int1e_kin)
+DEFINE_INT1E_LOOP_FN_OPT(nuclear_integral_array, int1e_nuc_sph,  int1e_nuc)
+DEFINE_INT1E_LOOP_FN(momentum_integral_array,   int1e_ipovlp_sph, int1e_ipovlp)
+DEFINE_INT1E_LOOP_FN(rinv_integral_array,       int1e_rinv_sph,   int1e_rinv)
+DEFINE_INT1E_LOOP_FN(dipole_integral_array,     int1e_r_sph,      int1e_r)
+DEFINE_INT1E_LOOP_FN(quadrupole_integral_array, int1e_rr_sph,     int1e_rr)
+DEFINE_INT1E_LOOP_FN(octupole_integral_array,   int1e_rrr_sph,    int1e_rrr)
 
 /* eri_array — array-based loop in C for 2-electron ERI (4 shells: I,J,K,L) */
 static PyObject *

--- a/gbasis/integrals/src/libcint_wrap.c
+++ b/gbasis/integrals/src/libcint_wrap.c
@@ -261,15 +261,14 @@ eri_shellloop(PyObject *self, PyObject *args)
                                 for (int s = 0; s < s_off; s++) {
                                     double val = buf[p + p_off*(q + q_off*(r + r_off*s))];
                                     int i = ipos+p, j = jpos+q, k = kpos+r, l = lpos+s;
-                                    out[i*nbfn*nbfn*nbfn + j*nbfn*nbfn + k*nbfn + l] = val;
-                                    out[i*nbfn*nbfn*nbfn + j*nbfn*nbfn + l*nbfn + k] = val;
-                                    out[j*nbfn*nbfn*nbfn + i*nbfn*nbfn + k*nbfn + l] = val;
-                                    out[j*nbfn*nbfn*nbfn + i*nbfn*nbfn + l*nbfn + k] = val;
-                                    out[k*nbfn*nbfn*nbfn + l*nbfn*nbfn + i*nbfn + j] = val;
-                                    out[k*nbfn*nbfn*nbfn + l*nbfn*nbfn + j*nbfn + i] = val;
-                                    out[l*nbfn*nbfn*nbfn + k*nbfn*nbfn + i*nbfn + j] = val;
-                                    out[l*nbfn*nbfn*nbfn + k*nbfn*nbfn + j*nbfn + i] = val;
-                                }
+                                    out[i*nbfn*nbfn*nbfn + k*nbfn*nbfn + j*nbfn + l] = val;
+                                    out[i*nbfn*nbfn*nbfn + l*nbfn*nbfn + j*nbfn + k] = val;
+                                    out[j*nbfn*nbfn*nbfn + k*nbfn*nbfn + i*nbfn + l] = val;
+                                    out[j*nbfn*nbfn*nbfn + l*nbfn*nbfn + i*nbfn + k] = val;
+                                    out[k*nbfn*nbfn*nbfn + i*nbfn*nbfn + l*nbfn + j] = val;
+                                    out[k*nbfn*nbfn*nbfn + j*nbfn*nbfn + l*nbfn + i] = val;
+                                    out[l*nbfn*nbfn*nbfn + i*nbfn*nbfn + k*nbfn + j] = val;
+                                    out[l*nbfn*nbfn*nbfn + j*nbfn*nbfn + k*nbfn + i] = val;                                }
                             }
                         }
                     }

--- a/gbasis/integrals/src/libcint_wrap.c
+++ b/gbasis/integrals/src/libcint_wrap.c
@@ -206,7 +206,84 @@ DEFINE_SHELLLOOP_INT1e(quadrupole_integral_shellloop, int1e_rr_sph)
 DEFINE_SHELLLOOP_INT1e(octupole_integral_shellloop,   int1e_rrr_sph)
 
 /* eri_shellloop — shell-by-shell loop in C for 2-electron ERI (4 shells: I,J,K,L) */
+static PyObject *
+eri_shellloop(PyObject *self, PyObject *args)
+{
+    PyArrayObject *out_arr, *atm_arr, *bas_arr, *env_arr, *offs_arr;
+    int natm, nbas, nbfn;
 
+    if (!PyArg_ParseTuple(args, "O!iO!iO!O!O!i",
+                          &PyArray_Type, &out_arr,
+                          &natm,
+                          &PyArray_Type, &atm_arr,
+                          &nbas,
+                          &PyArray_Type, &bas_arr,
+                          &PyArray_Type, &env_arr,
+                          &PyArray_Type, &offs_arr,
+                          &nbfn))
+        return NULL;
+
+    double *out  = (double *)PyArray_DATA(out_arr);
+    int    *atm  = (int *)   PyArray_GETPTR2(atm_arr, 0, 0);
+    int    *bas  = (int *)   PyArray_GETPTR2(bas_arr, 0, 0);
+    double *env  = (double *)PyArray_GETPTR1(env_arr, 0);
+    int    *offs = (int *)   PyArray_GETPTR1(offs_arr, 0);
+
+    int shls[4];
+    double buf[100000] = {0};
+
+    int ipos = 0;
+    for (int ishl = 0; ishl < nbas; ishl++) {
+        shls[0] = ishl;
+        int p_off = offs[ishl];
+        int jpos = 0;
+        for (int jshl = 0; jshl <= ishl; jshl++) {
+            int ij = ((ishl + 1) * ishl) / 2 + jshl;
+            shls[1] = jshl;
+            int q_off = offs[jshl];
+            int kpos = 0;
+            for (int kshl = 0; kshl < nbas; kshl++) {
+                shls[2] = kshl;
+                int r_off = offs[kshl];
+                int lpos = 0;
+                for (int lshl = 0; lshl <= kshl; lshl++) {
+                    int kl = ((kshl + 1) * kshl) / 2 + lshl;
+                    if (ij < kl) {
+                        lpos += offs[lshl];
+                        continue;
+                    }
+                    shls[3] = lshl;
+                    int s_off = offs[lshl];
+                    int2e_sph(buf, NULL, shls, atm, natm, bas, nbas, env, NULL, NULL);
+                    for (int p = 0; p < p_off; p++) {
+                        for (int q = 0; q < q_off; q++) {
+                            for (int r = 0; r < r_off; r++) {
+                                for (int s = 0; s < s_off; s++) {
+                                    double val = buf[p + p_off*(q + q_off*(r + r_off*s))];
+                                    int i = ipos+p, j = jpos+q, k = kpos+r, l = lpos+s;
+                                    out[i*nbfn*nbfn*nbfn + j*nbfn*nbfn + k*nbfn + l] = val;
+                                    out[i*nbfn*nbfn*nbfn + j*nbfn*nbfn + l*nbfn + k] = val;
+                                    out[j*nbfn*nbfn*nbfn + i*nbfn*nbfn + k*nbfn + l] = val;
+                                    out[j*nbfn*nbfn*nbfn + i*nbfn*nbfn + l*nbfn + k] = val;
+                                    out[k*nbfn*nbfn*nbfn + l*nbfn*nbfn + i*nbfn + j] = val;
+                                    out[k*nbfn*nbfn*nbfn + l*nbfn*nbfn + j*nbfn + i] = val;
+                                    out[l*nbfn*nbfn*nbfn + k*nbfn*nbfn + i*nbfn + j] = val;
+                                    out[l*nbfn*nbfn*nbfn + k*nbfn*nbfn + j*nbfn + i] = val;
+                                }
+                            }
+                        }
+                    }
+                    memset(buf, 0, sizeof(buf));
+                    lpos += s_off;
+                }
+                kpos += r_off;
+            }
+            jpos += q_off;
+        }
+        ipos += p_off;
+    }
+    Py_RETURN_NONE;
+}
 
 
 static PyMethodDef LibcintMethods[] = {
@@ -228,6 +305,7 @@ static PyMethodDef LibcintMethods[] = {
     {"dipole_integral_shellloop", dipole_integral_shellloop, METH_VARARGS, "Dipole integral shell loop in C"},
     {"quadrupole_integral_shellloop", quadrupole_integral_shellloop, METH_VARARGS, "Quadrupole integral shell loop in C"},
     {"octupole_integral_shellloop", octupole_integral_shellloop, METH_VARARGS, "Octupole integral shell loop in C"},
+    {"eri_shellloop", eri_shellloop, METH_VARARGS, "ERI 2-electron shell loop in C"},
     {NULL, NULL, 0, NULL}
 };
 

--- a/gbasis/integrals/src/libcint_wrap.c
+++ b/gbasis/integrals/src/libcint_wrap.c
@@ -185,7 +185,7 @@ func_name(PyObject *self, PyObject *args)                                       
     double *buf = calloc(buf_size, sizeof(double));                                \
     if (!buf) { PyErr_NoMemory(); return NULL; }                                   \
     CINTOpt *opt = NULL;                                                            \
-    opt_func##_optimizer(&opt, atm, natm, bas, nbas, env);      \
+    opt_func##_optimizer(&opt, atm, natm, bas, nbas, env);     \
     int shls[2];                                                                    \
     int ipos = 0;                                                                   \
     for (int ishl = 0; ishl < nbas; ishl++) {                                      \
@@ -248,7 +248,7 @@ func_name(PyObject *self, PyObject *args)                                       
     double *buf = calloc(buf_size, sizeof(double));                                \
     if (!buf) { PyErr_NoMemory(); return NULL; }                                   \
     CINTOpt *opt = NULL;                                                            \
-    opt_func##_optimizer(&opt, atm, natm, bas, nbas, env);                         \
+    opt_func##_optimizer(&opt, atm, natm, bas, nbas, env);                       \
     int ipos = 0;                                                                   \
     for (int ishl = 0; ishl < nbas; ishl++) {                                      \
         shls[0] = ishl;                                                             \

--- a/tests/test_libcint.py
+++ b/tests/test_libcint.py
@@ -68,7 +68,7 @@ TEST_INTEGRALS = [
 
 @pytest.mark.skipif(sys.platform == "win32", reason="This test does not work on Windows")
 @pytest.mark.skipif(
-    len(glob(join(dirname(gbasis.__file__), "integrals", "lib", "libcint.so*"))) == 0,
+    len(glob(join(dirname(gbasis.__file__), "integrals", "lib", "libcint.*"))) == 0,
     reason="The libcint shared library object was not found",
 )
 @pytest.mark.parametrize("integral", TEST_INTEGRALS)
@@ -198,7 +198,7 @@ TEST_INTEGRALS_IODATA = [
 ]
 @pytest.mark.skipif(sys.platform == "win32", reason="This test does not work on Windows")
 @pytest.mark.skipif(
-    len(glob(join(dirname(gbasis.__file__), "integrals", "lib", "libcint.so*"))) == 0,
+    len(glob(join(dirname(gbasis.__file__), "integrals", "lib", "libcint.*"))) == 0,
     reason="The libcint shared library object was not found",
 )
 @pytest.mark.parametrize("fname, elements, coord_type", TEST_SYSTEMS_IODATA)
@@ -343,3 +343,217 @@ def test_integral_iodata(fname, elements, coord_type, integral, transform):
         raise ValueError("Invalid integral name '{integral}' passed")
 
     npt.assert_allclose(lc_int, py_int, atol=atol, rtol=rtol)
+
+
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# New test list for C shell-loop bindings introduced in PR-5 and PR-6
+# ─────────────────────────────────────────────────────────────────────────
+
+TEST_C_SHELLLOOP_INTEGRALS = [
+    pytest.param("overlap", id="C-Overlap"),
+    pytest.param("kinetic_energy", id="C-KineticEnergy"),
+    pytest.param("nuclear_attraction", id="C-NuclearAttraction"),
+    pytest.param("rinv", id="C-Rinv"),
+    pytest.param("dipole", id="C-Dipole"),
+    pytest.param("quadrupole", id="C-Quadrupole"),
+    pytest.param("octupole", id="C-Octupole"),
+    pytest.param("point_charge", id="C-PointCharge"),
+    pytest.param("moment", id="C-Moment"),
+    pytest.param("electron_repulsion", id="C-ElectronRepulsion"),
+]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="This test does not work on Windows")
+@pytest.mark.skipif(
+    len(glob(join(dirname(gbasis.__file__), "integrals", "lib", "libcint.*"))) == 0,
+    reason="The libcint shared library object was not found",
+)
+@pytest.mark.parametrize("integral", TEST_C_SHELLLOOP_INTEGRALS)
+@pytest.mark.parametrize("atsyms, atcoords", TEST_SYSTEMS)
+@pytest.mark.parametrize("basis", TEST_BASIS_SETS)
+def test_c_shellloop_integral(basis, atsyms, atcoords, integral):
+    r"""
+    Test the C shell-loop bindings (PR-5: 1-electron, PR-6: ERI) added to
+    ``gbasis.integrals.libcint.CBasis`` against the existing GBasis Python
+    integral implementations.
+
+    These are the ``.overlap()``, ``.kinetic_energy()``,
+    ``.nuclear_attraction()``, ``.rinv()``, ``.dipole()``, ``.quadrupole()``,
+    ``.octupole()``, and ``.electron_repulsion()`` methods, which loop over
+    shells directly in C (as opposed to the ``*_integral()`` methods, which
+    loop over shells in Python and only call into C per shell pair).
+
+    """
+    from gbasis.integrals.libcint import ELEMENTS, CBasis
+
+    atol, rtol = 1e-6, 1e-6
+
+    atcoords = atcoords / 0.5291772083
+
+    atnums = np.asarray([ELEMENTS.index(i) for i in atsyms], dtype=float)
+
+    basis_dict = parse_nwchem(find_datafile(basis))
+
+    # C shell-loop bindings are implemented for spherical only
+    py_basis = make_contractions(basis_dict, atsyms, atcoords, coord_types="spherical")
+
+    lc_basis = CBasis(py_basis, atsyms, atcoords, coord_type="spherical")
+
+    if integral == "overlap":
+        py_int = overlap_integral(py_basis, screen_basis=False)
+        lc_int = lc_basis.overlap()
+        npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
+        npt.assert_allclose(lc_int, py_int, atol=atol, rtol=rtol)
+
+    elif integral == "kinetic_energy":
+        py_int = kinetic_energy_integral(py_basis, screen_basis=False)
+        lc_int = lc_basis.kinetic_energy()
+        npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
+        npt.assert_allclose(lc_int, py_int, atol=atol, rtol=rtol)
+
+    elif integral == "nuclear_attraction":
+        py_int = nuclear_electron_attraction_integral(py_basis, atcoords, atnums)
+        lc_int = lc_basis.nuclear_attraction()
+        npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
+        npt.assert_allclose(lc_int, py_int, atol=atol, rtol=rtol)
+
+    elif integral == "rinv":
+        # Compare against the point_charge Python integral with a single
+        # unit charge at the origin, since rinv == 1/|r - origin|
+        origin = np.zeros(3)
+        py_int = point_charge_integral(
+            py_basis, origin.reshape(1, 3), np.asarray([-1.0])
+        )[:, :, 0]
+        lc_int = lc_basis.rinv()
+        npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
+        npt.assert_allclose(lc_int, py_int, atol=atol, rtol=rtol)
+
+    elif integral == "dipole":
+        origin = np.zeros(3)
+        orders = np.asarray([[1, 0, 0]])
+        py_int = moment_integral(py_basis, origin, orders, screen_basis=False)[:, :, 0]
+        lc_int = lc_basis.dipole()
+        npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
+        npt.assert_allclose(lc_int, py_int, atol=atol, rtol=rtol)
+
+    elif integral == "quadrupole":
+        origin = np.zeros(3)
+        orders = np.asarray([[2, 0, 0]])
+        py_int = moment_integral(py_basis, origin, orders, screen_basis=False)[:, :, 0]
+        lc_int = lc_basis.quadrupole()
+        npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
+        npt.assert_allclose(lc_int, py_int, atol=atol, rtol=rtol)
+
+    elif integral == "octupole":
+        origin = np.zeros(3)
+        orders = np.asarray([[3, 0, 0]])
+        py_int = moment_integral(py_basis, origin, orders, screen_basis=False)[:, :, 0]
+        lc_int = lc_basis.octupole()
+        npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn))
+        npt.assert_allclose(lc_int, py_int, atol=atol, rtol=rtol)
+
+    elif integral == "point_charge":
+        charge_coords = np.asarray([[2.0, 2.0, 2.0], [-3.0, -3.0, -3.0], [-1.0, 2.0, -3.0]])
+        charges = np.asarray([1.0, 0.666, -3.1415926])
+        for i in range(1, len(charges) + 1):
+            py_int = point_charge_integral(py_basis, charge_coords[:i], charges[:i])
+            lc_int = lc_basis.point_charge(charge_coords[:i], charges[:i])
+            npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn, i))
+            npt.assert_allclose(lc_int, py_int, atol=atol, rtol=rtol)
+
+    elif integral == "moment":
+        origin = np.zeros(3)
+        orders = np.asarray(
+            [
+                [0, 0, 0],
+                [1, 0, 0],
+                [0, 1, 0],
+                [0, 0, 1],
+                [2, 0, 0],
+                [0, 2, 0],
+                [0, 0, 2],
+                [1, 1, 0],
+                [1, 0, 1],
+                [0, 1, 1],
+                [3, 0, 0],
+                [0, 3, 0],
+                [0, 0, 3],
+            ]
+        )
+        py_int = moment_integral(py_basis, origin, orders, screen_basis=False)
+        lc_int = lc_basis.moment(orders, origin=origin)
+        npt.assert_array_equal(lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn, len(orders)))
+        npt.assert_allclose(lc_int, py_int, atol=atol, rtol=rtol)
+
+    elif integral == "electron_repulsion":
+        py_int = electron_repulsion_integral_improved(py_basis)
+        lc_int = lc_basis.electron_repulsion()
+        npt.assert_array_equal(
+            lc_int.shape, (lc_basis.nbfn, lc_basis.nbfn, lc_basis.nbfn, lc_basis.nbfn)
+        )
+        # ERI uses a looser tolerance, consistent with the existing
+        # electron_repulsion_integral test above
+        npt.assert_allclose(lc_int, py_int, atol=1e-4, rtol=1e-5)
+
+    else:
+        raise ValueError(f"Invalid integral name '{integral}' passed")
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="This test does not work on Windows")
+@pytest.mark.skipif(
+    len(glob(join(dirname(gbasis.__file__), "integrals", "lib", "libcint.*"))) == 0,
+    reason="The libcint shared library object was not found",
+)
+@pytest.mark.parametrize("atsyms, atcoords", TEST_SYSTEMS)
+@pytest.mark.parametrize("basis", TEST_BASIS_SETS)
+
+def test_c_shellloop_matches_make_int1e(basis, atsyms, atcoords):
+    r"""
+    Cross-check the new C shell-loop bindings (``.overlap()``,
+    ``.kinetic_energy()``, ``.nuclear_attraction()``, ``.electron_repulsion()``)
+    directly against the existing ``make_int1e``/``make_int2e``-based methods
+    (``.overlap_integral()``, ``.kinetic_energy_integral()``,
+    ``.nuclear_attraction_integral()``, ``.electron_repulsion_integral()``)
+    on the *same* ``CBasis`` instance.
+
+    This isolates the C shell-loop logic itself (PR-5/PR-6) from any
+    differences against the pure-Python GBasis implementation, since both
+    sides here come from libcint.
+
+    """
+    from gbasis.integrals.libcint import ELEMENTS, CBasis
+
+    atcoords = atcoords / 0.5291772083
+
+    basis_dict = parse_nwchem(find_datafile(basis))
+
+    py_basis = make_contractions(basis_dict, atsyms, atcoords, coord_types="spherical")
+
+    lc_basis = CBasis(py_basis, atsyms, atcoords, coord_type="spherical")
+
+    # 1-electron integrals: C shell-loop vs. make_int1e shell-loop
+    npt.assert_allclose(
+        lc_basis.overlap(), lc_basis.overlap_integral(), atol=1e-10, rtol=1e-10
+    )
+    npt.assert_allclose(
+        lc_basis.kinetic_energy(),
+        lc_basis.kinetic_energy_integral(),
+        atol=1e-10,
+        rtol=1e-10,
+    )
+    npt.assert_allclose(
+        lc_basis.nuclear_attraction(),
+        lc_basis.nuclear_attraction_integral(),
+        atol=1e-10,
+        rtol=1e-10,
+    )
+
+    # 2-electron ERI: C shell-loop vs. make_int2e shell-loop
+    npt.assert_allclose(
+        lc_basis.electron_repulsion(),
+        lc_basis.electron_repulsion_integral(),
+        atol=1e-8,
+        rtol=1e-8,
+    )


### PR DESCRIPTION
## Changes
- Added C shell-loop binding for `point_charge()` — uses `rinv_integral_shellloop` internally per charge ~13x speedup
- Added C shell-loop binding for `moment()` — uses `_moments` dict internally
- Updated `momentum()` to return full 3-component complex array (now matches `momentum_integral()`)


### New Tests (test_libcint.py)
- `test_c_shellloop_integral` — tests all C shell-loop methods against GBasis Python implementations:
  - overlap, kinetic_energy, nuclear_attraction, rinv, dipole, quadrupole, octupole, point_charge, moment, electron_repulsion
- `test_c_shellloop_matches_make_int1e` — cross-checks C shell-loop directly against make_int1e/make_int2e on same CBasis instance

## Related
- Builds on [PR-5](https://github.com/theochem/gbasis/pull/253) (1e shell-loop) and [PR-6](https://github.com/theochem/gbasis/pull/254) (ERI shell-loop)
- Issue: https://github.com/theochem/gbasis/issues/229

## Test verifications:

```bash
pytest tests/test_libcint.py -v
```

<img width="1464" height="818" alt="Screenshot 2026-07-02 at 9 00 56 AM" src="https://github.com/user-attachments/assets/562d8071-8ef3-4a2a-be44-fc7142c4e0e2" />


